### PR TITLE
fix: handle all exception types in download task to avoid stuck DOWNLOADING status

### DIFF
--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -213,10 +213,13 @@ def download_video_task(self, video_id: str, user_id: str | None = None) -> dict
 
     except Exception as exc:
         logger.exception("Download failed for video %s", video_id)
-        # Mark as FAILED if we've exhausted retries
+        # Mark as FAILED if we've exhausted retries or exception won't trigger retry
         try:
             video = db.get(Video, video_id)
-            if video and self.request.retries >= self.max_retries:
+            if video and (
+                self.request.retries >= self.max_retries
+                or not isinstance(exc, RuntimeError)
+            ):
                 video.status = "FAILED"
                 db.commit()
         except Exception:


### PR DESCRIPTION
## Summary
Fixes #28

The `download_video_task` has `autoretry_for=(RuntimeError,)`, meaning only RuntimeError triggers automatic retries. For other exception types (ValueError, TypeError, etc.), retries don't happen, and the old code only set status to FAILED when `retries >= max_retries` — which is never true for non-retried exceptions.

**Fix:** Also set video status to FAILED when the caught exception is NOT a RuntimeError (since it won't be retried anyway).

## Changes
- Modified exception handler in `download_video_task` to check `isinstance(exc, RuntimeError)`
- If not RuntimeError (won't be retried), always set status to FAILED

## Test
- Trigger a download that raises a non-RuntimeError (e.g., ValueError)
- Verify video status is set to FAILED instead of staying DOWNLOADING