### PR TITLE
Add refresh-images endpoint for channels

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -164,7 +164,32 @@ async def refresh_channel_images(
     await db.commit()
     await db.refresh(channel)
 
+    sub_count_result = await db.execute(
+        select(func.count())
+        .select_from(UserSubscription)
+        .where(UserSubscription.channel_id == channel_id)
+    )
+    subscriber_count = sub_count_result.scalar() or 0
+
+    video_count_result = await db.execute(
+        select(func.count()).select_from(Video).where(Video.channel_id == channel_id)
+    )
+    video_count = video_count_result.scalar() or 0
+
+    sub_result = await db.execute(
+        select(UserSubscription).where(
+            UserSubscription.user_id == user.id,
+            UserSubscription.channel_id == channel_id,
+        )
+    )
+    sub = sub_result.scalar_one_or_none()
+
     detail = ChannelDetail.model_validate(channel)
+    detail.subscriber_count = subscriber_count
+    detail.video_count = video_count
+    detail.is_subscribed = sub is not None
+    if sub:
+        detail.tracking_mode = sub.tracking_mode
     return detail
 
 

--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -144,6 +144,30 @@ async def subscribe(
     return out
 
 
+@router.post("/{channel_id}/refresh-images", response_model=ChannelDetail)
+async def refresh_channel_images(
+    channel_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ChannelDetail:
+    """Fetch fresh avatar and banner images from YouTube and update the channel."""
+    result = await db.execute(select(Channel).where(Channel.id == channel_id))
+    channel = result.scalar_one_or_none()
+    if not channel:
+        raise HTTPException(status_code=404, detail="Channel not found")
+
+    images = await _resolve_channel_images(channel.youtube_channel_id)
+    if images.get("avatar_url"):
+        channel.avatar_url = images["avatar_url"]
+    if images.get("banner_url"):
+        channel.banner_url = images["banner_url"]
+    await db.commit()
+    await db.refresh(channel)
+
+    detail = ChannelDetail.model_validate(channel)
+    return detail
+
+
 @router.delete("/{channel_id}/unsubscribe")
 async def unsubscribe(
     channel_id: str,


### PR DESCRIPTION
## Summary
- Adds `POST /api/channels/{id}/refresh-images` endpoint that fetches fresh avatar and banner URLs from YouTube and updates the channel record
- Only overwrites existing URLs if the fetch returns non-null values, so images are never accidentally cleared
- Returns updated `ChannelDetail` so the client can immediately use the new URLs

## Test plan
- [ ] Open a channel detail page and verify backend logs show the image fetch
- [ ] Confirm avatar_url and banner_url are updated in the database after the call
- [ ] Verify the endpoint returns 404 for a non-existent channel ID
- [ ] Verify authentication is required (no X-User-Token → 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)