### PR TITLE
fix: only cancel download for requesting user, not globally

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -144,6 +144,32 @@ async def cancel_download(
     if video.status not in ("PENDING", "DOWNLOADING"):
         return {"detail": "Not in progress", "video_id": video_id}
 
+    # Check if other users still have active references to this video
+    refs_result = await db.execute(
+        select(UserVideoRef).where(
+            UserVideoRef.video_id == video_id,
+            UserVideoRef.user_id != user.id,
+            UserVideoRef.removed_at.is_(None),
+        )
+    )
+    other_refs = refs_result.scalars().all()
+
+    if other_refs:
+        # Other users still want this video — only remove current user's ref
+        ref_result = await db.execute(
+            select(UserVideoRef).where(
+                UserVideoRef.user_id == user.id,
+                UserVideoRef.video_id == video_id,
+                UserVideoRef.removed_at.is_(None),
+            )
+        )
+        ref = ref_result.scalar_one_or_none()
+        if ref:
+            ref.removed_at = datetime.now(timezone.utc)
+        await db.commit()
+        return {"detail": "Download cancelled for current user only", "video_id": video_id}
+
+    # No other references — safe to cancel globally
     video.status = "CATALOGED"
     await db.commit()
 


### PR DESCRIPTION
## Summary
Fixes #32

The cancel endpoint now checks for other active UserVideoRef records before cancelling.

**Before:** `POST /api/videos/{id}/cancel` immediately set `video.status = CATALOGED` for ALL users, even if other users still had active references.

**After:**
1. Check if other users have active references to this video
2. If yes → only remove the requesting user's UserVideoRef (soft delete via `removed_at`)
3. If no → safe to cancel globally (set status to CATALOGED)

This prevents one user's cancel action from disrupting other users' downloads.

## Test
- Two users reference the same downloading video
- User A cancels → User B's reference and download should remain intact
- Only user's reference is removed, video stays DOWNLOADING