### PR TITLE
fix: update Video status when orphaned files are deleted

### DIFF
--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -79,6 +79,12 @@ async def check_and_delete_orphan(video_id: str, db: AsyncSession) -> bool:
             except OSError:
                 pass
 
+    # Update the Video record to reflect deletion
+    video.status = "ORPHANED"
+    video.file_path = None
+    video.preview_file_path = None
+    await db.commit()
+
     logger.info(
         "Orphan cleanup complete for video %s (%s)",
         video_id,


### PR DESCRIPTION
## Summary
Fixes #17

When `check_and_delete_orphan` deletes physical files, it now also updates the Video record in the database:
- Sets `video.status = "ORPHANED"`
- Clears `video.file_path` and `video.preview_file_path`
- Commits the changes

Previously the Video record was left with status COMPLETE and a file_path pointing to a deleted file.

## Test
- Trigger orphan cleanup for a video with no remaining UserVideoRef
- Verify video.status is set to ORPHANED and file_path is None