### PR TITLE
fix: reset Video record after orphan cleanup

### DIFF
--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 async def check_and_delete_orphan(video_id: str, db: AsyncSession) -> bool:
     """
     Check if a video has any remaining active references.
-    If not, delete the physical file from disk and clean up thumbnails.
+    If not, delete the physical file from disk, clean up thumbnails,
+    and reset the Video record so it can be re-downloaded if needed.
     Returns True if the file was deleted.
     """
     # Count active (non-removed) references
@@ -78,6 +79,16 @@ async def check_and_delete_orphan(video_id: str, db: AsyncSession) -> bool:
                 os.remove(info_json)
             except OSError:
                 pass
+
+    # Reset the Video record so it appears as not-downloaded.
+    # Without this, the status remains "COMPLETE" and file_path still points
+    # to the deleted file. New UserVideoRef associations created later would
+    # try to stream a missing file (404) and auto-download logic would skip it
+    # because it looks already complete.
+    video.status = "CATALOGED"
+    video.file_path = None
+    video.file_size_bytes = 0
+    await db.commit()
 
     logger.info(
         "Orphan cleanup complete for video %s (%s)",


### PR DESCRIPTION
## Problem

Fixes #17

`check_and_delete_orphan` in `app/services/storage.py` correctly removes the physical media, preview, and thumbnail files from disk when a video has no remaining active `UserVideoRef` associations. However, the `Video` record itself is never updated — `status` stays `"COMPLETE"` and `file_path` still points to the deleted file.

**Impact:**
- A new user subscribing to the same channel later will get a new `UserVideoRef`, but attempting to stream the video returns a 404 ("Video file missing from disk")
- Auto-download logic skips the video because `status == "COMPLETE"`, so it never re-downloads
- Users have no direct path to recover the video without manual DB intervention

## Fix

After deleting all files from disk, reset the `Video` record to reflect its actual state:

```python
video.status = "CATALOGED"
video.file_path = None
video.file_size_bytes = 0
await db.commit()
```

This makes the video eligible for re-download if a new user subscribes to the channel.

## Changes

- `app/services/storage.py`: Reset `video.status`, `video.file_path`, and `video.file_size_bytes` after orphan deletion; moved `db.commit()` inside the function (was missing entirely).
