### PR TITLE
Profile management, YouTube profile import, and reliability hardening

### DIFF
--- a/alembic/versions/005_profiles_and_hardening.py
+++ b/alembic/versions/005_profiles_and_hardening.py
@@ -1,0 +1,48 @@
+"""Profiles and hardening: sessions table, last_watched_at, downloaded_at
+
+Revision ID: 005_profiles_and_hardening
+Revises: 004_add_metadata_refreshed_at
+Create Date: 2026-06-11
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "005_profiles_and_hardening"
+down_revision: Union[str, None] = "004_add_metadata_refreshed_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Persistent auth sessions (token_hash is SHA-256 hex of the raw token)
+    op.create_table(
+        "sessions",
+        sa.Column("token_hash", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(36), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime, nullable=False, server_default=sa.func.now()
+        ),
+        sa.Column(
+            "last_seen_at", sa.DateTime, nullable=False, server_default=sa.func.now()
+        ),
+    )
+    op.create_index("ix_sessions_user_id", "sessions", ["user_id"])
+
+    op.add_column(
+        "user_video_refs",
+        sa.Column("last_watched_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "videos",
+        sa.Column("downloaded_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("videos", "downloaded_at")
+    op.drop_column("user_video_refs", "last_watched_at")
+    op.drop_index("ix_sessions_user_id", table_name="sessions")
+    op.drop_table("sessions")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,23 +1,131 @@
+import asyncio
 import hashlib
+import hmac
+import logging
+import os
 import secrets
+import time
 import uuid
+from datetime import timedelta
+from pathlib import Path
 
+import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException
-from sqlalchemy import select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.database import get_db
+from app.config import settings
+from app.database import async_session_factory, get_db
+from app.models.recommendation import Recommendation
+from app.models.session import Session
+from app.models.subscription import UserSubscription
 from app.models.user import User
-from app.schemas.user import UserCreate, UserProfile, UserSelect, UserSession
+from app.models.user_video_ref import UserVideoRef
+from app.schemas.user import (
+    UserCreate,
+    UserProfile,
+    UserSelect,
+    UserSession,
+    UserUpdate,
+)
+from app.services.storage import check_and_delete_orphan
+from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
+logger = logging.getLogger(__name__)
 
-# Simple in-memory session store. In production, use Redis or signed JWTs.
-_sessions: dict[str, str] = {}
+# scrypt parameters for PIN hashing
+_SCRYPT_N = 16384
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+
+# Refresh sessions.last_seen_at at most this often.
+_LAST_SEEN_REFRESH = timedelta(hours=1)
+
+# In-memory PIN rate limiting: after N consecutive failures, lock for a bit.
+_PIN_MAX_FAILURES = 5
+_PIN_LOCKOUT_SECONDS = 30.0
+_pin_failures: dict[str, int] = {}
+_pin_lockouts: dict[str, float] = {}
 
 
 def _hash_pin(pin: str) -> str:
-    return hashlib.sha256(pin.encode()).hexdigest()
+    """Hash a PIN with scrypt and a per-user random salt."""
+    salt = secrets.token_bytes(16)
+    digest = hashlib.scrypt(
+        pin.encode(), salt=salt, n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P
+    )
+    return f"scrypt${salt.hex()}${digest.hex()}"
+
+
+def _is_legacy_pin_hash(stored: str) -> bool:
+    """Legacy hashes are plain SHA-256 hex digests (no '$' separators)."""
+    return "$" not in stored
+
+
+def _verify_pin(pin: str, stored: str) -> bool:
+    if _is_legacy_pin_hash(stored):
+        legacy = hashlib.sha256(pin.encode()).hexdigest()
+        return hmac.compare_digest(legacy, stored)
+    try:
+        scheme, salt_hex, hash_hex = stored.split("$")
+        if scheme != "scrypt":
+            return False
+        digest = hashlib.scrypt(
+            pin.encode(),
+            salt=bytes.fromhex(salt_hex),
+            n=_SCRYPT_N,
+            r=_SCRYPT_R,
+            p=_SCRYPT_P,
+        )
+    except ValueError:
+        return False
+    return hmac.compare_digest(digest.hex(), hash_hex)
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _check_pin_rate_limit(user_id: str) -> None:
+    """Raise 429 while the user is locked out from PIN attempts."""
+    locked_until = _pin_lockouts.get(user_id)
+    if locked_until is None:
+        return
+    if time.monotonic() < locked_until:
+        raise HTTPException(
+            status_code=429,
+            detail="Too many failed PIN attempts. Try again in 30 seconds.",
+        )
+    _pin_lockouts.pop(user_id, None)
+    _pin_failures.pop(user_id, None)
+
+
+def _record_pin_failure(user_id: str) -> None:
+    count = _pin_failures.get(user_id, 0) + 1
+    _pin_failures[user_id] = count
+    if count >= _PIN_MAX_FAILURES:
+        _pin_lockouts[user_id] = time.monotonic() + _PIN_LOCKOUT_SECONDS
+
+
+def _clear_pin_failures(user_id: str) -> None:
+    _pin_failures.pop(user_id, None)
+    _pin_lockouts.pop(user_id, None)
+
+
+async def _resolve_session(token: str, db: AsyncSession) -> Session | None:
+    """Look up a persistent session by raw token; refresh last_seen_at hourly."""
+    result = await db.execute(
+        select(Session).where(Session.token_hash == _hash_token(token))
+    )
+    session = result.scalar_one_or_none()
+    if session is None:
+        return None
+    now = utcnow_naive()
+    if session.last_seen_at is None or now - session.last_seen_at >= _LAST_SEEN_REFRESH:
+        session.last_seen_at = now
+        await db.commit()
+    return session
 
 
 async def get_current_user(
@@ -27,19 +135,44 @@ async def get_current_user(
     """Resolve the current user from the X-User-Token header."""
     if not x_user_token:
         raise HTTPException(status_code=401, detail="Missing X-User-Token header")
-    user_id = _sessions.get(x_user_token)
-    if not user_id:
+    session = await _resolve_session(x_user_token, db)
+    if session is None:
         raise HTTPException(status_code=401, detail="Invalid or expired session token")
-    result = await db.execute(select(User).where(User.id == user_id))
+    result = await db.execute(select(User).where(User.id == session.user_id))
     user = result.scalar_one_or_none()
     if not user:
         raise HTTPException(status_code=401, detail="User not found")
     return user
 
 
-def validate_token(token: str) -> str | None:
+async def validate_token(token: str) -> str | None:
     """Look up a session token and return the user_id, or None."""
-    return _sessions.get(token)
+    async with async_session_factory() as db:
+        session = await _resolve_session(token, db)
+        return session.user_id if session else None
+
+
+def _write_bytes(path: str, data: bytes) -> None:
+    Path(path).write_bytes(data)
+
+
+async def cache_avatar(url: str, user_id: str) -> str | None:
+    """Download an avatar image and cache it under the thumbnails path.
+
+    Returns the public URL path of the cached file, or None on any failure.
+    """
+    avatar_dir = os.path.join(settings.thumbnails_path, "avatars")
+    dest = os.path.join(avatar_dir, f"{user_id}.jpg")
+    try:
+        os.makedirs(avatar_dir, exist_ok=True)
+        async with httpx.AsyncClient(timeout=15.0, follow_redirects=True) as client:
+            response = await client.get(url)
+            response.raise_for_status()
+        await asyncio.to_thread(_write_bytes, dest, response.content)
+    except Exception:
+        logger.warning("Failed to cache avatar from %s", url, exc_info=True)
+        return None
+    return f"/data/thumbnails/avatars/{user_id}.jpg"
 
 
 @router.post("/profiles", response_model=list[UserProfile])
@@ -60,13 +193,20 @@ async def select_profile(
         raise HTTPException(status_code=404, detail="User not found")
 
     if user.pin_hash:
+        _check_pin_rate_limit(user.id)
         if not body.pin:
             raise HTTPException(status_code=403, detail="PIN required")
-        if _hash_pin(body.pin) != user.pin_hash:
+        if not _verify_pin(body.pin, user.pin_hash):
+            _record_pin_failure(user.id)
             raise HTTPException(status_code=403, detail="Incorrect PIN")
+        _clear_pin_failures(user.id)
+        # Upgrade legacy SHA-256 hashes to scrypt on successful verification.
+        if _is_legacy_pin_hash(user.pin_hash):
+            user.pin_hash = _hash_pin(body.pin)
 
     token = secrets.token_urlsafe(32)
-    _sessions[token] = user.id
+    db.add(Session(token_hash=_hash_token(token), user_id=user.id))
+    await db.commit()
     return UserSession(user=UserProfile.model_validate(user), token=token)
 
 
@@ -75,19 +215,150 @@ async def create_profile(
     body: UserCreate,
     db: AsyncSession = Depends(get_db),
 ) -> UserProfile:
-    # Check if any users exist; first user becomes admin automatically.
-    result = await db.execute(select(User))
-    existing = result.scalars().all()
-    is_first_user = len(existing) == 0
+    # First user ever created becomes admin; everyone else does not.
+    result = await db.execute(select(func.count()).select_from(User))
+    is_first_user = result.scalar_one() == 0
+
+    user_id = str(uuid.uuid4())
+    display_name = body.display_name
+    avatar_url = body.avatar_url
+
+    youtube_handle = (body.youtube_handle or "").strip()
+    if youtube_handle:
+        # Lazy import: the resolver pulls in yt-dlp subprocess machinery.
+        from app.services.youtube_import import YoutubeResolveError, resolve_handle
+
+        try:
+            identity = await resolve_handle(youtube_handle)
+        except YoutubeResolveError:
+            raise HTTPException(
+                status_code=502, detail="Could not resolve YouTube handle"
+            )
+        if display_name is None:
+            resolved_name = (identity.get("name") or "").strip()
+            display_name = (resolved_name or youtube_handle.lstrip("@"))[:50]
+        avatar_url = None
+        if identity.get("avatar_url"):
+            avatar_url = await cache_avatar(identity["avatar_url"], user_id)
+
+    if not display_name:
+        raise HTTPException(status_code=422, detail="display_name is required")
 
     user = User(
-        id=str(uuid.uuid4()),
-        display_name=body.display_name,
-        avatar_url=body.avatar_url,
+        id=user_id,
+        display_name=display_name,
+        avatar_url=avatar_url,
         pin_hash=_hash_pin(body.pin) if body.pin else None,
-        is_admin=is_first_user or body.is_admin,
+        is_admin=is_first_user,
     )
     db.add(user)
     await db.commit()
     await db.refresh(user)
     return UserProfile.model_validate(user)
+
+
+@router.get("/me", response_model=UserProfile)
+async def get_me(user: User = Depends(get_current_user)) -> UserProfile:
+    return UserProfile.model_validate(user)
+
+
+@router.post("/logout")
+async def logout(
+    x_user_token: str | None = Header(None),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    if x_user_token:
+        await db.execute(
+            delete(Session).where(Session.token_hash == _hash_token(x_user_token))
+        )
+        await db.commit()
+    return {"detail": "Logged out"}
+
+
+@router.patch("/profiles/{user_id}", response_model=UserProfile)
+async def update_profile(
+    user_id: str,
+    body: UserUpdate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> UserProfile:
+    if current_user.id != user_id and not current_user.is_admin:
+        raise HTTPException(
+            status_code=403, detail="Not authorized to modify this profile"
+        )
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    target = result.scalar_one_or_none()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if body.display_name is not None:
+        target.display_name = body.display_name
+    if body.avatar_url is not None:
+        target.avatar_url = body.avatar_url
+    if body.remove_pin:
+        target.pin_hash = None
+        _clear_pin_failures(target.id)
+    elif body.pin is not None:
+        target.pin_hash = _hash_pin(body.pin)
+        _clear_pin_failures(target.id)
+
+    await db.commit()
+    await db.refresh(target)
+    return UserProfile.model_validate(target)
+
+
+@router.delete("/profiles/{user_id}")
+async def delete_profile(
+    user_id: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    if current_user.id != user_id and not current_user.is_admin:
+        raise HTTPException(
+            status_code=403, detail="Not authorized to delete this profile"
+        )
+
+    result = await db.execute(select(User).where(User.id == user_id))
+    target = result.scalar_one_or_none()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if target.is_admin:
+        others = await db.execute(
+            select(func.count()).select_from(User).where(User.id != user_id)
+        )
+        other_admins = await db.execute(
+            select(func.count())
+            .select_from(User)
+            .where(User.id != user_id, User.is_admin.is_(True))
+        )
+        if others.scalar_one() > 0 and other_admins.scalar_one() == 0:
+            raise HTTPException(
+                status_code=409, detail="Cannot delete the only admin profile"
+            )
+
+    # Collect referenced videos before removing the refs, for orphan cleanup.
+    refs_result = await db.execute(
+        select(UserVideoRef.video_id).where(UserVideoRef.user_id == user_id)
+    )
+    video_ids = list(refs_result.scalars().all())
+
+    await db.execute(delete(UserVideoRef).where(UserVideoRef.user_id == user_id))
+    await db.execute(
+        delete(UserSubscription).where(UserSubscription.user_id == user_id)
+    )
+    await db.execute(delete(Recommendation).where(Recommendation.user_id == user_id))
+    await db.execute(delete(Session).where(Session.user_id == user_id))
+    await db.execute(delete(User).where(User.id == user_id))
+    await db.commit()
+
+    for video_id in video_ids:
+        try:
+            await check_and_delete_orphan(video_id, db)
+        except Exception:
+            logger.exception("Orphan cleanup failed for video %s", video_id)
+
+    _clear_pin_failures(user_id)
+    return {"detail": "Profile deleted"}

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -215,10 +215,6 @@ async def create_profile(
     body: UserCreate,
     db: AsyncSession = Depends(get_db),
 ) -> UserProfile:
-    # First user ever created becomes admin; everyone else does not.
-    result = await db.execute(select(func.count()).select_from(User))
-    is_first_user = result.scalar_one() == 0
-
     user_id = str(uuid.uuid4())
     display_name = body.display_name
     avatar_url = body.avatar_url
@@ -243,6 +239,12 @@ async def create_profile(
 
     if not display_name:
         raise HTTPException(status_code=422, detail="display_name is required")
+
+    # First user ever created becomes admin; everyone else does not. Counted
+    # here — after the (slow) YouTube resolve — so a concurrent create during
+    # that window cannot also observe an empty table and mint a second admin.
+    result = await db.execute(select(func.count()).select_from(User))
+    is_first_user = result.scalar_one() == 0
 
     user = User(
         id=user_id,

--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -450,6 +450,7 @@ async def list_channel_videos(
             thumbnail_url=f"/data/thumbnails/{v.youtube_video_id}.jpg",
             watch_position_seconds=ref.watch_position_seconds if ref else 0,
             is_watched=ref.is_watched if ref else False,
+            last_watched_at=ref.last_watched_at if ref else None,
         )
         items.append(item)
 
@@ -457,10 +458,19 @@ async def list_channel_videos(
 
 
 def _extract_channel_id(url: str) -> str | None:
-    """Best-effort extraction of a YouTube channel ID from a URL."""
+    """Best-effort extraction of a YouTube channel ID from a URL or handle."""
+    url = url.strip()
+
+    # Bare handle ("@mkbhd") or raw UC channel id — e.g. from AI
+    # recommendations, which store handles for one-tap subscribe.
+    if re.fullmatch(r"@[a-zA-Z0-9_.-]+", url):
+        return url
+    if re.fullmatch(r"UC[a-zA-Z0-9_-]{10,}", url):
+        return url
+
     patterns = [
         r"youtube\.com/channel/([a-zA-Z0-9_-]+)",
-        r"youtube\.com/@([a-zA-Z0-9_.-]+)",
+        r"youtube\.com/(@[a-zA-Z0-9_.-]+)",
         r"youtube\.com/c/([a-zA-Z0-9_.-]+)",
         r"youtube\.com/user/([a-zA-Z0-9_.-]+)",
     ]

--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -1,3 +1,5 @@
+import asyncio
+import logging
 import re
 import uuid
 
@@ -12,10 +14,20 @@ from app.models.subscription import UserSubscription
 from app.models.user import User
 from app.models.user_video_ref import UserVideoRef
 from app.models.video import Video
-from app.schemas.channel import ChannelDetail, ChannelOut, ChannelSubscribe
+from app.schemas.channel import (
+    BulkSubscribeItem,
+    BulkSubscribeItemResult,
+    BulkSubscribeRequest,
+    BulkSubscribeResponse,
+    ChannelDetail,
+    ChannelOut,
+    ChannelSubscribe,
+)
 from app.schemas.video import VideoOut, VideoPagination
 from app.services.download_manager import fetch_channel_images, fetch_channel_metadata
 from app.tasks.download_tasks import poll_channel_task
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/channels", tags=["channels"])
 
@@ -23,6 +35,46 @@ router = APIRouter(prefix="/api/channels", tags=["channels"])
 def _slugify(name: str) -> str:
     slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
     return slug or "channel"
+
+
+async def _unique_slug(base: str, db: AsyncSession) -> str:
+    """Return `base`, deduped with a -2, -3, ... suffix against existing slugs."""
+    result = await db.execute(select(Channel.slug).where(Channel.slug.like(f"{base}%")))
+    existing = {row[0] for row in result.all()}
+    if base not in existing:
+        return base
+    n = 2
+    while f"{base}-{n}" in existing:
+        n += 1
+    return f"{base}-{n}"
+
+
+async def _ensure_refs_for_channel(
+    user_id: str, channel_id: str, db: AsyncSession
+) -> None:
+    """Ensure the user has an active UserVideoRef for every video in the channel.
+
+    Creates missing refs and reactivates soft-deleted ones (removed_at set).
+    """
+    video_result = await db.execute(
+        select(Video.id).where(Video.channel_id == channel_id)
+    )
+    video_ids = [row[0] for row in video_result.all()]
+    if not video_ids:
+        return
+    ref_result = await db.execute(
+        select(UserVideoRef).where(
+            UserVideoRef.user_id == user_id,
+            UserVideoRef.video_id.in_(video_ids),
+        )
+    )
+    refs_by_video = {ref.video_id: ref for ref in ref_result.scalars().all()}
+    for video_id in video_ids:
+        ref = refs_by_video.get(video_id)
+        if ref is None:
+            db.add(UserVideoRef(user_id=user_id, video_id=video_id))
+        elif ref.removed_at is not None:
+            ref.removed_at = None
 
 
 @router.get("", response_model=list[ChannelOut])
@@ -33,6 +85,12 @@ async def list_channels(
     result = await db.execute(select(Channel).order_by(Channel.name))
     channels = result.scalars().all()
 
+    # Per-channel video counts in a single GROUP BY query
+    count_result = await db.execute(
+        select(Video.channel_id, func.count()).group_by(Video.channel_id)
+    )
+    video_counts = {row[0]: row[1] for row in count_result.all()}
+
     # Gather subscription status for this user
     sub_result = await db.execute(
         select(UserSubscription.channel_id).where(UserSubscription.user_id == user.id)
@@ -41,12 +99,8 @@ async def list_channels(
 
     out = []
     for ch in channels:
-        video_count_result = await db.execute(
-            select(func.count()).select_from(Video).where(Video.channel_id == ch.id)
-        )
-        video_count = video_count_result.scalar() or 0
         item = ChannelOut.model_validate(ch)
-        item.video_count = video_count
+        item.video_count = video_counts.get(ch.id, 0)
         item.is_subscribed = ch.id in subscribed_ids
         out.append(item)
     return out
@@ -68,7 +122,7 @@ async def subscribe(
 
     # Resolve channel metadata to get canonical UC ID and display name.
     # This lets us detect duplicates when subscribing via handle vs UC ID.
-    meta = await _resolve_channel(yt_channel_id)
+    meta = await asyncio.to_thread(fetch_channel_metadata, yt_channel_id)
     canonical_id = meta.get("channel_id", yt_channel_id)
     resolved_name = meta.get("name", yt_channel_id)
 
@@ -82,16 +136,17 @@ async def subscribe(
 
     if not channel:
         # Fetch channel avatar & banner from YouTube
-        images = await _resolve_channel_images(canonical_id)
+        images = await asyncio.to_thread(fetch_channel_images, canonical_id)
 
         # Create the channel record with resolved metadata
+        base_slug = _slugify(
+            resolved_name if resolved_name != yt_channel_id else yt_channel_id
+        )
         channel = Channel(
             id=str(uuid.uuid4()),
             youtube_channel_id=canonical_id,
             name=resolved_name,
-            slug=_slugify(
-                resolved_name if resolved_name != yt_channel_id else yt_channel_id
-            ),
+            slug=await _unique_slug(base_slug, db),
             description=meta.get("description", ""),
             avatar_url=images.get("avatar_url"),
             banner_url=images.get("banner_url"),
@@ -119,19 +174,8 @@ async def subscribe(
     )
     db.add(sub)
 
-    # Create user video refs for ALL existing videos in this channel (not just COMPLETE)
-    video_result = await db.execute(select(Video).where(Video.channel_id == channel.id))
-    existing_videos = video_result.scalars().all()
-    for video in existing_videos:
-        ref_check = await db.execute(
-            select(UserVideoRef).where(
-                UserVideoRef.user_id == user.id,
-                UserVideoRef.video_id == video.id,
-            )
-        )
-        if not ref_check.scalar_one_or_none():
-            ref = UserVideoRef(user_id=user.id, video_id=video.id)
-            db.add(ref)
+    # Create/reactivate user video refs for ALL existing videos in this channel
+    await _ensure_refs_for_channel(user.id, channel.id, db)
 
     await db.commit()
     await db.refresh(channel)
@@ -142,6 +186,107 @@ async def subscribe(
     out = ChannelOut.model_validate(channel)
     out.is_subscribed = True
     return out
+
+
+@router.post("/subscribe-bulk", response_model=BulkSubscribeResponse)
+async def subscribe_bulk(
+    body: BulkSubscribeRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> BulkSubscribeResponse:
+    """Subscribe to up to 25 channels at once. Per-item errors don't fail the batch."""
+    results: list[BulkSubscribeItemResult] = []
+    for item in body.items:
+        try:
+            results.append(await _subscribe_bulk_item(item, user, db))
+        except Exception:
+            logger.exception("Bulk subscribe failed for %s", item.youtube_channel_id)
+            await db.rollback()
+            results.append(
+                BulkSubscribeItemResult(
+                    youtube_channel_id=item.youtube_channel_id,
+                    status="error",
+                    detail="Subscription failed",
+                )
+            )
+    return BulkSubscribeResponse(results=results)
+
+
+async def _subscribe_bulk_item(
+    item: BulkSubscribeItem, user: User, db: AsyncSession
+) -> BulkSubscribeItemResult:
+    yt_channel_id = item.youtube_channel_id.strip()
+
+    result = await db.execute(
+        select(Channel).where(Channel.youtube_channel_id == yt_channel_id)
+    )
+    channel = result.scalar_one_or_none()
+
+    created = False
+    if not channel:
+        # Create the channel WITHOUT resolving via yt-dlp when a name is
+        # provided; the enqueued poll refreshes metadata/images async.
+        name = (item.name or "").strip()
+        if not name:
+            # Best effort: resolve the display name in a thread executor.
+            meta = await asyncio.to_thread(fetch_channel_metadata, yt_channel_id)
+            name = (meta.get("name") or "").strip()
+            # fetch_channel_metadata echoes the input back on failure.
+            if not name or (
+                name == yt_channel_id
+                and meta.get("channel_id") == yt_channel_id
+                and not meta.get("handle")
+            ):
+                return BulkSubscribeItemResult(
+                    youtube_channel_id=item.youtube_channel_id,
+                    status="error",
+                    detail="Could not resolve channel name",
+                )
+        channel = Channel(
+            id=str(uuid.uuid4()),
+            youtube_channel_id=yt_channel_id,
+            name=name,
+            slug=await _unique_slug(_slugify(name), db),
+            description="",
+            avatar_url=None,
+            banner_url=None,
+        )
+        db.add(channel)
+        await db.flush()
+        created = True
+
+    sub_result = await db.execute(
+        select(UserSubscription).where(
+            UserSubscription.user_id == user.id,
+            UserSubscription.channel_id == channel.id,
+        )
+    )
+    if sub_result.scalar_one_or_none():
+        return BulkSubscribeItemResult(
+            youtube_channel_id=item.youtube_channel_id,
+            status="already_subscribed",
+            channel_id=channel.id,
+        )
+
+    db.add(
+        UserSubscription(
+            user_id=user.id,
+            channel_id=channel.id,
+            retention_policy="KEEP_ALL",
+            tracking_mode="FUTURE_ONLY",
+        )
+    )
+    await _ensure_refs_for_channel(user.id, channel.id, db)
+    await db.commit()
+
+    if created:
+        poll_channel_task.delay(channel.id)
+
+    return BulkSubscribeItemResult(
+        youtube_channel_id=item.youtube_channel_id,
+        status="subscribed",
+        channel_id=channel.id,
+    )
 
 
 @router.post("/{channel_id}/refresh-images", response_model=ChannelDetail)
@@ -156,7 +301,7 @@ async def refresh_channel_images(
     if not channel:
         raise HTTPException(status_code=404, detail="Channel not found")
 
-    images = await _resolve_channel_images(channel.youtube_channel_id)
+    images = await asyncio.to_thread(fetch_channel_images, channel.youtube_channel_id)
     if images.get("avatar_url"):
         channel.avatar_url = images["avatar_url"]
     if images.get("banner_url"):
@@ -277,16 +422,22 @@ async def list_channel_videos(
     )
     videos = result.scalars().all()
 
-    items = []
-    for v in videos:
+    # One query for the user's refs across this page of videos
+    refs_by_video: dict[str, UserVideoRef] = {}
+    video_ids = [v.id for v in videos]
+    if video_ids:
         ref_result = await db.execute(
             select(UserVideoRef).where(
                 UserVideoRef.user_id == user.id,
-                UserVideoRef.video_id == v.id,
+                UserVideoRef.video_id.in_(video_ids),
                 UserVideoRef.removed_at.is_(None),
             )
         )
-        ref = ref_result.scalar_one_or_none()
+        refs_by_video = {ref.video_id: ref for ref in ref_result.scalars().all()}
+
+    items = []
+    for v in videos:
+        ref = refs_by_video.get(v.id)
         item = VideoOut(
             id=v.id,
             youtube_video_id=v.youtube_video_id,
@@ -318,25 +469,3 @@ def _extract_channel_id(url: str) -> str | None:
         if match:
             return match.group(1)
     return None
-
-
-async def _resolve_channel(yt_channel_id: str) -> dict:
-    """Resolve a YouTube channel handle/ID to its canonical metadata.
-
-    Runs the blocking yt-dlp call in a thread to avoid blocking the event loop.
-    """
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, fetch_channel_metadata, yt_channel_id)
-
-
-async def _resolve_channel_images(yt_channel_id: str) -> dict:
-    """Fetch channel avatar and banner URLs from YouTube.
-
-    Runs the blocking HTTP call in a thread to avoid blocking the event loop.
-    """
-    import asyncio
-
-    loop = asyncio.get_event_loop()
-    return await loop.run_in_executor(None, fetch_channel_images, yt_channel_id)

--- a/app/api/feed.py
+++ b/app/api/feed.py
@@ -57,7 +57,10 @@ async def continue_watching(
             UserVideoRef.watch_position_seconds > 0,
             Video.status == "COMPLETE",
         )
-        .order_by(UserVideoRef.added_at.desc())
+        .order_by(
+            UserVideoRef.last_watched_at.desc().nullslast(),
+            UserVideoRef.added_at.desc(),
+        )
         .limit(limit)
     )
     rows = result.all()
@@ -89,40 +92,41 @@ async def new_episodes(
         select(UserSubscription.channel_id).where(UserSubscription.user_id == user.id)
     )
     subscribed_ids = [row[0] for row in sub_result.all()]
+    if not subscribed_ids:
+        return []
+
+    # One query for all unwatched videos across subscribed channels; keep the
+    # newest unwatched video per channel.
+    result = await db.execute(
+        select(UserVideoRef, Video, Channel)
+        .join(Video, UserVideoRef.video_id == Video.id)
+        .join(Channel, Video.channel_id == Channel.id)
+        .where(
+            UserVideoRef.user_id == user.id,
+            UserVideoRef.removed_at.is_(None),
+            UserVideoRef.is_watched == False,  # noqa: E712
+            Video.channel_id.in_(subscribed_ids),
+            Video.status == "COMPLETE",
+        )
+        .order_by(Video.uploaded_at.desc().nullslast())
+    )
 
     items = []
-    for channel_id in subscribed_ids:
-        ch_result = await db.execute(select(Channel).where(Channel.id == channel_id))
-        channel = ch_result.scalar_one_or_none()
-        if not channel:
+    seen_channels: set[str] = set()
+    for ref, video, channel in result.all():
+        if channel.id in seen_channels:
             continue
-
-        # Count unwatched videos for this user in this channel
-        unwatched_result = await db.execute(
-            select(UserVideoRef, Video)
-            .join(Video, UserVideoRef.video_id == Video.id)
-            .where(
-                UserVideoRef.user_id == user.id,
-                UserVideoRef.removed_at.is_(None),
-                UserVideoRef.is_watched == False,  # noqa: E712
-                Video.channel_id == channel_id,
-                Video.status == "COMPLETE",
-            )
-            .order_by(Video.uploaded_at.desc())
-        )
-        unwatched_rows = unwatched_result.all()
-        if not unwatched_rows:
-            continue
-
-        ref, latest_video = unwatched_rows[0]
+        seen_channels.add(channel.id)
         items.append(
             FeedItem(
                 channel=_channel_out(channel),
-                video=_video_out(latest_video, ref),
+                video=_video_out(video, ref),
             )
         )
+        if len(items) >= limit:
+            break
 
-    return items[:limit]
+    return items
 
 
 @router.get("/recently-added", response_model=list[FeedItem])
@@ -141,7 +145,10 @@ async def recently_added(
             UserVideoRef.removed_at.is_(None),
             Video.status == "COMPLETE",
         )
-        .order_by(Video.uploaded_at.desc())
+        .order_by(
+            Video.downloaded_at.desc().nullslast(),
+            Video.created_at.desc(),
+        )
         .limit(limit)
     )
     rows = result.all()

--- a/app/api/health.py
+++ b/app/api/health.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,13 +8,19 @@ router = APIRouter(prefix="/api", tags=["health"])
 
 
 @router.get("/health")
-async def health_check(db: AsyncSession = Depends(get_db)) -> dict:
+async def health_check(
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
     # Verify database connectivity
     try:
         await db.execute(text("SELECT 1"))
         db_status = "ok"
     except Exception:
         db_status = "error"
+
+    if db_status != "ok":
+        response.status_code = 503
 
     return {
         "status": "ok" if db_status == "ok" else "degraded",

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -102,6 +102,7 @@ async def get_video(
         thumbnail_url=f"/data/thumbnails/{video.youtube_video_id}.jpg",
         watch_position_seconds=ref.watch_position_seconds if ref else 0,
         is_watched=ref.is_watched if ref else False,
+        last_watched_at=ref.last_watched_at if ref else None,
         metadata_json=video.metadata_json,
         channel_name=channel.name if channel else "",
         channel_slug=channel.slug if channel else "",
@@ -122,6 +123,10 @@ async def trigger_download(
 
     if video.status in ("PENDING", "DOWNLOADING"):
         raise HTTPException(status_code=409, detail="Download already in progress")
+    if video.status == "CANCELLING":
+        raise HTTPException(
+            status_code=409, detail="Previous download is still being cancelled"
+        )
 
     # CATALOGED, FAILED, COMPLETE — (re-)enqueue. Keep file_path/file_size_bytes
     # intact so the existing file stays playable until the worker replaces it.
@@ -145,10 +150,20 @@ async def cancel_download(
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
+    if video.status == "CANCELLING":
+        # Escape hatch: a second cancel force-clears a cancel whose worker
+        # never confirmed (e.g. the worker died mid-download).
+        video.status = "CATALOGED"
+        await db.commit()
+        return {"detail": "Download cancelled", "video_id": video_id}
+
     if video.status not in ("PENDING", "DOWNLOADING"):
         return {"detail": "Not in progress", "video_id": video_id}
 
-    video.status = "CATALOGED"
+    # PENDING tasks never started — the worker's start guard skips CATALOGED.
+    # An in-flight download moves to CANCELLING until the worker confirms it
+    # has killed yt-dlp and cleaned up, blocking a concurrent re-download.
+    video.status = "CATALOGED" if video.status == "PENDING" else "CANCELLING"
     await db.commit()
 
     return {"detail": "Download cancelled", "video_id": video_id}
@@ -241,16 +256,27 @@ async def update_progress(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    exists = await db.execute(select(Video.id).where(Video.id == video_id))
-    if exists.scalar_one_or_none() is None:
+    result = await db.execute(
+        select(Video.duration_seconds).where(Video.id == video_id)
+    )
+    row = result.one_or_none()
+    if row is None:
         raise HTTPException(status_code=404, detail="Video not found")
+    duration = row[0]
+
+    # The client only reports positions; watched state is derived here. A
+    # position within the last 5% (or 30s) of the video marks it watched;
+    # restarting a watched video makes it in-progress again.
+    is_watched = bool(body.is_watched)
+    if not is_watched and duration and duration > 0:
+        is_watched = body.position_seconds >= max(duration * 0.95, duration - 30)
 
     now = utcnow_naive()
     stmt = sqlite_insert(UserVideoRef).values(
         user_id=user.id,
         video_id=video_id,
         watch_position_seconds=body.position_seconds,
-        is_watched=body.is_watched,
+        is_watched=is_watched,
         added_at=now,
         removed_at=None,
         last_watched_at=now,
@@ -260,7 +286,7 @@ async def update_progress(
         index_elements=["user_id", "video_id"],
         set_={
             "watch_position_seconds": body.position_seconds,
-            "is_watched": body.is_watched,
+            "is_watched": is_watched,
             "removed_at": None,
             "last_watched_at": now,
         },

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -1,21 +1,24 @@
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 from fastapi import APIRouter, Depends, Header, HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import Response
 from sqlalchemy import or_, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.api.auth import get_current_user, validate_token
+from app.config import settings
 from app.database import get_db
 from app.models.user import User
 from app.models.user_video_ref import UserVideoRef
 from app.models.video import Video
-from app.schemas.video import VideoDetail, VideoOut, VideoProgress
-from app.services.media_server import build_range_response
+from app.schemas.video import DownloadRequest, VideoDetail, VideoOut, VideoProgress
+from app.services.media_server import build_media_response
 from app.services.storage import check_and_delete_orphan
 from app.tasks.download_tasks import download_preview_task, download_video_task
+from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/videos", tags=["videos"])
 
@@ -25,7 +28,7 @@ async def get_active_downloads(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[VideoOut]:
-    cutoff = datetime.now(timezone.utc) - timedelta(seconds=60)
+    cutoff = utcnow_naive() - timedelta(seconds=60)
 
     stmt = (
         select(Video)
@@ -37,7 +40,7 @@ async def get_active_downloads(
             or_(
                 Video.status.in_(["PENDING", "DOWNLOADING"]),
                 # Include recently completed videos for the "done" transition
-                (Video.status == "COMPLETE") & (Video.created_at >= cutoff),
+                (Video.status == "COMPLETE") & (Video.downloaded_at >= cutoff),
             ),
         )
         .order_by(Video.created_at.desc())
@@ -108,6 +111,7 @@ async def get_video(
 @router.post("/{video_id}/download")
 async def trigger_download(
     video_id: str,
+    body: DownloadRequest | None = None,
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
@@ -116,16 +120,16 @@ async def trigger_download(
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
-    if video.status in ("DOWNLOADING", "PENDING"):
-        return {"detail": "Download already in progress", "video_id": video_id}
+    if video.status in ("PENDING", "DOWNLOADING"):
+        raise HTTPException(status_code=409, detail="Download already in progress")
 
-    # CATALOGED, FAILED, COMPLETE — (re-)enqueue
+    # CATALOGED, FAILED, COMPLETE — (re-)enqueue. Keep file_path/file_size_bytes
+    # intact so the existing file stays playable until the worker replaces it.
     video.status = "PENDING"
-    video.file_path = None
-    video.file_size_bytes = 0
     await db.commit()
 
-    download_video_task.delay(video_id, user.id)
+    quality = body.quality if body else None
+    download_video_task.delay(video_id, user.id, quality=quality)
 
     return {"detail": "Download enqueued", "video_id": video_id}
 
@@ -178,9 +182,9 @@ async def stream_preview(
     x_user_token: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
     range_header: str | None = Header(None, alias="Range"),
-):
+) -> Response:
     auth_token = token or x_user_token
-    if not auth_token or not validate_token(auth_token):
+    if not auth_token or not await validate_token(auth_token):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     result = await db.execute(select(Video).where(Video.id == video_id))
@@ -192,22 +196,12 @@ async def stream_preview(
 
     file_path = video.preview_file_path
     if not os.path.isabs(file_path):
-        file_path = os.path.join("/data/media", file_path)
+        file_path = os.path.join(settings.media_path, file_path)
 
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Preview file missing from disk")
 
-    if range_header:
-        return build_range_response(file_path, range_header)
-
-    return FileResponse(
-        file_path,
-        media_type="video/mp4",
-        headers={
-            "Accept-Ranges": "bytes",
-            "Content-Length": str(os.path.getsize(file_path)),
-        },
-    )
+    return build_media_response(file_path, range_header)
 
 
 @router.get("/{video_id}/stream")
@@ -217,10 +211,10 @@ async def stream_video(
     x_user_token: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
     range_header: str | None = Header(None, alias="Range"),
-):
+) -> Response:
     # Accept auth via query param (for <video> element) or header
     auth_token = token or x_user_token
-    if not auth_token or not validate_token(auth_token):
+    if not auth_token or not await validate_token(auth_token):
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     result = await db.execute(select(Video).where(Video.id == video_id))
@@ -232,22 +226,12 @@ async def stream_video(
 
     file_path = video.file_path
     if not os.path.isabs(file_path):
-        file_path = os.path.join("/data/media", file_path)
+        file_path = os.path.join(settings.media_path, file_path)
 
     if not os.path.exists(file_path):
         raise HTTPException(status_code=404, detail="Video file missing from disk")
 
-    if range_header:
-        return build_range_response(file_path, range_header)
-
-    return FileResponse(
-        file_path,
-        media_type="video/mp4",
-        headers={
-            "Accept-Ranges": "bytes",
-            "Content-Length": str(os.path.getsize(file_path)),
-        },
-    )
+    return build_media_response(file_path, range_header)
 
 
 @router.put("/{video_id}/progress")
@@ -257,25 +241,31 @@ async def update_progress(
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    result = await db.execute(
-        select(UserVideoRef).where(
-            UserVideoRef.user_id == user.id,
-            UserVideoRef.video_id == video_id,
-            UserVideoRef.removed_at.is_(None),
-        )
+    exists = await db.execute(select(Video.id).where(Video.id == video_id))
+    if exists.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    now = utcnow_naive()
+    stmt = sqlite_insert(UserVideoRef).values(
+        user_id=user.id,
+        video_id=video_id,
+        watch_position_seconds=body.position_seconds,
+        is_watched=body.is_watched,
+        added_at=now,
+        removed_at=None,
+        last_watched_at=now,
     )
-    ref = result.scalar_one_or_none()
-    if not ref:
-        ref = UserVideoRef(
-            user_id=user.id,
-            video_id=video_id,
-            watch_position_seconds=body.position_seconds,
-            is_watched=body.is_watched,
-        )
-        db.add(ref)
-    else:
-        ref.watch_position_seconds = body.position_seconds
-        ref.is_watched = body.is_watched
+    # UPSERT: update progress and reactivate soft-deleted refs in one statement.
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["user_id", "video_id"],
+        set_={
+            "watch_position_seconds": body.position_seconds,
+            "is_watched": body.is_watched,
+            "removed_at": None,
+            "last_watched_at": now,
+        },
+    )
+    await db.execute(stmt)
     await db.commit()
     return {"detail": "Progress updated"}
 
@@ -297,7 +287,7 @@ async def remove_video_ref(
     if not ref:
         raise HTTPException(status_code=404, detail="Video reference not found")
 
-    ref.removed_at = datetime.now(timezone.utc)
+    ref.removed_at = utcnow_naive()
     await db.commit()
 
     # Check if this was the last active reference; if so, delete file from disk.

--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -2,7 +2,9 @@ import json
 import logging
 from collections import defaultdict
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
+
+from app.api.auth import validate_token
 
 router = APIRouter(tags=["websocket"])
 logger = logging.getLogger(__name__)
@@ -12,8 +14,20 @@ _connections: dict[str, set[WebSocket]] = defaultdict(set)
 
 
 @router.websocket("/ws/{user_id}")
-async def websocket_endpoint(websocket: WebSocket, user_id: str):
+async def websocket_endpoint(
+    websocket: WebSocket,
+    user_id: str,
+    token: str | None = Query(None),
+) -> None:
     await websocket.accept()
+
+    # The token must resolve to a session belonging to this user.
+    token_user_id = await validate_token(token) if token else None
+    if token_user_id != user_id:
+        logger.info("WebSocket rejected (bad token): user=%s", user_id)
+        await websocket.close(code=4401)
+        return
+
     _connections[user_id].add(websocket)
     logger.info("WebSocket connected: user=%s", user_id)
 
@@ -24,6 +38,8 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
             if data == "ping":
                 await websocket.send_text("pong")
     except WebSocketDisconnect:
+        pass
+    finally:
         _connections[user_id].discard(websocket)
         if not _connections[user_id]:
             del _connections[user_id]
@@ -32,18 +48,18 @@ async def websocket_endpoint(websocket: WebSocket, user_id: str):
 
 async def broadcast_to_user(user_id: str, event: dict) -> None:
     """Send an event to all WebSocket connections for a specific user."""
-    sockets = _connections.get(user_id, set())
-    dead: list[WebSocket] = []
+    sockets = _connections.get(user_id)
+    if not sockets:
+        return
     message = json.dumps(event)
 
-    for ws in sockets:
+    # Iterate over a copy: sends can yield to the event loop, during which
+    # connects/disconnects may mutate the underlying set.
+    for ws in list(sockets):
         try:
             await ws.send_text(message)
         except Exception:
-            dead.append(ws)
-
-    for ws in dead:
-        sockets.discard(ws)
+            sockets.discard(ws)
 
 
 async def broadcast_to_all(event: dict) -> None:

--- a/app/api/youtube.py
+++ b/app/api/youtube.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.youtube import (
+    ChannelSuggestion,
+    SuggestionsResponse,
+    YoutubeHandleRequest,
+    YoutubeProfile,
+)
+from app.services.youtube_import import (
+    YoutubeResolveError,
+    YoutubeResolveTimeoutError,
+    get_suggestions,
+    resolve_handle,
+)
+
+# Unauthenticated: both endpoints are used from the profile picker pre-login.
+router = APIRouter(prefix="/api/youtube", tags=["youtube"])
+
+
+@router.post("/resolve", response_model=YoutubeProfile)
+async def resolve(body: YoutubeHandleRequest) -> YoutubeProfile:
+    try:
+        identity = await resolve_handle(body.handle)
+    except YoutubeResolveTimeoutError:
+        raise HTTPException(status_code=504, detail="YouTube lookup timed out")
+    except YoutubeResolveError:
+        raise HTTPException(status_code=404, detail="YouTube channel not found")
+    return YoutubeProfile(**identity)
+
+
+@router.post("/suggestions", response_model=SuggestionsResponse)
+async def suggestions(body: YoutubeHandleRequest) -> SuggestionsResponse:
+    try:
+        items = await get_suggestions(body.handle)
+    except YoutubeResolveTimeoutError:
+        raise HTTPException(status_code=504, detail="YouTube lookup timed out")
+    except YoutubeResolveError:
+        raise HTTPException(status_code=404, detail="YouTube channel not found")
+    return SuggestionsResponse(
+        suggestions=[ChannelSuggestion(**item) for item in items]
+    )

--- a/app/database.py
+++ b/app/database.py
@@ -1,14 +1,32 @@
 from collections.abc import AsyncGenerator
+from typing import Any
 
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
+
+
+def register_sqlite_pragmas(sync_engine: Engine) -> None:
+    """Apply SQLite PRAGMAs on every new connection of the given engine."""
+
+    @event.listens_for(sync_engine, "connect")
+    def _set_sqlite_pragmas(dbapi_connection: Any, connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA journal_mode=WAL")
+        cursor.execute("PRAGMA busy_timeout=5000")
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.execute("PRAGMA synchronous=NORMAL")
+        cursor.close()
+
 
 engine = create_async_engine(
     settings.database_url,
     echo=False,
     connect_args={"check_same_thread": False},
 )
+register_sqlite_pragmas(engine.sync_engine)
 
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 
@@ -8,9 +9,32 @@ from fastapi.staticfiles import StaticFiles
 
 import os
 
-from app.api import auth, channels, discover, feed, health, videos, websocket
+from app.api import auth, channels, discover, feed, health, videos, websocket, youtube
 from app.config import settings
 from app.services.progress_broadcaster import start_progress_listener
+
+logger = logging.getLogger(__name__)
+
+
+async def _run_progress_listener() -> None:
+    """Run the Redis progress listener, reconnecting with backoff on failure."""
+    delay = 1.0
+    while True:
+        try:
+            await start_progress_listener()
+            # Clean return: the listener handles cancellation internally.
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Progress listener error; reconnecting in %.0fs",
+                delay,
+                exc_info=True,
+            )
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, 60.0)
+
 
 # Ensure data directories exist before mounting StaticFiles
 for _p in [
@@ -35,7 +59,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     ]:
         os.makedirs(path, exist_ok=True)
 
-    progress_task = asyncio.create_task(start_progress_listener())
+    progress_task = asyncio.create_task(_run_progress_listener())
 
     yield
 
@@ -78,6 +102,7 @@ app.include_router(videos.router)
 app.include_router(feed.router)
 app.include_router(discover.router)
 app.include_router(websocket.router)
+app.include_router(youtube.router)
 
 
 @app.get("/")

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,10 @@ from app.api import auth, channels, discover, feed, health, videos, websocket, y
 from app.config import settings
 from app.services.progress_broadcaster import start_progress_listener
 
+# Self-hosters debug from container logs; surface app-level INFO messages
+# (graceful degradation in the YouTube importer, poller skips, etc.).
+logging.basicConfig(level=logging.INFO)
+
 logger = logging.getLogger(__name__)
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -12,3 +12,4 @@ from app.models.video import Video  # noqa: E402, F401
 from app.models.subscription import UserSubscription  # noqa: E402, F401
 from app.models.user_video_ref import UserVideoRef  # noqa: E402, F401
 from app.models.recommendation import Recommendation  # noqa: E402, F401
+from app.models.session import Session  # noqa: E402, F401

--- a/app/models/recommendation.py
+++ b/app/models/recommendation.py
@@ -1,10 +1,11 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models import Base
+from app.utils.time import utcnow_naive
 
 
 class Recommendation(Base):
@@ -14,12 +15,10 @@ class Recommendation(Base):
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())
     )
     user_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("users.id"), nullable=False
+        String(36), ForeignKey("users.id"), nullable=False, index=True
     )
     channel_name: Mapped[str] = mapped_column(String(255), nullable=False)
     youtube_channel_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     dismissed: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc)
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models import Base
+from app.utils.time import utcnow_naive
+
+
+class Session(Base):
+    """Persistent auth session. token_hash is the SHA-256 hex of the raw token."""
+
+    __tablename__ = "sessions"
+
+    token_hash: Mapped[str] = mapped_column(String(64), primary_key=True)
+    user_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id"), nullable=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -1,9 +1,10 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
+from app.utils.time import utcnow_naive
 
 
 class UserSubscription(Base):
@@ -15,9 +16,7 @@ class UserSubscription(Base):
     channel_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("channels.id"), primary_key=True
     )
-    subscribed_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc)
-    )
+    subscribed_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
     retention_policy: Mapped[str] = mapped_column(String(20), default="KEEP_ALL")
     retention_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     tracking_mode: Mapped[str] = mapped_column(String(20), default="FUTURE_ONLY")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,10 +1,11 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import Boolean, DateTime, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
+from app.utils.time import utcnow_naive
 
 
 class User(Base):
@@ -17,11 +18,13 @@ class User(Base):
     avatar_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
     pin_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc)
-    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
 
     subscriptions = relationship(
         "UserSubscription", back_populates="user", lazy="selectin"
     )
     video_refs = relationship("UserVideoRef", back_populates="user", lazy="selectin")
+
+    @property
+    def has_pin(self) -> bool:
+        return self.pin_hash is not None

--- a/app/models/user_video_ref.py
+++ b/app/models/user_video_ref.py
@@ -1,13 +1,15 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
+from app.utils.time import utcnow_naive
 
 
 class UserVideoRef(Base):
     __tablename__ = "user_video_refs"
+    __table_args__ = (Index("ix_user_video_refs_removed", "removed_at"),)
 
     user_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("users.id"), primary_key=True
@@ -17,10 +19,9 @@ class UserVideoRef(Base):
     )
     watch_position_seconds: Mapped[int] = mapped_column(Integer, default=0)
     is_watched: Mapped[bool] = mapped_column(Boolean, default=False)
-    added_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc)
-    )
+    added_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
     removed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_watched_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     user = relationship("User", back_populates="video_refs")
     video = relationship("Video", back_populates="user_refs")

--- a/app/models/video.py
+++ b/app/models/video.py
@@ -1,10 +1,11 @@
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, JSON, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
+from app.utils.time import utcnow_naive
 
 
 class Video(Base):
@@ -17,20 +18,19 @@ class Video(Base):
         String(255), unique=True, nullable=False
     )
     channel_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("channels.id"), nullable=False
+        String(36), ForeignKey("channels.id"), nullable=False, index=True
     )
     title: Mapped[str] = mapped_column(String(512), nullable=False)
     duration_seconds: Mapped[int] = mapped_column(Integer, default=0)
     uploaded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     file_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
-    file_size_bytes: Mapped[int] = mapped_column(BigInteger, default=0)
-    status: Mapped[str] = mapped_column(String(20), default="PENDING")
+    file_size_bytes: Mapped[int | None] = mapped_column(BigInteger, default=0)
+    status: Mapped[str] = mapped_column(String(20), default="PENDING", index=True)
     metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     preview_file_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     preview_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime, default=lambda: datetime.now(timezone.utc)
-    )
+    downloaded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
 
     channel = relationship("Channel", back_populates="videos")
     user_refs = relationship("UserVideoRef", back_populates="video", lazy="selectin")

--- a/app/schemas/channel.py
+++ b/app/schemas/channel.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ChannelOut(BaseModel):
@@ -29,3 +29,23 @@ class ChannelSubscribe(BaseModel):
 class ChannelDetail(ChannelOut):
     subscriber_count: int = 0
     tracking_mode: str | None = None
+
+
+class BulkSubscribeItem(BaseModel):
+    youtube_channel_id: str = Field(min_length=1)
+    name: str | None = None
+
+
+class BulkSubscribeRequest(BaseModel):
+    items: list[BulkSubscribeItem] = Field(min_length=1, max_length=25)
+
+
+class BulkSubscribeItemResult(BaseModel):
+    youtube_channel_id: str
+    status: str  # "subscribed" | "already_subscribed" | "error"
+    channel_id: str | None = None
+    detail: str | None = None
+
+
+class BulkSubscribeResponse(BaseModel):
+    results: list[BulkSubscribeItemResult]

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,6 +1,22 @@
+import re
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
+
+_PIN_PATTERN = re.compile(r"^\d{4,8}$")
+
+
+def _clean_display_name(value: str) -> str:
+    cleaned = value.strip()
+    if not 1 <= len(cleaned) <= 50:
+        raise ValueError("display_name must be 1-50 characters")
+    return cleaned
+
+
+def _check_pin(value: str) -> str:
+    if not _PIN_PATTERN.fullmatch(value):
+        raise ValueError("PIN must be 4-8 digits")
+    return value
 
 
 class UserProfile(BaseModel):
@@ -8,16 +24,58 @@ class UserProfile(BaseModel):
     display_name: str
     avatar_url: str | None = None
     is_admin: bool = False
+    has_pin: bool = False
     created_at: datetime
 
     model_config = {"from_attributes": True}
 
 
 class UserCreate(BaseModel):
-    display_name: str
+    display_name: str | None = None
     avatar_url: str | None = None
     pin: str | None = None
-    is_admin: bool = False
+    youtube_handle: str | None = None
+
+    @field_validator("display_name")
+    @classmethod
+    def validate_display_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _clean_display_name(value)
+
+    @field_validator("pin")
+    @classmethod
+    def validate_pin(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _check_pin(value)
+
+    @model_validator(mode="after")
+    def require_name_or_handle(self) -> "UserCreate":
+        if self.display_name is None and not (self.youtube_handle or "").strip():
+            raise ValueError("display_name is required unless youtube_handle is given")
+        return self
+
+
+class UserUpdate(BaseModel):
+    display_name: str | None = None
+    avatar_url: str | None = None
+    pin: str | None = None
+    remove_pin: bool = False
+
+    @field_validator("display_name")
+    @classmethod
+    def validate_display_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _clean_display_name(value)
+
+    @field_validator("pin")
+    @classmethod
+    def validate_pin(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        return _check_pin(value)
 
 
 class UserSelect(BaseModel):

--- a/app/schemas/video.py
+++ b/app/schemas/video.py
@@ -1,6 +1,7 @@
 from datetime import datetime
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class VideoOut(BaseModel):
@@ -28,8 +29,12 @@ class VideoDetail(VideoOut):
 
 
 class VideoProgress(BaseModel):
-    position_seconds: int
+    position_seconds: int = Field(ge=0)
     is_watched: bool = False
+
+
+class DownloadRequest(BaseModel):
+    quality: Literal["720p", "1080p", "4k", "best"] | None = None
 
 
 class VideoPagination(BaseModel):

--- a/app/schemas/video.py
+++ b/app/schemas/video.py
@@ -17,6 +17,7 @@ class VideoOut(BaseModel):
     thumbnail_url: str | None = None
     watch_position_seconds: int = 0
     is_watched: bool = False
+    last_watched_at: datetime | None = None
     channel_name: str = ""
 
     model_config = {"from_attributes": True}

--- a/app/schemas/youtube.py
+++ b/app/schemas/youtube.py
@@ -1,0 +1,28 @@
+from pydantic import BaseModel, Field
+
+
+class YoutubeHandleRequest(BaseModel):
+    handle: str = Field(min_length=1)
+
+
+class YoutubeProfile(BaseModel):
+    handle: str
+    channel_id: str
+    name: str
+    description: str = ""
+    avatar_url: str | None = None
+    banner_url: str | None = None
+    follower_count: int | None = None
+
+
+class ChannelSuggestion(BaseModel):
+    youtube_channel_id: str
+    name: str
+    handle: str | None = None
+    avatar_url: str | None = None
+    source: str
+    score: int
+
+
+class SuggestionsResponse(BaseModel):
+    suggestions: list[ChannelSuggestion]

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -14,8 +14,16 @@ from app.services.download_manager import (
     fetch_channel_metadata,
     fetch_channel_videos,
 )
+from app.utils.time import utcnow_naive
 
 logger = logging.getLogger(__name__)
+
+
+def _as_naive_utc(value: datetime | None) -> datetime | None:
+    """Normalize a datetime to naive UTC for safe comparisons."""
+    if value is not None and value.tzinfo is not None:
+        return value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
 
 
 def poll_all_channels(db: Session) -> list[str]:
@@ -36,6 +44,7 @@ def poll_all_channels(db: Session) -> list[str]:
             all_auto_download_ids.extend(poll_result["auto_download_ids"])
         except Exception:
             logger.exception("Error polling channel %s", channel_id)
+            db.rollback()
 
     return all_auto_download_ids
 
@@ -49,6 +58,10 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
     if not channel:
         logger.warning("Channel %s not found", channel_id)
         return {"cataloged_ids": [], "auto_download_ids": []}
+
+    # The very first poll catalogs the back catalog; videos discovered then
+    # must never be auto-downloaded for FUTURE_ONLY subscribers.
+    had_initial_poll = channel.last_checked_at is not None
 
     # Fetch latest videos from YouTube
     fetch_result = fetch_channel_videos(channel.youtube_channel_id)
@@ -72,13 +85,11 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
             _ensure_user_refs(existing, channel_id, db)
             continue
 
-        # Parse upload_date into uploaded_at
+        # Parse upload_date into uploaded_at (stored as naive UTC)
         uploaded_at = None
         if yt_vid.get("upload_date"):
             try:
-                uploaded_at = datetime.strptime(
-                    yt_vid["upload_date"], "%Y%m%d"
-                ).replace(tzinfo=timezone.utc)
+                uploaded_at = datetime.strptime(yt_vid["upload_date"], "%Y%m%d")
             except (ValueError, TypeError):
                 pass
 
@@ -105,9 +116,11 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
     # Determine auto-download candidates based on subscriber tracking modes
     auto_download_ids: list[str] = []
     if new_video_ids:
-        auto_download_ids = _determine_auto_downloads(new_video_ids, channel_id, db)
+        auto_download_ids = _determine_auto_downloads(
+            new_video_ids, channel_id, db, had_initial_poll
+        )
 
-    channel.last_checked_at = datetime.now(timezone.utc)
+    channel.last_checked_at = utcnow_naive()
     db.commit()
 
     return {"cataloged_ids": cataloged_ids, "auto_download_ids": auto_download_ids}
@@ -120,7 +133,7 @@ def refresh_stale_channel_metadata(db: Session) -> int:
     """
     from app.config import settings
 
-    staleness_threshold = datetime.now(timezone.utc) - timedelta(
+    staleness_threshold = utcnow_naive() - timedelta(
         hours=settings.metadata_refresh_interval_hours
     )
 
@@ -197,44 +210,58 @@ def _refresh_single_channel_metadata(channel: Channel, db: Session) -> None:
         if images.get("banner_url"):
             channel.banner_url = images["banner_url"]
 
-    channel.metadata_refreshed_at = datetime.now(timezone.utc)
+    channel.metadata_refreshed_at = utcnow_naive()
     db.commit()
 
 
 def _determine_auto_downloads(
-    new_video_ids: list[str], channel_id: str, db: Session
+    new_video_ids: list[str],
+    channel_id: str,
+    db: Session,
+    had_initial_poll: bool,
 ) -> list[str]:
-    """Determine which new videos should be auto-downloaded based on subscriber tracking modes."""
+    """Determine which new videos should be auto-downloaded based on subscriber tracking modes.
+
+    A video qualifies for FUTURE_ONLY auto-download when its row was created
+    during this poll (it's in new_video_ids), the channel already had a
+    completed initial poll (so this isn't back-catalog ingestion), and the
+    row was created after the subscription.
+    """
+    if not had_initial_poll:
+        # Initial poll: everything discovered is back catalog. Catalog only.
+        return []
+
     # Get all subscribers and their tracking modes
     sub_result = db.execute(
         select(UserSubscription).where(UserSubscription.channel_id == channel_id)
     )
     subscriptions = sub_result.scalars().all()
 
-    # If any subscriber has FUTURE_ONLY mode, check upload dates vs subscription dates
-    auto_download_set: set[str] = set()
+    videos = (
+        db.execute(select(Video).where(Video.id.in_(new_video_ids))).scalars().all()
+    )
 
+    auto_download_set: set[str] = set()
     for sub in subscriptions:
         if sub.tracking_mode == "ALL_VIDEOS":
             # ALL_VIDEOS mode: never auto-download, just catalog
             continue
 
-        # FUTURE_ONLY (default): auto-download if uploaded_at > subscribed_at
-        for video_id in new_video_ids:
-            video = db.get(Video, video_id)
-            if not video or video.status != "CATALOGED":
+        # FUTURE_ONLY (default): auto-download videos cataloged after the
+        # user subscribed. Compare as naive UTC.
+        subscribed_at = _as_naive_utc(sub.subscribed_at)
+        if subscribed_at is None:
+            continue
+        for video in videos:
+            if video.status != "CATALOGED":
                 continue
-
-            if video.uploaded_at and sub.subscribed_at:
-                if video.uploaded_at > sub.subscribed_at:
-                    auto_download_set.add(video_id)
-            # If upload_date is unknown, do NOT auto-download for FUTURE_ONLY
-            # (conservative: leave as cataloged to avoid back-catalog spam)
+            created_at = _as_naive_utc(video.created_at)
+            if created_at and created_at > subscribed_at:
+                auto_download_set.add(video.id)
 
     # Set auto-download candidates to PENDING
-    for video_id in auto_download_set:
-        video = db.get(Video, video_id)
-        if video and video.status == "CATALOGED":
+    for video in videos:
+        if video.id in auto_download_set and video.status == "CATALOGED":
             video.status = "PENDING"
 
     return list(auto_download_set)

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import json
 import time
@@ -16,6 +17,14 @@ logger = logging.getLogger(__name__)
 
 class DownloadCancelled(Exception):
     """Raised when an in-flight download is cancelled (e.g. via the API)."""
+
+
+def _kill_process_group(process: subprocess.Popen) -> None:
+    """Kill a subprocess and its children (yt-dlp delegates to aria2c)."""
+    try:
+        os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+    except (OSError, ProcessLookupError):
+        process.kill()
 
 
 def download_video(
@@ -81,6 +90,7 @@ def download_video(
         stderr=subprocess.STDOUT,
         text=True,
         bufsize=1,  # line-buffered for more frequent progress updates
+        start_new_session=True,  # own process group so cancel kills aria2c too
     )
 
     # yt-dlp native: [download]  45.2% ...
@@ -100,7 +110,7 @@ def download_video(
                 if now - last_cancel_check_time >= 5.0:
                     last_cancel_check_time = now
                     if cancel_check():
-                        process.kill()
+                        _kill_process_group(process)
                         process.wait()
                         _cleanup_partial_files(output_dir, youtube_video_id)
                         raise DownloadCancelled(
@@ -117,7 +127,8 @@ def download_video(
 
         process.wait(timeout=3600)
     except subprocess.TimeoutExpired:
-        process.kill()
+        _kill_process_group(process)
+        process.wait()
         raise RuntimeError(f"yt-dlp timed out for {youtube_video_id}")
 
     if process.returncode != 0:

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -14,15 +14,25 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 
+class DownloadCancelled(Exception):
+    """Raised when an in-flight download is cancelled (e.g. via the API)."""
+
+
 def download_video(
     youtube_video_id: str,
     channel_slug: str,
     quality: str | None = None,
     progress_callback: Callable[[float], None] | None = None,
+    cancel_check: Callable[[], bool] | None = None,
 ) -> dict:
     """
     Download a video using yt-dlp. Returns metadata dict on success.
-    Raises RuntimeError on failure.
+
+    `cancel_check` is polled every ~5s while the download runs; when it
+    returns True, yt-dlp is killed, partial files are cleaned up, and
+    DownloadCancelled is raised.
+
+    Raises RuntimeError on failure, DownloadCancelled on cancellation.
     """
     quality = quality or settings.media_quality
     output_dir = os.path.join(settings.media_path, channel_slug)
@@ -77,11 +87,26 @@ def download_video(
     # aria2c:        [#abc 1.7MiB/81MiB(2%) ...]
     progress_re = re.compile(r"\[download\]\s+([\d.]+)%|\((\d+)%\)")
     last_callback_time = 0.0
+    last_cancel_check_time = time.monotonic()
     last_line = ""
 
     try:
         for line in process.stdout or []:
             last_line = line
+
+            # Poll for cancellation every ~5s while output is flowing
+            if cancel_check is not None:
+                now = time.monotonic()
+                if now - last_cancel_check_time >= 5.0:
+                    last_cancel_check_time = now
+                    if cancel_check():
+                        process.kill()
+                        process.wait()
+                        _cleanup_partial_files(output_dir, youtube_video_id)
+                        raise DownloadCancelled(
+                            f"Download cancelled for {youtube_video_id}"
+                        )
+
             m = progress_re.search(line)
             if m and progress_callback is not None:
                 now = time.monotonic()
@@ -158,21 +183,24 @@ def download_preview(
 
     logger.info("Starting preview download: %s", youtube_video_id)
 
-    process = subprocess.Popen(
-        cmd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-
+    # subprocess.run drains stdout/stderr while waiting (via communicate),
+    # avoiding the pipe-fill deadlock of Popen + wait with a PIPE attached.
     try:
-        process.wait(timeout=120)
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
     except subprocess.TimeoutExpired:
-        process.kill()
         raise RuntimeError(f"Preview download timed out for {youtube_video_id}")
 
-    if process.returncode != 0:
-        raise RuntimeError(f"Preview download failed for {youtube_video_id}")
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "").strip().splitlines()[-1:]
+        detail = tail[0] if tail else "unknown error"
+        raise RuntimeError(
+            f"Preview download failed for {youtube_video_id}: {detail[:300]}"
+        )
 
     file_path = _find_preview_file(output_dir, video_id)
     if not file_path:
@@ -185,6 +213,29 @@ def download_preview(
         "file_path": relative_path,
         "file_size_bytes": file_size,
     }
+
+
+def _cleanup_partial_files(output_dir: str, youtube_video_id: str) -> None:
+    """Remove partial download artifacts for a video in the channel directory.
+
+    Targets `.part`, `.aria2`, `.ytdl` files and `.fNNN.` format fragments
+    left behind by an interrupted yt-dlp/aria2c download.
+    """
+    try:
+        entries = os.listdir(output_dir)
+    except OSError:
+        return
+    fragment_re = re.compile(rf"^{re.escape(youtube_video_id)}\.f\d+\.")
+    for name in entries:
+        if not name.startswith(youtube_video_id):
+            continue
+        if name.endswith((".part", ".aria2", ".ytdl")) or fragment_re.match(name):
+            path = os.path.join(output_dir, name)
+            try:
+                os.remove(path)
+                logger.info("Removed partial file: %s", path)
+            except OSError:
+                logger.warning("Failed to remove partial file: %s", path)
 
 
 def _find_preview_file(output_dir: str, video_id: str) -> str | None:

--- a/app/services/media_server.py
+++ b/app/services/media_server.py
@@ -63,6 +63,11 @@ def build_media_response(file_path: str, range_header: str | None = None) -> Res
     )
 
 
+def _is_ascii_digits(value: str) -> bool:
+    """True when value is one or more ASCII digits (safe to int())."""
+    return bool(value) and value.isascii() and value.isdigit()
+
+
 def _parse_range(range_header: str, file_size: int) -> tuple[int, int] | None:
     """Parse a Range header into an inclusive (start, end) byte tuple.
 
@@ -82,15 +87,17 @@ def _parse_range(range_header: str, file_size: int) -> tuple[int, int] | None:
     end_s = end_s.strip()
 
     if start_s:
-        # Open-ended "N-" or bounded "N-M".
-        if not start_s.isdigit():
+        # Open-ended "N-" or bounded "N-M". ASCII check required: isdigit()
+        # alone accepts non-ASCII digits (e.g. latin-1 '\xb2') that int()
+        # rejects, which would turn a malformed header into a 500.
+        if not _is_ascii_digits(start_s):
             return None
         start = int(start_s)
         if start >= file_size:
             return None
         if not end_s:
             return start, file_size - 1
-        if not end_s.isdigit():
+        if not _is_ascii_digits(end_s):
             return None
         end = int(end_s)
         if end < start:
@@ -98,7 +105,7 @@ def _parse_range(range_header: str, file_size: int) -> tuple[int, int] | None:
         return start, min(end, file_size - 1)
 
     # Suffix range "-N": the last N bytes of the file.
-    if not end_s or not end_s.isdigit():
+    if not _is_ascii_digits(end_s):
         return None
     suffix_length = int(end_s)
     if suffix_length == 0:

--- a/app/services/media_server.py
+++ b/app/services/media_server.py
@@ -1,62 +1,128 @@
+import asyncio
+import hashlib
 import mimetypes
 import os
-import hashlib
-from datetime import datetime, timezone
+from collections.abc import AsyncIterator
 from email.utils import formatdate
-from time import mktime
 
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
+
+# Read media files in 1 MiB chunks so large files/ranges are never fully buffered.
+CHUNK_SIZE = 1024 * 1024
 
 
-def build_range_response(file_path: str, range_header: str) -> Response:
+def build_media_response(file_path: str, range_header: str | None = None) -> Response:
+    """Build a streaming HTTP response for a media file.
+
+    Implements RFC 7233 byte ranges:
+    - No Range header -> 200 streaming the full file.
+    - `bytes=N-`, `bytes=N-M`, suffix `bytes=-N` (last N bytes) -> 206.
+    - Multi-range requests are served as the first range only.
+    - Malformed or unsatisfiable ranges -> 416 with `Content-Range: bytes */size`.
+
+    ETag (derived from mtime+size) and Last-Modified are set on both the
+    200 and 206 paths. File content is streamed in chunks via a thread
+    offload — the requested range is never read into memory at once.
     """
-    Build an HTTP 206 Partial Content response for range requests.
-    Supports single byte ranges (e.g. "bytes=0-1023").
-    """
-    file_size = os.path.getsize(file_path)
     stat = os.stat(file_path)
+    file_size = stat.st_size
 
-    # Parse range header: "bytes=start-end"
-    range_spec = range_header.replace("bytes=", "").strip()
-    parts = range_spec.split("-")
+    headers = {
+        "Accept-Ranges": "bytes",
+        "ETag": _compute_etag(stat),
+        "Last-Modified": formatdate(stat.st_mtime, usegmt=True),
+        "Cache-Control": "public, max-age=86400",
+    }
+    content_type = _guess_content_type(file_path)
 
-    start = int(parts[0]) if parts[0] else 0
-    end = int(parts[1]) if len(parts) > 1 and parts[1] else file_size - 1
+    if range_header is None:
+        headers["Content-Length"] = str(file_size)
+        return StreamingResponse(
+            _file_iterator(file_path, 0, file_size),
+            status_code=200,
+            media_type=content_type,
+            headers=headers,
+        )
 
-    # Clamp values
-    start = max(0, start)
-    end = min(end, file_size - 1)
-
-    if start > end or start >= file_size:
+    byte_range = _parse_range(range_header, file_size)
+    if byte_range is None:
         return Response(
             status_code=416,
             headers={"Content-Range": f"bytes */{file_size}"},
         )
 
+    start, end = byte_range
     content_length = end - start + 1
-
-    # Read the requested range
-    with open(file_path, "rb") as f:
-        f.seek(start)
-        data = f.read(content_length)
-
-    content_type = _guess_content_type(file_path)
-    etag = _compute_etag(file_path, stat)
-    last_modified = _format_http_date(stat.st_mtime)
-
-    return Response(
-        content=data,
+    headers["Content-Range"] = f"bytes {start}-{end}/{file_size}"
+    headers["Content-Length"] = str(content_length)
+    return StreamingResponse(
+        _file_iterator(file_path, start, content_length),
         status_code=206,
-        headers={
-            "Content-Range": f"bytes {start}-{end}/{file_size}",
-            "Content-Length": str(content_length),
-            "Content-Type": content_type,
-            "Accept-Ranges": "bytes",
-            "ETag": etag,
-            "Last-Modified": last_modified,
-            "Cache-Control": "public, max-age=86400",
-        },
+        media_type=content_type,
+        headers=headers,
     )
+
+
+def _parse_range(range_header: str, file_size: int) -> tuple[int, int] | None:
+    """Parse a Range header into an inclusive (start, end) byte tuple.
+
+    Returns None when the header is malformed or unsatisfiable; the caller
+    responds with 416. Multi-range requests yield the first range only.
+    """
+    header = range_header.strip()
+    if file_size <= 0 or not header.lower().startswith("bytes="):
+        return None
+
+    # Multi-range: serve the first range only.
+    spec = header[len("bytes=") :].split(",")[0].strip()
+    if "-" not in spec:
+        return None
+    start_s, _, end_s = spec.partition("-")
+    start_s = start_s.strip()
+    end_s = end_s.strip()
+
+    if start_s:
+        # Open-ended "N-" or bounded "N-M".
+        if not start_s.isdigit():
+            return None
+        start = int(start_s)
+        if start >= file_size:
+            return None
+        if not end_s:
+            return start, file_size - 1
+        if not end_s.isdigit():
+            return None
+        end = int(end_s)
+        if end < start:
+            return None
+        return start, min(end, file_size - 1)
+
+    # Suffix range "-N": the last N bytes of the file.
+    if not end_s or not end_s.isdigit():
+        return None
+    suffix_length = int(end_s)
+    if suffix_length == 0:
+        return None
+    return max(0, file_size - suffix_length), file_size - 1
+
+
+async def _file_iterator(
+    file_path: str, start: int, length: int
+) -> AsyncIterator[bytes]:
+    """Yield `length` bytes from `start` in chunks without blocking the loop."""
+    remaining = length
+    file = await asyncio.to_thread(open, file_path, "rb")
+    try:
+        if start:
+            await asyncio.to_thread(file.seek, start)
+        while remaining > 0:
+            chunk = await asyncio.to_thread(file.read, min(CHUNK_SIZE, remaining))
+            if not chunk:
+                break
+            remaining -= len(chunk)
+            yield chunk
+    finally:
+        await asyncio.to_thread(file.close)
 
 
 def _guess_content_type(file_path: str) -> str:
@@ -64,11 +130,6 @@ def _guess_content_type(file_path: str) -> str:
     return mime or "application/octet-stream"
 
 
-def _compute_etag(file_path: str, stat: os.stat_result) -> str:
-    raw = f"{file_path}:{stat.st_size}:{stat.st_mtime}"
+def _compute_etag(stat: os.stat_result) -> str:
+    raw = f"{stat.st_mtime_ns}:{stat.st_size}"
     return f'"{hashlib.md5(raw.encode()).hexdigest()}"'
-
-
-def _format_http_date(timestamp: float) -> str:
-    dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
-    return formatdate(mktime(dt.timetuple()), usegmt=True)

--- a/app/services/progress_broadcaster.py
+++ b/app/services/progress_broadcaster.py
@@ -51,7 +51,11 @@ def publish_preview_ready(video_id: str, user_id: str) -> None:
 
 
 def publish_download_complete(
-    video_id: str, user_id: str, channel_id: str | None = None
+    video_id: str,
+    user_id: str,
+    channel_id: str | None = None,
+    title: str | None = None,
+    youtube_video_id: str | None = None,
 ) -> None:
     """Publish download_complete event from the Celery worker (sync)."""
     _get_sync_redis().publish(
@@ -62,6 +66,8 @@ def publish_download_complete(
                 "video_id": video_id,
                 "user_id": user_id,
                 "channel_id": channel_id,
+                "title": title,
+                "youtube_video_id": youtube_video_id,
             }
         ),
     )
@@ -93,8 +99,9 @@ async def start_progress_listener() -> None:
                     )
                 elif msg_type == "download_complete":
                     data = {"video_id": payload["video_id"]}
-                    if payload.get("channel_id"):
-                        data["channel_id"] = payload["channel_id"]
+                    for key in ("channel_id", "title", "youtube_video_id"):
+                        if payload.get(key):
+                            data[key] = payload[key]
                     await broadcast_to_user(
                         payload["user_id"],
                         {

--- a/app/services/recommendation.py
+++ b/app/services/recommendation.py
@@ -19,7 +19,8 @@ RECOMMENDATION_PROMPT = """You are a YouTube channel recommendation engine. Base
 
 For each suggestion, provide:
 1. The channel name
-2. A brief reason why the user would enjoy it
+2. The channel's YouTube @handle (e.g. "@mkbhd")
+3. A brief reason why the user would enjoy it
 
 Current subscriptions:
 {subscriptions}
@@ -32,7 +33,7 @@ Previously dismissed suggestions (do not recommend these again):
 
 Respond in JSON format:
 [
-  {{"channel_name": "ChannelName", "reason": "Because you watch..."}}
+  {{"channel_name": "ChannelName", "handle": "@channelhandle", "reason": "Because you watch..."}}
 ]
 
 Only return the JSON array, no other text."""
@@ -69,18 +70,25 @@ async def generate_recommendations(
     )
 
     try:
-        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
-        message = client.messages.create(
-            model="claude-sonnet-4-20250514",
+        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+        message = await client.messages.create(
+            model="claude-sonnet-4-6",
             max_tokens=1024,
             messages=[{"role": "user", "content": prompt}],
         )
 
         block = message.content[0]
         response_text = block.text if hasattr(block, "text") else ""
+        # Strip markdown code fences if the model wrapped the JSON anyway
+        response_text = response_text.strip()
+        if response_text.startswith("```"):
+            response_text = response_text.strip("`")
+            response_text = response_text.removeprefix("json").strip()
         suggestions = json.loads(response_text)
-    except Exception:
-        logger.exception("Failed to get recommendations from Anthropic")
+        if not isinstance(suggestions, list):
+            raise ValueError("Expected a JSON array of suggestions")
+    except Exception as exc:
+        logger.warning("Failed to get recommendations from Anthropic: %s", exc)
         return []
 
     # Clear old non-dismissed recommendations for this user
@@ -93,13 +101,18 @@ async def generate_recommendations(
     for old_rec in old_result.scalars().all():
         await db.delete(old_rec)
 
-    # Store new recommendations
+    # Store new recommendations. The @handle goes in youtube_channel_id so
+    # the client can one-tap subscribe (the subscribe endpoint resolves it).
     new_recs: list[Recommendation] = []
     for s in suggestions:
+        handle = s.get("handle")
+        if not (isinstance(handle, str) and handle.strip()):
+            handle = None
         rec = Recommendation(
             id=str(uuid.uuid4()),
             user_id=user.id,
             channel_name=s.get("channel_name", "Unknown"),
+            youtube_channel_id=handle,
             reason=s.get("reason", ""),
         )
         db.add(rec)

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -79,6 +79,14 @@ async def check_and_delete_orphan(video_id: str, db: AsyncSession) -> bool:
             except OSError:
                 pass
 
+    # Reset the video row so it reflects the on-disk state (re-downloadable).
+    video.status = "CATALOGED"
+    video.file_path = None
+    video.file_size_bytes = None
+    video.preview_file_path = None
+    video.preview_status = None
+    await db.commit()
+
     logger.info(
         "Orphan cleanup complete for video %s (%s)",
         video_id,

--- a/app/services/youtube_import.py
+++ b/app/services/youtube_import.py
@@ -254,7 +254,9 @@ async def get_suggestions(handle: str) -> list[dict[str, Any]]:
             data = await asyncio.to_thread(
                 _run_yt_dlp_json,
                 _channel_url(normalized, "/playlists"),
-                [],
+                # Only the first few playlists are fetched below; bounding the
+                # tab dump keeps this fast for channels with thousands.
+                ["--playlist-items", f"1-{MAX_PLAYLISTS}"],
                 SUGGESTIONS_CALL_TIMEOUT_SECONDS,
             )
             for entry in (data.get("entries") or [])[:MAX_PLAYLISTS]:

--- a/app/services/youtube_import.py
+++ b/app/services/youtube_import.py
@@ -1,0 +1,311 @@
+"""YouTube channel identity resolution and channel suggestions via yt-dlp.
+
+The contracts here (exception type and function signatures) are depended on by
+app.api.auth and app.api.youtube.
+"""
+
+import asyncio
+import json
+import logging
+import re
+import subprocess
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 3600
+RESOLVE_TIMEOUT_SECONDS = 30
+SUGGESTIONS_CALL_TIMEOUT_SECONDS = 25
+SUGGESTIONS_BUDGET_SECONDS = 60
+MAX_PLAYLISTS = 5
+MAX_PLAYLIST_ITEMS = 25
+MAX_SUGGESTIONS = 15
+FEATURED_SCORE = 100
+
+
+class YoutubeResolveError(Exception):
+    """Raised when a YouTube handle cannot be resolved to a channel."""
+
+
+class YoutubeResolveTimeoutError(YoutubeResolveError):
+    """Raised when a YouTube lookup exceeds its time budget."""
+
+
+# In-memory TTL caches keyed by normalized handle.
+_resolve_cache: dict[str, tuple[float, dict[str, Any]]] = {}
+_suggestions_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+
+def _cache_get(cache: dict[str, tuple[float, Any]], key: str) -> Any | None:
+    entry = cache.get(key)
+    if entry is None:
+        return None
+    expires_at, value = entry
+    if time.monotonic() >= expires_at:
+        del cache[key]
+        return None
+    return value
+
+
+def _cache_set(cache: dict[str, tuple[float, Any]], key: str, value: Any) -> None:
+    cache[key] = (time.monotonic() + CACHE_TTL_SECONDS, value)
+
+
+def _normalize_handle(handle: str) -> str:
+    """Normalize ``@name``, ``name``, or a full YouTube URL to ``@name``/UC id."""
+    value = handle.strip()
+    if "youtube.com" in value:
+        for pattern in (
+            r"youtube\.com/channel/(UC[A-Za-z0-9_-]+)",
+            r"youtube\.com/(@[A-Za-z0-9._-]+)",
+            r"youtube\.com/(?:c|user)/([A-Za-z0-9._-]+)",
+        ):
+            match = re.search(pattern, value)
+            if match:
+                value = match.group(1)
+                break
+        else:
+            raise YoutubeResolveError(f"Could not parse YouTube URL: {handle}")
+    value = value.strip().strip("/")
+    if not value:
+        raise YoutubeResolveError("No handle provided")
+    if value.startswith("UC") and len(value) == 24:
+        return value
+    if not value.startswith("@"):
+        value = f"@{value}"
+    return value
+
+
+def _channel_url(normalized: str, suffix: str = "") -> str:
+    if normalized.startswith("UC"):
+        return f"https://www.youtube.com/channel/{normalized}{suffix}"
+    return f"https://www.youtube.com/{normalized}{suffix}"
+
+
+def _run_yt_dlp_json(url: str, extra_args: list[str], timeout: int) -> dict[str, Any]:
+    """Run yt-dlp with -J against a URL and return the parsed JSON document.
+
+    Blocking; callers run this via asyncio.to_thread. Always passes
+    --no-update so the version nag never pollutes stderr.
+    """
+    cmd = ["yt-dlp", "--no-update", "--flat-playlist", *extra_args, "-J", url]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        raise YoutubeResolveTimeoutError(f"yt-dlp timed out for {url}")
+    except OSError as exc:
+        logger.error("Could not run yt-dlp: %s", exc)
+        raise YoutubeResolveError(f"Could not run yt-dlp: {exc}")
+    if result.returncode != 0 or not result.stdout.strip():
+        stderr_lines = (result.stderr or "").strip().splitlines()
+        detail = stderr_lines[-1] if stderr_lines else "no output"
+        raise YoutubeResolveError(f"yt-dlp failed for {url}: {detail[:300]}")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        raise YoutubeResolveError(f"yt-dlp returned invalid JSON for {url}")
+    if not isinstance(data, dict):
+        raise YoutubeResolveError(f"yt-dlp returned unexpected JSON for {url}")
+    return data
+
+
+def _select_images(
+    thumbnails: list[dict[str, Any]],
+) -> tuple[str | None, str | None]:
+    """Pick avatar and banner URLs from a yt-dlp thumbnails list.
+
+    Avatar: the ``avatar_uncropped`` thumbnail, else the largest square-ish
+    one. Banner: ``banner_uncropped`` if present.
+    """
+    avatar_uncropped: str | None = None
+    banner: str | None = None
+    best_square: str | None = None
+    best_area = -1
+    for thumb in thumbnails:
+        url = thumb.get("url")
+        if not url:
+            continue
+        thumb_id = thumb.get("id")
+        if thumb_id == "avatar_uncropped":
+            avatar_uncropped = url
+        elif thumb_id == "banner_uncropped":
+            banner = url
+        width = thumb.get("width")
+        height = thumb.get("height")
+        if width and height and 0.8 <= width / height <= 1.25:
+            area = width * height
+            if area > best_area:
+                best_area = area
+                best_square = url
+    return avatar_uncropped or best_square, banner
+
+
+def _entry_handle(entry: dict[str, Any]) -> str | None:
+    handle = entry.get("uploader_id")
+    if isinstance(handle, str) and handle.startswith("@"):
+        return handle
+    return None
+
+
+async def resolve_handle(handle: str) -> dict[str, Any]:
+    """Resolve a YouTube handle (or channel URL) to channel identity.
+
+    Returns a dict with keys: handle, channel_id, name, description,
+    avatar_url, banner_url, follower_count.
+
+    Raises YoutubeResolveError if the channel cannot be resolved, or
+    YoutubeResolveTimeoutError (a subclass) on timeout.
+    """
+    normalized = _normalize_handle(handle)
+    cached = _cache_get(_resolve_cache, normalized)
+    if cached is not None:
+        return cached
+
+    data = await asyncio.to_thread(
+        _run_yt_dlp_json,
+        _channel_url(normalized),
+        ["--playlist-items", "0"],
+        RESOLVE_TIMEOUT_SECONDS,
+    )
+
+    channel_id = data.get("channel_id") or data.get("id")
+    if not channel_id:
+        raise YoutubeResolveError(f"No channel id in yt-dlp output for {normalized}")
+    name = (
+        data.get("channel") or data.get("uploader") or data.get("title") or normalized
+    )
+    resolved_handle = _entry_handle(data) or normalized
+
+    thumbnails = data.get("thumbnails")
+    avatar_url, banner_url = _select_images(
+        thumbnails if isinstance(thumbnails, list) else []
+    )
+
+    follower_count = data.get("channel_follower_count")
+    result: dict[str, Any] = {
+        "handle": resolved_handle,
+        "channel_id": channel_id,
+        "name": name,
+        "description": data.get("description") or "",
+        "avatar_url": avatar_url,
+        "banner_url": banner_url,
+        "follower_count": follower_count if isinstance(follower_count, int) else None,
+    }
+    _cache_set(_resolve_cache, normalized, result)
+    return result
+
+
+async def get_suggestions(handle: str) -> list[dict[str, Any]]:
+    """Return ranked suggestions of channels the given handle follows.
+
+    Each item is a dict with keys: youtube_channel_id, name, handle,
+    avatar_url, source, score. An empty list is a normal result.
+
+    Strategy (graceful degradation, total budget ~60s):
+    1. Legacy featured-channels tab (usually absent — errors are skipped).
+    2. Public playlists: channel frequency across up to 5 playlists.
+    """
+    normalized = _normalize_handle(handle)
+    cached = _cache_get(_suggestions_cache, normalized)
+    if cached is not None:
+        return cached
+
+    # Resolve the user's own channel first (cached) so we can exclude it.
+    identity = await resolve_handle(handle)
+    own_channel_id = identity.get("channel_id")
+
+    deadline = time.monotonic() + SUGGESTIONS_BUDGET_SECONDS
+    by_channel: dict[str, dict[str, Any]] = {}
+
+    # 1. Legacy featured channels tab. Most channels no longer have one;
+    # yt-dlp errors with "does not have a channels tab" — skip and continue.
+    try:
+        data = await asyncio.to_thread(
+            _run_yt_dlp_json,
+            _channel_url(normalized, "/channels"),
+            [],
+            SUGGESTIONS_CALL_TIMEOUT_SECONDS,
+        )
+        for entry in data.get("entries") or []:
+            channel_id = entry.get("channel_id") or entry.get("id")
+            if not channel_id or channel_id == own_channel_id:
+                continue
+            by_channel[channel_id] = {
+                "youtube_channel_id": channel_id,
+                "name": (
+                    entry.get("channel")
+                    or entry.get("title")
+                    or entry.get("uploader")
+                    or channel_id
+                ),
+                "handle": _entry_handle(entry),
+                "avatar_url": None,
+                "source": "featured",
+                "score": FEATURED_SCORE,
+            }
+    except YoutubeResolveError as exc:
+        logger.info("No featured channels for %s: %s", normalized, exc)
+
+    # 2. Public playlists: count how often other channels appear.
+    playlist_urls: list[str] = []
+    if time.monotonic() < deadline:
+        try:
+            data = await asyncio.to_thread(
+                _run_yt_dlp_json,
+                _channel_url(normalized, "/playlists"),
+                [],
+                SUGGESTIONS_CALL_TIMEOUT_SECONDS,
+            )
+            for entry in (data.get("entries") or [])[:MAX_PLAYLISTS]:
+                url = entry.get("url")
+                if not url and entry.get("id"):
+                    url = f"https://www.youtube.com/playlist?list={entry['id']}"
+                if url:
+                    playlist_urls.append(url)
+        except YoutubeResolveError as exc:
+            logger.info("Could not list playlists for %s: %s", normalized, exc)
+
+    counts: dict[str, int] = {}
+    meta: dict[str, dict[str, Any]] = {}
+    for playlist_url in playlist_urls:
+        if time.monotonic() >= deadline:
+            logger.info("Suggestion budget exhausted for %s", normalized)
+            break
+        try:
+            data = await asyncio.to_thread(
+                _run_yt_dlp_json,
+                playlist_url,
+                ["--playlist-items", f"1-{MAX_PLAYLIST_ITEMS}"],
+                SUGGESTIONS_CALL_TIMEOUT_SECONDS,
+            )
+        except YoutubeResolveError as exc:
+            logger.info("Skipping playlist %s: %s", playlist_url, exc)
+            continue
+        for entry in data.get("entries") or []:
+            channel_id = entry.get("channel_id")
+            if not channel_id or channel_id == own_channel_id:
+                continue
+            counts[channel_id] = counts.get(channel_id, 0) + 1
+            if channel_id not in meta:
+                meta[channel_id] = {
+                    "name": entry.get("channel") or entry.get("uploader") or channel_id,
+                    "handle": _entry_handle(entry),
+                }
+
+    for channel_id, count in counts.items():
+        if channel_id in by_channel:
+            continue  # already suggested via featured (higher score)
+        by_channel[channel_id] = {
+            "youtube_channel_id": channel_id,
+            "name": meta[channel_id]["name"],
+            "handle": meta[channel_id]["handle"],
+            "avatar_url": None,
+            "source": "playlists",
+            "score": count,
+        }
+
+    suggestions = sorted(by_channel.values(), key=lambda s: -int(s["score"]))
+    suggestions = suggestions[:MAX_SUGGESTIONS]
+    _cache_set(_suggestions_cache, normalized, suggestions)
+    return suggestions

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -18,6 +18,10 @@ celery_app.conf.update(
     worker_concurrency=settings.download_concurrency,
     task_acks_late=True,
     worker_prefetch_multiplier=1,
+    # Long downloads (>1h) must not be redelivered to another worker while
+    # still running; with acks_late the Redis broker redelivers after the
+    # visibility timeout. 12 hours gives ample headroom.
+    broker_transport_options={"visibility_timeout": 43200},
 )
 
 # Periodic tasks

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -1,11 +1,12 @@
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime
 
 from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
+from app.database import register_sqlite_pragmas
 from app.tasks.celery_app import celery_app
 from app.models.channel import Channel
 from app.models.subscription import UserSubscription
@@ -15,7 +16,12 @@ from app.services.channel_poller import (
     poll_single_channel,
     refresh_stale_channel_metadata,
 )
-from app.services.download_manager import download_preview, download_video
+from app.services.download_manager import (
+    DownloadCancelled,
+    download_preview,
+    download_video,
+)
+from app.utils.time import utcnow_naive
 from app.services.progress_broadcaster import (
     publish_download_complete,
     publish_download_progress,
@@ -28,6 +34,7 @@ logger = logging.getLogger(__name__)
 _engine = create_engine(
     settings.sync_database_url, connect_args={"check_same_thread": False}
 )
+register_sqlite_pragmas(_engine)
 _SessionLocal = sessionmaker(bind=_engine)
 
 
@@ -114,7 +121,12 @@ def refresh_stale_channel_metadata_task(self) -> dict:
     retry_backoff=True,
     retry_backoff_max=600,
 )
-def download_video_task(self, video_id: str, user_id: str | None = None) -> dict:
+def download_video_task(
+    self,
+    video_id: str,
+    user_id: str | None = None,
+    quality: str | None = None,
+) -> dict:
     """Download a single video from YouTube."""
     db = _get_sync_db()
     try:
@@ -125,6 +137,10 @@ def download_video_task(self, video_id: str, user_id: str | None = None) -> dict
 
         if video.status == "COMPLETE":
             return {"status": "skipped", "reason": "already_complete"}
+
+        # Guard: another worker is already downloading this video
+        if video.status == "DOWNLOADING":
+            return {"status": "skipped", "reason": "already_downloading"}
 
         # Guard: skip CATALOGED videos (they must be explicitly triggered)
         if video.status == "CATALOGED":
@@ -155,12 +171,27 @@ def download_video_task(self, video_id: str, user_id: str | None = None) -> dict
             def progress_cb(percentage: float) -> None:
                 publish_download_progress(video_id, user_id, percentage)
 
+        def _is_cancelled() -> bool:
+            """True when the video is no longer DOWNLOADING (e.g. cancelled)."""
+            check_db = _get_sync_db()
+            try:
+                status = check_db.execute(
+                    select(Video.status).where(Video.id == video_id)
+                ).scalar_one_or_none()
+                return status != "DOWNLOADING"
+            except Exception:
+                logger.warning("Cancel check failed for video %s", video_id)
+                return False
+            finally:
+                check_db.close()
+
         # Perform the download
         result = download_video(
             youtube_video_id=video.youtube_video_id,
             channel_slug=channel.slug,
-            quality=settings.media_quality,
+            quality=quality or settings.media_quality,
             progress_callback=progress_cb,
+            cancel_check=_is_cancelled,
         )
 
         # Update video record with results
@@ -170,12 +201,11 @@ def download_video_task(self, video_id: str, user_id: str | None = None) -> dict
         video.duration_seconds = result["duration_seconds"]
         video.metadata_json = result.get("metadata_json")
         video.status = "COMPLETE"
+        video.downloaded_at = utcnow_naive()
 
         if result.get("uploaded_at"):
             try:
-                video.uploaded_at = datetime.strptime(
-                    result["uploaded_at"], "%Y%m%d"
-                ).replace(tzinfo=timezone.utc)
+                video.uploaded_at = datetime.strptime(result["uploaded_at"], "%Y%m%d")
             except (ValueError, TypeError):
                 pass
 
@@ -193,23 +223,35 @@ def download_video_task(self, video_id: str, user_id: str | None = None) -> dict
 
         db.commit()
 
-        # Notify all subscribers of this channel
-        subscriber_ids = (
-            db.execute(
-                select(UserSubscription.user_id).where(
-                    UserSubscription.channel_id == video.channel_id
+        # Notify all subscribers of this channel. Isolated from the retry
+        # path: a publish failure after commit must never re-download.
+        try:
+            subscriber_ids = (
+                db.execute(
+                    select(UserSubscription.user_id).where(
+                        UserSubscription.channel_id == video.channel_id
+                    )
                 )
+                .scalars()
+                .all()
             )
-            .scalars()
-            .all()
-        )
-        for sub_user_id in subscriber_ids:
-            publish_download_complete(
-                video_id, sub_user_id, channel_id=video.channel_id
+            for sub_user_id in subscriber_ids:
+                publish_download_complete(
+                    video_id, sub_user_id, channel_id=video.channel_id
+                )
+        except Exception:
+            logger.exception(
+                "Failed to publish download_complete for video %s", video_id
             )
 
         logger.info("Download complete: %s (%s)", video.youtube_video_id, video.title)
         return {"status": "complete", "video_id": video_id}
+
+    except DownloadCancelled:
+        # Cancel endpoint already reset the status (e.g. to CATALOGED);
+        # partial files were cleaned up by the download loop. No retry.
+        logger.info("Download cancelled for video %s", video_id)
+        return {"status": "cancelled", "video_id": video_id}
 
     except Exception as exc:
         logger.exception("Download failed for video %s", video_id)

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -142,6 +142,13 @@ def download_video_task(
         if video.status == "DOWNLOADING":
             return {"status": "skipped", "reason": "already_downloading"}
 
+        # Guard: a cancel is still being confirmed; finish the hand-off here
+        # (the worker that owned the download has already exited).
+        if video.status == "CANCELLING":
+            video.status = "CATALOGED"
+            db.commit()
+            return {"status": "skipped", "reason": "cancelled"}
+
         # Guard: skip CATALOGED videos (they must be explicitly triggered)
         if video.status == "CATALOGED":
             return {"status": "skipped", "reason": "cataloged"}
@@ -237,7 +244,11 @@ def download_video_task(
             )
             for sub_user_id in subscriber_ids:
                 publish_download_complete(
-                    video_id, sub_user_id, channel_id=video.channel_id
+                    video_id,
+                    sub_user_id,
+                    channel_id=video.channel_id,
+                    title=video.title,
+                    youtube_video_id=video.youtube_video_id,
                 )
         except Exception:
             logger.exception(
@@ -248,21 +259,38 @@ def download_video_task(
         return {"status": "complete", "video_id": video_id}
 
     except DownloadCancelled:
-        # Cancel endpoint already reset the status (e.g. to CATALOGED);
-        # partial files were cleaned up by the download loop. No retry.
+        # Partial files were cleaned up by the download loop. Confirm the
+        # cancel hand-off: CANCELLING -> CATALOGED re-enables re-downloads.
         logger.info("Download cancelled for video %s", video_id)
+        try:
+            db.rollback()
+            video = db.get(Video, video_id)
+            if video and video.status == "CANCELLING":
+                video.status = "CATALOGED"
+                db.commit()
+        except Exception:
+            logger.exception("Could not confirm cancel for video %s", video_id)
         return {"status": "cancelled", "video_id": video_id}
 
     except Exception as exc:
         logger.exception("Download failed for video %s", video_id)
-        # Mark as FAILED if we've exhausted retries
+        # A retry must pass the already-downloading guard above, so reset the
+        # status to PENDING when another attempt is coming; otherwise this is
+        # terminal (retries exhausted, or an exception type we never retry)
+        # and the video is marked FAILED.
+        will_retry = (
+            isinstance(exc, RuntimeError) and self.request.retries < self.max_retries
+        )
         try:
+            db.rollback()
             video = db.get(Video, video_id)
-            if video and self.request.retries >= self.max_retries:
-                video.status = "FAILED"
+            if video and video.status == "DOWNLOADING":
+                video.status = "PENDING" if will_retry else "FAILED"
                 db.commit()
         except Exception:
-            pass
+            logger.exception(
+                "Could not update status after failed download of %s", video_id
+            )
         raise exc
     finally:
         db.close()

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -1,0 +1,13 @@
+"""Time helpers shared across the app."""
+
+from datetime import datetime, timezone
+
+
+def utcnow_naive() -> datetime:
+    """Return the current UTC time as a naive datetime.
+
+    SQLite stores datetimes without timezone info, so the codebase
+    standardizes on naive UTC datetimes to avoid ever comparing
+    timezone-aware and naive values.
+    """
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ yt-dlp==2026.2.21
 anthropic==0.43.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
-python-multipart==0.0.22
+python-multipart==0.0.27
 websockets==14.1
 httpx==0.28.1
 passlib==1.7.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+# ruff: noqa: E402
+"""Shared fixtures for the backend test suite.
+
+Path and database environment variables are set BEFORE any app import so
+that ``app.config.Settings`` picks up temp paths — the real defaults point
+at /data, which only exists inside the Docker container.
+"""
+
+import os
+import tempfile
+
+_TMP_ROOT = tempfile.mkdtemp(prefix="nullfeed-tests-")
+
+os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{os.path.join(_TMP_ROOT, 'test.db')}"
+os.environ["MEDIA_PATH"] = os.path.join(_TMP_ROOT, "media")
+os.environ["DB_PATH"] = os.path.join(_TMP_ROOT, "db")
+os.environ["CONFIG_PATH"] = os.path.join(_TMP_ROOT, "config")
+os.environ["THUMBNAILS_PATH"] = os.path.join(_TMP_ROOT, "thumbnails")
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+import app.api.auth as auth_api
+import app.api.websocket as websocket_api
+import app.services.youtube_import as youtube_import
+from app.database import engine
+from app.main import app
+from app.models import Base
+
+
+@pytest.fixture(autouse=True)
+def _reset_in_memory_state():
+    """Clear per-process caches/counters that would leak between tests."""
+    yield
+    auth_api._pin_failures.clear()
+    auth_api._pin_lockouts.clear()
+    youtube_import._resolve_cache.clear()
+    youtube_import._suggestions_cache.clear()
+    websocket_api._connections.clear()
+
+
+@pytest_asyncio.fixture
+async def _database():
+    """Fresh tables for the test; dispose pooled connections afterwards.
+
+    Disposing matters: each test runs in its own event loop, and aiosqlite
+    connections are bound to the loop that created them.
+    """
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+        await conn.run_sync(Base.metadata.create_all)
+    yield
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(_database):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture
+async def make_user(client):
+    """Factory: create a profile, select it, return (profile, auth headers)."""
+
+    async def _make(
+        display_name: str = "User", pin: str | None = None
+    ) -> tuple[dict, dict]:
+        payload: dict = {"display_name": display_name}
+        if pin is not None:
+            payload["pin"] = pin
+        resp = await client.post("/api/auth/create", json=payload)
+        assert resp.status_code == 200, resp.text
+        profile = resp.json()
+
+        select_payload: dict = {"user_id": profile["id"]}
+        if pin is not None:
+            select_payload["pin"] = pin
+        resp = await client.post("/api/auth/select", json=select_payload)
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        return data["user"], {"X-User-Token": data["token"]}
+
+    return _make

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,110 @@
+"""Seeding and mocking helpers shared across test modules."""
+
+import json
+import subprocess
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+
+# A canonical yt-dlp channel-resolve JSON document (flat-playlist, items 0).
+IDENTITY_JSON: dict[str, Any] = {
+    "channel_id": "UCabc123",
+    "channel": "Test Channel",
+    "uploader_id": "@testchannel",
+    "description": "A test channel",
+    "channel_follower_count": 12345,
+    "thumbnails": [
+        {"id": "avatar_uncropped", "url": "https://img/avatar.jpg"},
+        {"id": "banner_uncropped", "url": "https://img/banner.jpg"},
+        {"url": "https://img/big-square.jpg", "width": 800, "height": 800},
+    ],
+}
+
+
+def fake_completed_process(
+    stdout: dict | list | str,
+    returncode: int = 0,
+    stderr: str = "",
+) -> subprocess.CompletedProcess:
+    """Build a CompletedProcess like a mocked yt-dlp invocation would return."""
+    if not isinstance(stdout, str):
+        stdout = json.dumps(stdout)
+    return subprocess.CompletedProcess(
+        args=["yt-dlp"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+async def seed_channel(
+    db: AsyncSession,
+    *,
+    name: str = "Test Channel",
+    youtube_channel_id: str | None = None,
+    slug: str | None = None,
+) -> Channel:
+    suffix = uuid.uuid4().hex[:8]
+    channel = Channel(
+        id=str(uuid.uuid4()),
+        youtube_channel_id=youtube_channel_id or f"UCtest{suffix}",
+        name=name,
+        slug=slug or f"test-channel-{suffix}",
+        description="",
+    )
+    db.add(channel)
+    await db.commit()
+    await db.refresh(channel)
+    return channel
+
+
+async def seed_video(
+    db: AsyncSession,
+    channel: Channel,
+    *,
+    title: str = "Test Video",
+    status: str = "CATALOGED",
+    file_path: str | None = None,
+    downloaded_at: datetime | None = None,
+    uploaded_at: datetime | None = None,
+    preview_file_path: str | None = None,
+    preview_status: str | None = None,
+) -> Video:
+    video = Video(
+        id=str(uuid.uuid4()),
+        youtube_video_id=f"yt{uuid.uuid4().hex[:9]}",
+        channel_id=channel.id,
+        title=title,
+        status=status,
+        file_path=file_path,
+        downloaded_at=downloaded_at,
+        uploaded_at=uploaded_at,
+        preview_file_path=preview_file_path,
+        preview_status=preview_status,
+    )
+    db.add(video)
+    await db.commit()
+    await db.refresh(video)
+    return video
+
+
+async def seed_ref(
+    db: AsyncSession, user_id: str, video_id: str, **kwargs: Any
+) -> UserVideoRef:
+    ref = UserVideoRef(user_id=user_id, video_id=video_id, **kwargs)
+    db.add(ref)
+    await db.commit()
+    return ref
+
+
+async def seed_subscription(
+    db: AsyncSession, user_id: str, channel_id: str, **kwargs: Any
+) -> UserSubscription:
+    sub = UserSubscription(user_id=user_id, channel_id=channel_id, **kwargs)
+    db.add(sub)
+    await db.commit()
+    return sub

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,321 @@
+"""Auth and profile endpoint tests (design section 1.1)."""
+
+import hashlib
+import os
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+import app.services.youtube_import as youtube_import
+from app.config import settings
+from app.database import async_session_factory, engine
+from app.main import app
+from app.models.subscription import UserSubscription
+from app.models.user import User
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from tests.helpers import (
+    IDENTITY_JSON,
+    fake_completed_process,
+    seed_channel,
+    seed_ref,
+    seed_subscription,
+    seed_video,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_first_user_is_admin_and_body_is_admin_ignored(client):
+    resp = await client.post(
+        "/api/auth/create", json={"display_name": "Alice", "is_admin": False}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["is_admin"] is True
+
+    resp = await client.post(
+        "/api/auth/create", json={"display_name": "Bob", "is_admin": True}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["is_admin"] is False
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"display_name": ""},
+        {"display_name": "   "},
+        {"display_name": "x" * 51},
+        {},  # neither display_name nor youtube_handle
+        {"display_name": "Ok", "pin": "12"},
+        {"display_name": "Ok", "pin": "abcd"},
+        {"display_name": "Ok", "pin": "123456789"},
+    ],
+)
+async def test_create_validation_422(client, payload):
+    resp = await client.post("/api/auth/create", json=payload)
+    assert resp.status_code == 422
+
+
+async def test_create_trims_display_name(client):
+    resp = await client.post("/api/auth/create", json={"display_name": "  Bo  "})
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Bo"
+
+
+async def test_select_pin_flow(client):
+    resp = await client.post(
+        "/api/auth/create", json={"display_name": "Pinned", "pin": "1234"}
+    )
+    assert resp.status_code == 200
+    profile = resp.json()
+    assert profile["has_pin"] is True
+
+    resp = await client.post("/api/auth/select", json={"user_id": profile["id"]})
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "PIN required"
+
+    resp = await client.post(
+        "/api/auth/select", json={"user_id": profile["id"], "pin": "9999"}
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Incorrect PIN"
+
+    resp = await client.post(
+        "/api/auth/select", json={"user_id": profile["id"], "pin": "1234"}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["token"]
+    assert data["user"]["id"] == profile["id"]
+    assert data["user"]["has_pin"] is True
+
+
+async def test_legacy_sha256_pin_verifies_and_upgrades(client):
+    user_id = str(uuid.uuid4())
+    async with async_session_factory() as db:
+        db.add(
+            User(
+                id=user_id,
+                display_name="Legacy",
+                pin_hash=hashlib.sha256(b"4321").hexdigest(),
+            )
+        )
+        await db.commit()
+
+    resp = await client.post(
+        "/api/auth/select", json={"user_id": user_id, "pin": "4321"}
+    )
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        user = (await db.execute(select(User).where(User.id == user_id))).scalar_one()
+        assert user.pin_hash is not None
+        assert user.pin_hash.startswith("scrypt$")
+
+    # The upgraded scrypt hash still verifies.
+    resp = await client.post(
+        "/api/auth/select", json={"user_id": user_id, "pin": "4321"}
+    )
+    assert resp.status_code == 200
+
+
+async def test_pin_rate_limit_429_after_five_failures(client):
+    resp = await client.post(
+        "/api/auth/create", json={"display_name": "Locked", "pin": "1234"}
+    )
+    user_id = resp.json()["id"]
+
+    for _ in range(5):
+        resp = await client.post(
+            "/api/auth/select", json={"user_id": user_id, "pin": "0000"}
+        )
+        assert resp.status_code == 403
+
+    # Even the correct PIN is rejected during the lockout window.
+    resp = await client.post(
+        "/api/auth/select", json={"user_id": user_id, "pin": "1234"}
+    )
+    assert resp.status_code == 429
+
+
+async def test_me_and_logout(client, make_user):
+    profile, headers = await make_user("Me")
+
+    resp = await client.get("/api/auth/me", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["id"] == profile["id"]
+
+    resp = await client.post("/api/auth/logout", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"detail": "Logged out"}
+
+    resp = await client.get("/api/auth/me", headers=headers)
+    assert resp.status_code == 401
+
+
+async def test_session_persists_across_app_instances(client, make_user):
+    _, headers = await make_user("Persistent")
+
+    # Drop all pooled DB connections, then use a brand-new transport: the
+    # session must come back from the database, not process/connection state.
+    await engine.dispose()
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as fresh:
+        resp = await fresh.get("/api/auth/me", headers=headers)
+        assert resp.status_code == 200
+
+
+async def test_update_profile_self_and_admin_rules(client, make_user):
+    admin, admin_headers = await make_user("Admin")
+    other, other_headers = await make_user("Other")
+
+    # Non-admins cannot modify someone else's profile.
+    resp = await client.patch(
+        f"/api/auth/profiles/{admin['id']}",
+        json={"display_name": "Hax"},
+        headers=other_headers,
+    )
+    assert resp.status_code == 403
+
+    # Self-rename works.
+    resp = await client.patch(
+        f"/api/auth/profiles/{other['id']}",
+        json={"display_name": "Renamed"},
+        headers=other_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Renamed"
+
+    # Admins can modify others: set then remove a PIN.
+    resp = await client.patch(
+        f"/api/auth/profiles/{other['id']}",
+        json={"pin": "5678"},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["has_pin"] is True
+
+    resp = await client.patch(
+        f"/api/auth/profiles/{other['id']}",
+        json={"remove_pin": True},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["has_pin"] is False
+
+
+async def test_delete_only_admin_409(client, make_user):
+    admin, admin_headers = await make_user("Admin")
+    await make_user("Other")
+
+    resp = await client.delete(
+        f"/api/auth/profiles/{admin['id']}", headers=admin_headers
+    )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Cannot delete the only admin profile"
+
+
+async def test_delete_other_requires_admin(client, make_user):
+    admin, _ = await make_user("Admin")
+    _, other_headers = await make_user("Other")
+
+    resp = await client.delete(
+        f"/api/auth/profiles/{admin['id']}", headers=other_headers
+    )
+    assert resp.status_code == 403
+
+
+async def test_delete_profile_cascades_and_cleans_orphans(client, make_user):
+    await make_user("Admin")  # the first user keeps an admin around
+    victim, victim_headers = await make_user("Victim")
+
+    rel_path = "chan/video.mp4"
+    full_path = os.path.join(settings.media_path, rel_path)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "wb") as f:
+        f.write(b"x" * 10)
+
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE", file_path=rel_path)
+        await seed_ref(db, victim["id"], video.id)
+        await seed_subscription(db, victim["id"], channel.id)
+
+    resp = await client.delete(
+        f"/api/auth/profiles/{victim['id']}", headers=victim_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"detail": "Profile deleted"}
+
+    # The session was cascade-deleted.
+    resp = await client.get("/api/auth/me", headers=victim_headers)
+    assert resp.status_code == 401
+
+    # Refs and subscriptions are gone; the orphaned file was removed and the
+    # video row reset to a re-downloadable state.
+    assert not os.path.exists(full_path)
+    async with async_session_factory() as db:
+        refs = (
+            (
+                await db.execute(
+                    select(UserVideoRef).where(UserVideoRef.user_id == victim["id"])
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert refs == []
+        subs = (
+            (
+                await db.execute(
+                    select(UserSubscription).where(
+                        UserSubscription.user_id == victim["id"]
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert subs == []
+        v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()
+        assert v.status == "CATALOGED"
+        assert v.file_path is None
+
+
+async def test_create_from_youtube_handle(client, monkeypatch):
+    monkeypatch.setattr(
+        youtube_import.subprocess,
+        "run",
+        lambda *a, **kw: fake_completed_process(IDENTITY_JSON),
+    )
+
+    async def fake_cache_avatar(url: str, user_id: str) -> None:
+        # Simulate avatar download failure: profile must still be created.
+        return None
+
+    monkeypatch.setattr("app.api.auth.cache_avatar", fake_cache_avatar)
+
+    resp = await client.post(
+        "/api/auth/create", json={"youtube_handle": "@testchannel"}
+    )
+    assert resp.status_code == 200
+    profile = resp.json()
+    assert profile["display_name"] == "Test Channel"
+    assert profile["avatar_url"] is None
+
+
+async def test_create_from_youtube_handle_resolve_failure_502(client, monkeypatch):
+    monkeypatch.setattr(
+        youtube_import.subprocess,
+        "run",
+        lambda *a, **kw: fake_completed_process(
+            "", returncode=1, stderr="ERROR: Unable to download webpage"
+        ),
+    )
+    resp = await client.post("/api/auth/create", json={"youtube_handle": "@nope"})
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "Could not resolve YouTube handle"

--- a/tests/test_channels.py
+++ b/tests/test_channels.py
@@ -1,0 +1,253 @@
+"""Channel subscribe + bulk subscribe tests (design 1.3 and 1.4)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.database import async_session_factory
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.models.user_video_ref import UserVideoRef
+from app.utils.time import utcnow_naive
+from tests.helpers import seed_channel, seed_ref, seed_subscription, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def poll_delay(monkeypatch):
+    """Stub out Celery enqueueing so tests never touch the Redis broker."""
+    mock = MagicMock()
+    monkeypatch.setattr("app.api.channels.poll_channel_task.delay", mock)
+    return mock
+
+
+async def test_bulk_subscribe_creates_channel_without_resolution(
+    client, make_user, poll_delay, monkeypatch
+):
+    def boom(youtube_channel_id):
+        raise AssertionError(
+            "fetch_channel_metadata must not be called when a name is provided"
+        )
+
+    monkeypatch.setattr("app.api.channels.fetch_channel_metadata", boom)
+
+    _, headers = await make_user()
+    resp = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={"items": [{"youtube_channel_id": "UCnew1", "name": "Cool Channel"}]},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert results[0]["status"] == "subscribed"
+    channel_id = results[0]["channel_id"]
+
+    async with async_session_factory() as db:
+        channel = (
+            await db.execute(select(Channel).where(Channel.id == channel_id))
+        ).scalar_one()
+        assert channel.name == "Cool Channel"
+        assert channel.slug == "cool-channel"
+        assert channel.description == ""
+        assert channel.avatar_url is None
+        sub = (
+            await db.execute(
+                select(UserSubscription).where(
+                    UserSubscription.channel_id == channel_id
+                )
+            )
+        ).scalar_one()
+        assert sub.retention_policy == "KEEP_ALL"
+        assert sub.tracking_mode == "FUTURE_ONLY"
+
+    poll_delay.assert_called_once_with(channel_id)
+
+
+async def test_bulk_subscribe_dedupes_slugs(client, make_user, poll_delay):
+    _, headers = await make_user()
+    resp = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={
+            "items": [
+                {"youtube_channel_id": "UCa", "name": "Same Name"},
+                {"youtube_channel_id": "UCb", "name": "Same Name"},
+            ]
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert [r["status"] for r in resp.json()["results"]] == [
+        "subscribed",
+        "subscribed",
+    ]
+
+    async with async_session_factory() as db:
+        slugs = sorted((await db.execute(select(Channel.slug))).scalars().all())
+        assert slugs == ["same-name", "same-name-2"]
+
+
+async def test_bulk_subscribe_existing_channel_reactivates_refs(
+    client, make_user, poll_delay
+):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, youtube_channel_id="UCexisting")
+        video = await seed_video(db, channel)
+        await seed_ref(db, user["id"], video.id, removed_at=utcnow_naive())
+
+    resp = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={"items": [{"youtube_channel_id": "UCexisting"}]},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert results[0]["status"] == "subscribed"
+    assert results[0]["channel_id"] == channel.id
+
+    async with async_session_factory() as db:
+        ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user["id"],
+                    UserVideoRef.video_id == video.id,
+                )
+            )
+        ).scalar_one()
+        assert ref.removed_at is None
+
+    # No new channel was created, so no poll was enqueued.
+    poll_delay.assert_not_called()
+
+
+async def test_bulk_subscribe_already_subscribed(client, make_user, poll_delay):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, youtube_channel_id="UCdup")
+        await seed_subscription(db, user["id"], channel.id)
+
+    resp = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={"items": [{"youtube_channel_id": "UCdup"}]},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert results[0]["status"] == "already_subscribed"
+    assert results[0]["channel_id"] == channel.id
+
+
+async def test_bulk_subscribe_per_item_errors_isolated(
+    client, make_user, poll_delay, monkeypatch
+):
+    def echo_back(youtube_channel_id):
+        # fetch_channel_metadata echoes its input back on resolution failure.
+        return {"name": youtube_channel_id, "channel_id": youtube_channel_id}
+
+    monkeypatch.setattr("app.api.channels.fetch_channel_metadata", echo_back)
+
+    _, headers = await make_user()
+    resp = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={
+            "items": [
+                {"youtube_channel_id": "UCbroken"},
+                {"youtube_channel_id": "UCfine", "name": "Fine"},
+            ]
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    results = resp.json()["results"]
+    assert results[0]["status"] == "error"
+    assert results[1]["status"] == "subscribed"
+    assert results[1]["channel_id"] is not None
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [],
+        [{"youtube_channel_id": f"UC{i}"} for i in range(26)],
+    ],
+)
+async def test_bulk_subscribe_item_count_validation(client, make_user, items):
+    _, headers = await make_user()
+    resp = await client.post(
+        "/api/channels/subscribe-bulk", json={"items": items}, headers=headers
+    )
+    assert resp.status_code == 422
+
+
+async def test_subscribe_reactivates_soft_deleted_refs(
+    client, make_user, poll_delay, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.channels.fetch_channel_metadata",
+        lambda cid: {"channel_id": "UCsub", "name": "Sub Channel", "handle": "@sub"},
+    )
+    monkeypatch.setattr(
+        "app.api.channels.fetch_channel_images",
+        lambda cid: {"avatar_url": None, "banner_url": None},
+    )
+
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, youtube_channel_id="UCsub")
+        v1 = await seed_video(db, channel)
+        v2 = await seed_video(db, channel)
+        await seed_ref(db, user["id"], v1.id, removed_at=utcnow_naive())
+
+    resp = await client.post(
+        "/api/channels/subscribe",
+        json={"youtube_channel_id": "UCsub"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        refs = (
+            (
+                await db.execute(
+                    select(UserVideoRef).where(UserVideoRef.user_id == user["id"])
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert {r.video_id for r in refs} == {v1.id, v2.id}
+        assert all(r.removed_at is None for r in refs)
+
+
+async def test_subscribe_dedupes_slug_against_existing(
+    client, make_user, poll_delay, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.channels.fetch_channel_metadata",
+        lambda cid: {"channel_id": "UCnewslug", "name": "Test Channel"},
+    )
+    monkeypatch.setattr(
+        "app.api.channels.fetch_channel_images",
+        lambda cid: {"avatar_url": None, "banner_url": None},
+    )
+
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        await seed_channel(db, youtube_channel_id="UCother", slug="test-channel")
+
+    resp = await client.post(
+        "/api/channels/subscribe",
+        json={"youtube_channel_id": "UCnewslug"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        channel = (
+            await db.execute(
+                select(Channel).where(Channel.youtube_channel_id == "UCnewslug")
+            )
+        ).scalar_one()
+        assert channel.slug == "test-channel-2"

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -1,0 +1,63 @@
+"""Feed ordering tests (design 1.4)."""
+
+from datetime import timedelta
+
+import pytest
+
+from app.database import async_session_factory
+from app.utils.time import utcnow_naive
+from tests.helpers import seed_channel, seed_ref, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_continue_watching_ordered_by_last_watched(client, make_user):
+    user, headers = await make_user()
+    now = utcnow_naive()
+    async with async_session_factory() as db:
+        channel_a = await seed_channel(db, name="Channel A")
+        channel_b = await seed_channel(db, name="Channel B")
+        video_a = await seed_video(db, channel_a, status="COMPLETE")
+        video_b = await seed_video(db, channel_b, status="COMPLETE")
+        await seed_ref(
+            db,
+            user["id"],
+            video_a.id,
+            watch_position_seconds=30,
+            last_watched_at=now - timedelta(hours=2),
+        )
+        await seed_ref(
+            db,
+            user["id"],
+            video_b.id,
+            watch_position_seconds=10,
+            last_watched_at=now - timedelta(minutes=5),
+        )
+
+    resp = await client.get("/api/feed/continue-watching", headers=headers)
+    assert resp.status_code == 200
+    items = resp.json()
+    assert [item["video"]["id"] for item in items] == [video_b.id, video_a.id]
+
+
+async def test_recently_added_ordered_by_downloaded_at(client, make_user):
+    user, headers = await make_user()
+    now = utcnow_naive()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        old = await seed_video(
+            db,
+            channel,
+            status="COMPLETE",
+            downloaded_at=now - timedelta(days=1),
+        )
+        new = await seed_video(db, channel, status="COMPLETE", downloaded_at=now)
+        # Legacy row without downloaded_at sorts last (NULLS LAST).
+        legacy = await seed_video(db, channel, status="COMPLETE")
+        for video in (old, new, legacy):
+            await seed_ref(db, user["id"], video.id)
+
+    resp = await client.get("/api/feed/recently-added", headers=headers)
+    assert resp.status_code == 200
+    items = resp.json()
+    assert [item["video"]["id"] for item in items] == [new.id, old.id, legacy.id]

--- a/tests/test_media_server.py
+++ b/tests/test_media_server.py
@@ -1,0 +1,137 @@
+"""Media server range-request tests (design 1.4, RFC 7233)."""
+
+import os
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request, Response
+from httpx import ASGITransport, AsyncClient
+
+from app.config import settings
+from app.database import async_session_factory
+from app.services.media_server import build_media_response
+from tests.helpers import seed_channel, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+CONTENT = b"0123456789" * 10  # 100 bytes
+
+
+@pytest.fixture
+def media_file(tmp_path):
+    path = tmp_path / "clip.mp4"
+    path.write_bytes(CONTENT)
+    return str(path)
+
+
+@pytest_asyncio.fixture
+async def media_client(media_file):
+    """A minimal app exercising build_media_response in isolation."""
+    test_app = FastAPI()
+
+    @test_app.get("/file")
+    async def serve(request: Request) -> Response:
+        return build_media_response(media_file, request.headers.get("range"))
+
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def test_full_file_200(media_client):
+    resp = await media_client.get("/file")
+    assert resp.status_code == 200
+    assert resp.content == CONTENT
+    assert resp.headers["content-length"] == str(len(CONTENT))
+    assert resp.headers["accept-ranges"] == "bytes"
+    assert resp.headers["etag"]
+    assert resp.headers["last-modified"]
+
+
+async def test_open_ended_range(media_client):
+    resp = await media_client.get("/file", headers={"Range": "bytes=0-"})
+    assert resp.status_code == 206
+    assert resp.content == CONTENT
+    assert resp.headers["content-range"] == "bytes 0-99/100"
+    assert resp.headers["etag"]
+    assert resp.headers["last-modified"]
+
+
+async def test_bounded_range(media_client):
+    resp = await media_client.get("/file", headers={"Range": "bytes=10-19"})
+    assert resp.status_code == 206
+    assert resp.content == CONTENT[10:20]
+    assert resp.headers["content-range"] == "bytes 10-19/100"
+    assert resp.headers["content-length"] == "10"
+
+
+async def test_suffix_range_returns_last_bytes(media_client):
+    resp = await media_client.get("/file", headers={"Range": "bytes=-10"})
+    assert resp.status_code == 206
+    assert resp.content == CONTENT[-10:]
+    assert resp.headers["content-range"] == "bytes 90-99/100"
+
+
+async def test_range_end_clamped_to_file_size(media_client):
+    resp = await media_client.get("/file", headers={"Range": "bytes=90-200"})
+    assert resp.status_code == 206
+    assert resp.content == CONTENT[90:]
+    assert resp.headers["content-range"] == "bytes 90-99/100"
+
+
+async def test_multi_range_serves_first_range_only(media_client):
+    resp = await media_client.get("/file", headers={"Range": "bytes=0-9,20-29"})
+    assert resp.status_code == 206
+    assert resp.content == CONTENT[0:10]
+    assert resp.headers["content-range"] == "bytes 0-9/100"
+
+
+@pytest.mark.parametrize(
+    "range_header",
+    [
+        "bytes=100-",  # start >= size
+        "bytes=abc-",  # non-numeric
+        "items=0-10",  # wrong unit
+        "bytes=5-2",  # start > end
+        "bytes=-0",  # zero-length suffix
+        "bytes=",  # empty spec
+    ],
+)
+async def test_unsatisfiable_or_malformed_range_416(media_client, range_header):
+    resp = await media_client.get("/file", headers={"Range": range_header})
+    assert resp.status_code == 416
+    assert resp.headers["content-range"] == "bytes */100"
+
+
+async def test_stream_endpoint_auth_and_ranges(client, make_user):
+    _, headers = await make_user()
+    token = headers["X-User-Token"]
+
+    rel_path = "chan/streamed.mp4"
+    full_path = os.path.join(settings.media_path, rel_path)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "wb") as f:
+        f.write(CONTENT)
+
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE", file_path=rel_path)
+
+    # Missing/garbage tokens are rejected.
+    resp = await client.get(f"/api/videos/{video.id}/stream")
+    assert resp.status_code == 401
+    resp = await client.get(f"/api/videos/{video.id}/stream?token=garbage")
+    assert resp.status_code == 401
+
+    # Token via query param (used by video elements/players).
+    resp = await client.get(f"/api/videos/{video.id}/stream?token={token}")
+    assert resp.status_code == 200
+    assert resp.content == CONTENT
+
+    resp = await client.get(
+        f"/api/videos/{video.id}/stream?token={token}",
+        headers={"Range": "bytes=10-19"},
+    )
+    assert resp.status_code == 206
+    assert resp.content == CONTENT[10:20]
+    assert resp.headers["content-range"] == "bytes 10-19/100"

--- a/tests/test_orphan_cleanup.py
+++ b/tests/test_orphan_cleanup.py
@@ -1,0 +1,96 @@
+"""Orphan cleanup tests: removing the last ref resets the video row (design 1.4)."""
+
+import os
+
+import pytest
+from sqlalchemy import select
+
+from app.config import settings
+from app.database import async_session_factory
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from tests.helpers import seed_channel, seed_ref, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+def _write_file(path: str, data: bytes = b"data") -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(data)
+
+
+async def test_remove_last_ref_deletes_files_and_resets_video(client, make_user):
+    user, headers = await make_user()
+
+    rel_path = "chan/orphan.mp4"
+    preview_rel_path = "chan/orphan.preview.mp4"
+    full_path = os.path.join(settings.media_path, rel_path)
+    preview_full_path = os.path.join(settings.media_path, preview_rel_path)
+    _write_file(full_path)
+    _write_file(preview_full_path)
+
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(
+            db,
+            channel,
+            status="COMPLETE",
+            file_path=rel_path,
+            preview_file_path=preview_rel_path,
+            preview_status="READY",
+        )
+        await seed_ref(db, user["id"], video.id)
+
+    thumb_path = os.path.join(settings.thumbnails_path, f"{video.youtube_video_id}.jpg")
+    _write_file(thumb_path)
+
+    resp = await client.delete(f"/api/videos/{video.id}", headers=headers)
+    assert resp.status_code == 200
+
+    assert not os.path.exists(full_path)
+    assert not os.path.exists(preview_full_path)
+    assert not os.path.exists(thumb_path)
+
+    async with async_session_factory() as db:
+        v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()
+        assert v.status == "CATALOGED"
+        assert v.file_path is None
+        assert v.file_size_bytes is None
+        assert v.preview_file_path is None
+        assert v.preview_status is None
+
+
+async def test_orphan_cleanup_skipped_while_other_refs_active(client, make_user):
+    user_a, headers_a = await make_user("A")
+    user_b, _ = await make_user("B")
+
+    rel_path = "chan/shared.mp4"
+    full_path = os.path.join(settings.media_path, rel_path)
+    _write_file(full_path)
+
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE", file_path=rel_path)
+        await seed_ref(db, user_a["id"], video.id)
+        await seed_ref(db, user_b["id"], video.id)
+
+    resp = await client.delete(f"/api/videos/{video.id}", headers=headers_a)
+    assert resp.status_code == 200
+
+    # The other user still references the video: the file must survive.
+    assert os.path.exists(full_path)
+    async with async_session_factory() as db:
+        v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()
+        assert v.status == "COMPLETE"
+        assert v.file_path == rel_path
+
+        ref_a = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user_a["id"],
+                    UserVideoRef.video_id == video.id,
+                )
+            )
+        ).scalar_one()
+        assert ref_a.removed_at is not None

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -1,0 +1,203 @@
+"""Regression tests for the adversarial-review fixes on this branch."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.api.channels import _extract_channel_id
+from app.database import async_session_factory
+from app.models.user_video_ref import UserVideoRef
+from app.services.media_server import _parse_range
+from tests.helpers import seed_channel, seed_ref, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def download_delay(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("app.api.videos.download_video_task.delay", mock)
+    return mock
+
+
+# --- cancel state machine -------------------------------------------------
+
+
+async def test_cancel_inflight_download_moves_to_cancelling(client, make_user):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="DOWNLOADING")
+
+    resp = await client.post(f"/api/videos/{video.id}/cancel", headers=headers)
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        from app.models.video import Video
+
+        status = (
+            await db.execute(select(Video.status).where(Video.id == video.id))
+        ).scalar_one()
+    assert status == "CANCELLING"
+
+
+async def test_cancel_pending_download_goes_straight_to_cataloged(client, make_user):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="PENDING")
+
+    await client.post(f"/api/videos/{video.id}/cancel", headers=headers)
+
+    async with async_session_factory() as db:
+        from app.models.video import Video
+
+        status = (
+            await db.execute(select(Video.status).where(Video.id == video.id))
+        ).scalar_one()
+    assert status == "CATALOGED"
+
+
+async def test_redownload_blocked_while_cancelling_and_second_cancel_clears(
+    client, make_user, download_delay
+):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CANCELLING")
+
+    resp = await client.post(f"/api/videos/{video.id}/download", headers=headers)
+    assert resp.status_code == 409
+    download_delay.assert_not_called()
+
+    # Second cancel is the force-clear escape hatch.
+    resp = await client.post(f"/api/videos/{video.id}/cancel", headers=headers)
+    assert resp.status_code == 200
+    resp = await client.post(f"/api/videos/{video.id}/download", headers=headers)
+    assert resp.status_code == 200
+    download_delay.assert_called_once()
+
+
+# --- is_watched derivation -------------------------------------------------
+
+
+async def test_progress_near_end_marks_watched(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE")
+        video.duration_seconds = 600
+        await db.commit()
+
+    resp = await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": 590},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user["id"],
+                    UserVideoRef.video_id == video.id,
+                )
+            )
+        ).scalar_one()
+        assert ref.is_watched is True
+
+    # Restarting the video makes it in-progress again.
+    await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": 30},
+        headers=headers,
+    )
+    async with async_session_factory() as db:
+        ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user["id"],
+                    UserVideoRef.video_id == video.id,
+                )
+            )
+        ).scalar_one()
+        assert ref.is_watched is False
+
+
+async def test_progress_mid_video_not_watched(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE")
+        video.duration_seconds = 600
+        await db.commit()
+
+    await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": 300},
+        headers=headers,
+    )
+    async with async_session_factory() as db:
+        ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user["id"],
+                    UserVideoRef.video_id == video.id,
+                )
+            )
+        ).scalar_one()
+        assert ref.is_watched is False
+
+
+# --- channel videos expose last_watched_at ----------------------------------
+
+
+async def test_channel_videos_include_last_watched_at(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE")
+        await seed_ref(db, user["id"], video.id)
+
+    await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": 42},
+        headers=headers,
+    )
+    resp = await client.get(f"/api/channels/{channel.id}/videos", headers=headers)
+    items = resp.json()["items"]
+    assert items[0]["last_watched_at"] is not None
+
+
+# --- range parsing hardening -------------------------------------------------
+
+
+def test_parse_range_rejects_non_ascii_digits():
+    # latin-1 superscript two passes str.isdigit() but crashes int().
+    assert _parse_range("bytes=\xb2-", 1000) is None
+    assert _parse_range("bytes=0-\xb3", 1000) is None
+    assert _parse_range("bytes=-\xb9", 1000) is None
+
+
+def test_parse_range_still_accepts_normal_ranges():
+    assert _parse_range("bytes=0-", 1000) == (0, 999)
+    assert _parse_range("bytes=10-19", 1000) == (10, 19)
+    assert _parse_range("bytes=-10", 1000) == (990, 999)
+
+
+# --- subscribe accepts bare handles ------------------------------------------
+
+
+def test_extract_channel_id_accepts_bare_handle_and_uc_id():
+    assert _extract_channel_id("@mkbhd") == "@mkbhd"
+    assert _extract_channel_id("UCBJycsmduvYEL83R_U4JriQ") == (
+        "UCBJycsmduvYEL83R_U4JriQ"
+    )
+    assert _extract_channel_id("https://www.youtube.com/@mkbhd") == "@mkbhd"
+    assert (
+        _extract_channel_id("https://www.youtube.com/channel/UCBJycsmduvYEL83R_U4JriQ")
+        == "UCBJycsmduvYEL83R_U4JriQ"
+    )
+    assert _extract_channel_id("not a channel") is None

--- a/tests/test_videos.py
+++ b/tests/test_videos.py
@@ -1,0 +1,173 @@
+"""Video progress upsert, download guard, and downloads-window tests (design 1.4)."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.database import async_session_factory
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from app.utils.time import utcnow_naive
+from tests.helpers import seed_channel, seed_ref, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def download_delay(monkeypatch):
+    """Stub out Celery enqueueing so tests never touch the Redis broker."""
+    mock = MagicMock()
+    monkeypatch.setattr("app.api.videos.download_video_task.delay", mock)
+    return mock
+
+
+async def test_progress_unknown_video_404(client, make_user):
+    _, headers = await make_user()
+    resp = await client.put(
+        "/api/videos/does-not-exist/progress",
+        json={"position_seconds": 10},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+async def test_progress_negative_position_422(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+
+    resp = await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": -1},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_progress_upsert_double_put_single_row(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+
+    for position in (10, 20):
+        resp = await client.put(
+            f"/api/videos/{video.id}/progress",
+            json={"position_seconds": position},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        refs = (
+            (
+                await db.execute(
+                    select(UserVideoRef).where(UserVideoRef.video_id == video.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(refs) == 1
+        assert refs[0].watch_position_seconds == 20
+        assert refs[0].last_watched_at is not None
+
+
+async def test_progress_reactivates_soft_deleted_ref(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+        await seed_ref(
+            db,
+            user["id"],
+            video.id,
+            watch_position_seconds=5,
+            removed_at=utcnow_naive(),
+        )
+
+    resp = await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": 42},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user["id"],
+                    UserVideoRef.video_id == video.id,
+                )
+            )
+        ).scalar_one()
+        assert ref.removed_at is None
+        assert ref.watch_position_seconds == 42
+
+
+async def test_download_quality_passthrough_and_double_enqueue_409(
+    client, make_user, download_delay
+):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    resp = await client.post(
+        f"/api/videos/{video.id}/download",
+        json={"quality": "720p"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    download_delay.assert_called_once_with(video.id, user["id"], quality="720p")
+
+    async with async_session_factory() as db:
+        v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()
+        assert v.status == "PENDING"
+
+    # Double-enqueue while PENDING is rejected.
+    resp = await client.post(f"/api/videos/{video.id}/download", headers=headers)
+    assert resp.status_code == 409
+    download_delay.assert_called_once()
+
+
+async def test_download_invalid_quality_422(client, make_user, download_delay):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    resp = await client.post(
+        f"/api/videos/{video.id}/download",
+        json={"quality": "144p"},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    download_delay.assert_not_called()
+
+
+async def test_downloads_list_window(client, make_user):
+    user, headers = await make_user()
+    now = utcnow_naive()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        pending = await seed_video(db, channel, status="PENDING")
+        downloading = await seed_video(db, channel, status="DOWNLOADING")
+        fresh = await seed_video(db, channel, status="COMPLETE", downloaded_at=now)
+        stale = await seed_video(
+            db,
+            channel,
+            status="COMPLETE",
+            downloaded_at=now - timedelta(seconds=120),
+        )
+        for video in (pending, downloading, fresh, stale):
+            await seed_ref(db, user["id"], video.id)
+
+    resp = await client.get("/api/videos/downloads", headers=headers)
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()}
+    assert ids == {pending.id, downloading.id, fresh.id}

--- a/tests/test_youtube_import.py
+++ b/tests/test_youtube_import.py
@@ -1,0 +1,230 @@
+"""YouTube import service tests — yt-dlp subprocess is mocked (design 1.2)."""
+
+import subprocess
+
+import pytest
+
+from app.services import youtube_import
+from app.services.youtube_import import (
+    YoutubeResolveError,
+    YoutubeResolveTimeoutError,
+    _normalize_handle,
+    get_suggestions,
+    resolve_handle,
+)
+from tests.helpers import IDENTITY_JSON, fake_completed_process
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_resolve_parses_identity_fields(monkeypatch):
+    monkeypatch.setattr(
+        youtube_import.subprocess,
+        "run",
+        lambda *a, **kw: fake_completed_process(IDENTITY_JSON),
+    )
+    result = await resolve_handle("@testchannel")
+    assert result == {
+        "handle": "@testchannel",
+        "channel_id": "UCabc123",
+        "name": "Test Channel",
+        "description": "A test channel",
+        "avatar_url": "https://img/avatar.jpg",
+        "banner_url": "https://img/banner.jpg",
+        "follower_count": 12345,
+    }
+
+
+async def test_resolve_avatar_falls_back_to_largest_squareish(monkeypatch):
+    data = dict(IDENTITY_JSON)
+    data["thumbnails"] = [
+        {"url": "https://img/wide.jpg", "width": 1280, "height": 720},
+        {"url": "https://img/small-square.jpg", "width": 88, "height": 88},
+        {"url": "https://img/big-square.jpg", "width": 800, "height": 800},
+    ]
+    monkeypatch.setattr(
+        youtube_import.subprocess,
+        "run",
+        lambda *a, **kw: fake_completed_process(data),
+    )
+    result = await resolve_handle("@fallback")
+    assert result["avatar_url"] == "https://img/big-square.jpg"
+    assert result["banner_url"] is None
+
+
+async def test_resolve_caches_by_normalized_handle(monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return fake_completed_process(IDENTITY_JSON)
+
+    monkeypatch.setattr(youtube_import.subprocess, "run", fake_run)
+
+    await resolve_handle("testchannel")
+    await resolve_handle("@testchannel")
+    await resolve_handle("https://www.youtube.com/@testchannel")
+    assert len(calls) == 1
+
+
+async def test_normalize_handle_variants():
+    assert _normalize_handle("@name") == "@name"
+    assert _normalize_handle("name") == "@name"
+    assert _normalize_handle(" name ") == "@name"
+    assert _normalize_handle("https://www.youtube.com/@name/videos") == "@name"
+    assert _normalize_handle("https://www.youtube.com/c/SomeName") == "@SomeName"
+    uc_id = "UC" + "a" * 22
+    assert _normalize_handle(uc_id) == uc_id
+    assert _normalize_handle(f"https://www.youtube.com/channel/{uc_id}") == uc_id
+    with pytest.raises(YoutubeResolveError):
+        _normalize_handle("https://www.youtube.com/watch?v=abc")
+
+
+async def test_resolve_failure_maps_to_404(client, monkeypatch):
+    monkeypatch.setattr(
+        youtube_import.subprocess,
+        "run",
+        lambda *a, **kw: fake_completed_process(
+            "", returncode=1, stderr="ERROR: Unable to download webpage"
+        ),
+    )
+    resp = await client.post("/api/youtube/resolve", json={"handle": "@nope"})
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "YouTube channel not found"
+
+
+async def test_resolve_timeout_maps_to_504(client, monkeypatch):
+    def raise_timeout(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=cmd, timeout=30)
+
+    monkeypatch.setattr(youtube_import.subprocess, "run", raise_timeout)
+
+    # The timeout error is a YoutubeResolveError subclass (auth.py relies on it).
+    with pytest.raises(YoutubeResolveTimeoutError):
+        await resolve_handle("@slow")
+    assert issubclass(YoutubeResolveTimeoutError, YoutubeResolveError)
+
+    resp = await client.post("/api/youtube/resolve", json={"handle": "@slow"})
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "YouTube lookup timed out"
+
+
+OWN_CHANNEL_ID = "UCown0000000000000000000"
+
+
+def _suggestions_dispatcher():
+    """Mock yt-dlp: no channels tab, two public playlists with rankable entries."""
+
+    def fake_run(cmd, **kwargs):
+        url = cmd[-1]
+        if url.endswith("/channels"):
+            return fake_completed_process(
+                "",
+                returncode=1,
+                stderr="ERROR: This channel does not have a channels tab",
+            )
+        if url.endswith("/playlists"):
+            return fake_completed_process(
+                {
+                    "entries": [
+                        {"id": "PL1"},
+                        {"url": "https://www.youtube.com/playlist?list=PL2"},
+                    ]
+                }
+            )
+        if "PL1" in url:
+            entries = [
+                {"channel_id": "UCaaa", "channel": "Alpha", "uploader_id": "@alpha"},
+                {"channel_id": "UCaaa", "channel": "Alpha", "uploader_id": "@alpha"},
+                {"channel_id": "UCaaa", "channel": "Alpha", "uploader_id": "@alpha"},
+                {"channel_id": OWN_CHANNEL_ID, "channel": "Self"},
+                {"channel_id": "UCbbb", "channel": "Beta"},
+            ]
+            return fake_completed_process({"entries": entries})
+        if "PL2" in url:
+            entries = [
+                {"channel_id": "UCbbb", "channel": "Beta"},
+                {"channel_id": "UCccc", "channel": "Gamma"},
+                {"channel_id": OWN_CHANNEL_ID, "channel": "Self"},
+            ]
+            return fake_completed_process({"entries": entries})
+        # Identity resolve for the user's own channel.
+        return fake_completed_process(
+            {"channel_id": OWN_CHANNEL_ID, "channel": "Self", "thumbnails": []}
+        )
+
+    return fake_run
+
+
+async def test_suggestions_playlists_ranked_own_channel_excluded(monkeypatch):
+    monkeypatch.setattr(youtube_import.subprocess, "run", _suggestions_dispatcher())
+
+    suggestions = await get_suggestions("@self")
+
+    assert [s["youtube_channel_id"] for s in suggestions] == [
+        "UCaaa",
+        "UCbbb",
+        "UCccc",
+    ]
+    by_id = {s["youtube_channel_id"]: s for s in suggestions}
+    assert by_id["UCaaa"]["score"] == 3
+    assert by_id["UCbbb"]["score"] == 2
+    assert by_id["UCccc"]["score"] == 1
+    assert by_id["UCaaa"]["name"] == "Alpha"
+    assert by_id["UCaaa"]["handle"] == "@alpha"
+    assert all(s["source"] == "playlists" for s in suggestions)
+    assert OWN_CHANNEL_ID not in by_id
+
+
+async def test_suggestions_featured_channels_tab(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        url = cmd[-1]
+        if url.endswith("/channels"):
+            return fake_completed_process(
+                {
+                    "entries": [
+                        {
+                            "channel_id": "UCfeat",
+                            "channel": "Featured",
+                            "uploader_id": "@feat",
+                        }
+                    ]
+                }
+            )
+        if url.endswith("/playlists"):
+            return fake_completed_process({"entries": []})
+        return fake_completed_process(
+            {"channel_id": OWN_CHANNEL_ID, "channel": "Self", "thumbnails": []}
+        )
+
+    monkeypatch.setattr(youtube_import.subprocess, "run", fake_run)
+
+    suggestions = await get_suggestions("@self")
+    assert suggestions == [
+        {
+            "youtube_channel_id": "UCfeat",
+            "name": "Featured",
+            "handle": "@feat",
+            "avatar_url": None,
+            "source": "featured",
+            "score": 100,
+        }
+    ]
+
+
+async def test_suggestions_endpoint_empty_is_normal(client, monkeypatch):
+    def fake_run(cmd, **kwargs):
+        url = cmd[-1]
+        if url.endswith(("/channels", "/playlists")):
+            return fake_completed_process(
+                "", returncode=1, stderr="ERROR: tab not available"
+            )
+        return fake_completed_process(
+            {"channel_id": OWN_CHANNEL_ID, "channel": "Self", "thumbnails": []}
+        )
+
+    monkeypatch.setattr(youtube_import.subprocess, "run", fake_run)
+
+    resp = await client.post("/api/youtube/suggestions", json={"handle": "@self"})
+    assert resp.status_code == 200
+    assert resp.json() == {"suggestions": []}


### PR DESCRIPTION
## Summary

Implements the user-management half of the spec (sections 5/9.1) plus a sweep of reliability fixes, paired with windoze95/nullfeed-flutter#24 (profile picker overhaul).

### Profiles & auth
- **Persistent sessions** (new `sessions` table) — devices stay signed in across container restarts; works with multiple workers
- **Salted scrypt PIN hashing** with transparent upgrade from legacy SHA-256; PIN rate limiting (5 failures → 30s lockout)
- `POST /api/auth/create` hardened: `is_admin` no longer honored from the body; name/PIN validation; **optional `youtube_handle`** — resolves the channel via yt-dlp, defaults the display name, caches the avatar locally
- New endpoints: `GET /me`, `POST /logout`, `PATCH`/`DELETE /api/auth/profiles/{id}` (self-or-admin, last-admin protection, cascade cleanup), `has_pin` on profiles

### YouTube profile import (new)
- `POST /api/youtube/resolve` — handle → identity (name, avatar, banner, follower count)
- `POST /api/youtube/suggestions` — discovers channels a user follows from featured channels + public playlists (frequency-ranked, graceful degradation; verified live)
- `POST /api/channels/subscribe-bulk` — up to 25 channels without per-channel resolution

### Reliability fixes (from a 70+ finding audit, each adversarially verified)
- Media server rewritten: **streamed** range responses (a `bytes=0-` request no longer loads multi-GB files into RAM), correct RFC 7233 suffix ranges, 416 handling, ETag/Last-Modified
- Progress updates are upserts with `last_watched_at` (no more 500s from concurrent pings); `is_watched` derived server-side; soft-deleted refs reactivate on subscribe/progress
- Orphan cleanup resets video rows (no phantom "downloaded" videos)
- Download lifecycle: retry path actually retries (was wedging in DOWNLOADING), cancel kills the yt-dlp **process group** with a CANCELLING handshake, quality override, `downloaded_at` stamping, preview pipe-deadlock fixed
- SQLite WAL/busy_timeout/foreign_keys on both engines; Celery visibility_timeout 12h
- Recommendations: AsyncAnthropic (no event-loop blocking), migrated off `claude-sonnet-4-20250514` (retires June 15) to `claude-sonnet-4-6`, stores handles for one-tap subscribe
- WebSocket auth, health 503 when degraded, feed ordering fixes, N+1 query cleanup

### Tests
3 → **74 tests**: auth flows, sessions persistence, import (mocked yt-dlp), bulk subscribe, range requests, upserts, orphan cleanup, cancel state machine.

Supersedes the overlapping community PRs #36/#53/#43/#35/#55/#56 (same bugs, fixed here coherently with tests).

Verified live: booted the server, created profiles (plain + `@mkbhd` import with avatar caching), PIN flows incl. lockout, byte-exact range requests, suggestions degradation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
