### PR TITLE
fix: correctly parse suffix-byte-range Range header per RFC 7233

### DIFF
--- a/app/services/media_server.py
+++ b/app/services/media_server.py
@@ -16,12 +16,18 @@ def build_range_response(file_path: str, range_header: str) -> Response:
     file_size = os.path.getsize(file_path)
     stat = os.stat(file_path)
 
-    # Parse range header: "bytes=start-end"
+    # Parse range header: "bytes=start-end" or "bytes=-suffix" (last N bytes)
     range_spec = range_header.replace("bytes=", "").strip()
     parts = range_spec.split("-")
 
-    start = int(parts[0]) if parts[0] else 0
-    end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
+    if not parts[0]:
+        # Suffix-byte-range: "-500" means last 500 bytes
+        suffix_length = int(parts[1]) if len(parts) > 1 and parts[1] else 0
+        start = max(0, file_size - suffix_length)
+        end = file_size - 1
+    else:
+        start = int(parts[0])
+        end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
 
     # Clamp values
     start = max(0, start)


### PR DESCRIPTION
## Summary
Fixes #29

`build_range_response` now properly handles suffix-byte-range requests per RFC 7233.

**Before:** `bytes=-500` (last 500 bytes) was parsed as start=0, which is incorrect — it should be start=file_size-500.

**After:** When the range spec starts with `-`, the value is treated as a suffix length and start is calculated as `max(0, file_size - suffix_length)`.

## Changes
- Added explicit suffix-byte-range detection in `build_range_response`
- Correctly computes start position from file size and suffix length
- Maintains backward compatibility for normal byte-range requests

## Test
- Request with `Range: bytes=-500` should return the last 500 bytes
- Request with `Range: bytes=0-99` should still work as before