### PR TITLE
fix: correctly handle HTTP suffix-byte-range requests (bytes=-N)

### DIFF
--- a/app/services/media_server.py
+++ b/app/services/media_server.py
@@ -17,11 +17,18 @@ def build_range_response(file_path: str, range_header: str) -> Response:
     stat = os.stat(file_path)
 
     # Parse range header: "bytes=start-end"
+    # Handles both normal ranges (e.g. "bytes=0-1023") and suffix-byte-ranges
+    # (e.g. "bytes=-500", meaning the last 500 bytes).
     range_spec = range_header.replace("bytes=", "").strip()
     parts = range_spec.split("-")
 
-    start = int(parts[0]) if parts[0] else 0
-    end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
+    if not parts[0] and len(parts) > 1 and parts[1]:
+        # Suffix-byte-range: bytes=-N means the last N bytes
+        start = max(0, file_size - int(parts[1]))
+        end = file_size - 1
+    else:
+        start = int(parts[0]) if parts[0] else 0
+        end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
 
     # Clamp values
     start = max(0, start)


### PR DESCRIPTION
## Problem

Fixes #29

In `app/services/media_server.py`, the `build_range_response` function incorrectly handles suffix-byte-range requests (e.g. `bytes=-500`).

When a client sends `Range: bytes=-500` (meaning "give me the last 500 bytes"), the old code splits on `-` to get `["", "500"]`. Because `parts[0]` is empty, `start` was set to `0` and `end` to `500` — returning the **first 501 bytes** instead of the last 500.

This breaks clients that seek to the end of a file or read trailing metadata (e.g. MP4 moov atoms, ID3 tags).

## Fix

Add a check for the suffix-byte-range format before the normal parse:

```python
if not parts[0] and len(parts) > 1 and parts[1]:
    # Suffix-byte-range: bytes=-N means the last N bytes
    start = max(0, file_size - int(parts[1]))
    end = file_size - 1
else:
    start = int(parts[0]) if parts[0] else 0
    end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
```

## Tests

Verified with all four cases:
| Range header | file_size | Expected | Result |
|---|---|---|---|
| `bytes=-500` | 10000 | 9500–9999 | ✅ |
| `bytes=0-1023` | 10000 | 0–1023 | ✅ |
| `bytes=5000-` | 10000 | 5000–9999 | ✅ |
| `bytes=-99999` | 10000 | 0–9999 (clamped) | ✅ |