### PR TITLE
Bump python-multipart to 0.0.27 (two CVEs; unblocks Dependency Audit)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ yt-dlp==2026.2.21
 anthropic==0.43.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
-python-multipart==0.0.22
+python-multipart==0.0.27
 websockets==14.1
 httpx==0.28.1
 passlib==1.7.4


### PR DESCRIPTION
`pip-audit` fails on main: python-multipart 0.0.22 has CVE-2026-40347 (fixed 0.0.26) and CVE-2026-42561 (fixed 0.0.27).

One-line bump; backend test suite passes against 0.0.27. Kept separate from #61 per repo convention (infra fixes in their own PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)