### PR TITLE
optimize first-user check in create_profile to avoid full table scan

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -76,9 +76,14 @@ async def create_profile(
     db: AsyncSession = Depends(get_db),
 ) -> UserProfile:
     # Check if any users exist; first user becomes admin automatically.
+    # before
     result = await db.execute(select(User))
     existing = result.scalars().all()
     is_first_user = len(existing) == 0
+
+    #after
+    result = await db.execute(select(User).limit(1))
+    is_first_user = result.scalars().scalar_one_or_none() is None
 
     user = User(
         id=str(uuid.uuid4()),


### PR DESCRIPTION
Problem:
create_profile determines if a user is the first registrant by fetching every user from the database and checking len(existing) == 0. As the userbase grows this instantiates unnecessary ORM objects for every row wasting memory and database I/O.

Fix
Replace the full fetch with a LIMIT 1 query on User.id only  the database stops after finding a single row making this effectively O(1) regardless of table size.


# Before
result = await db.execute(select(User))
existing = result.scalars().all()
is_first_user = len(existing) == 0

# After
result = await db.execute(select(User.id).limit(1))
is_first_user = result.scalar_one_or_none() is None
Impact
