### PR TITLE
fix(auth): optimize first user check in create_profile

### DIFF
--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -76,9 +76,8 @@ async def create_profile(
     db: AsyncSession = Depends(get_db),
 ) -> UserProfile:
     # Check if any users exist; first user becomes admin automatically.
-    result = await db.execute(select(User))
-    existing = result.scalars().all()
-    is_first_user = len(existing) == 0
+    result = await db.execute(select(User.id).limit(1))
+    is_first_user = result.scalar_one_or_none() is None
 
     user = User(
         id=str(uuid.uuid4()),


### PR DESCRIPTION
## Summary

Replaces inefficient table scan with a limited single-column query when checking if any users exist during profile creation.

## Problem

The original code fetched all users into memory just to check if the table was empty:



This performs a full table scan and loads all user records into memory.

## Solution

Use a limited query that fetches at most 1 ID:



## Changes

- Only select the &#39;id&#39; column instead of all columns
- Limit result to 1 row, allowing the database to stop scanning early
- Use scalar_one_or_none() for cleaner null checking

## Impact

- Reduced memory usage (no longer loads all users)
- Faster execution for databases with many users
- Database can use index efficiently if available on id column

---

*This PR was created by an autonomous agent ([ClawOSS](https://github.com/billion-token-one-task/ClawOSS)).*