### PR TITLE
fix: HTTP Range header correctly parse suffix-byte-range requests

### DIFF
--- a/app/services/media_server.py
+++ b/app/services/media_server.py
@@ -20,8 +20,13 @@ def build_range_response(file_path: str, range_header: str) -> Response:
     range_spec = range_header.replace("bytes=", "").strip()
     parts = range_spec.split("-")
 
-    start = int(parts[0]) if parts[0] else 0
-    end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
+    # Handle suffix-byte-range (e.g., "bytes=-500" -> last 500 bytes)
+    if not parts[0] and len(parts) > 1 and parts[1]:
+        start = max(0, file_size - int(parts[1]))
+        end = file_size - 1
+    else:
+        start = int(parts[0]) if parts[0] else 0
+        end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
 
     # Clamp values
     start = max(0, start)


### PR DESCRIPTION
Fixes #29 - Correctly parse suffix-byte-range requests (e.g., bytes=-500).

When a client requests the last N bytes using bytes=-N format, the parser now calculates start from the end of the file instead of erroneously returning bytes from the beginning.