### PR TITLE
Add .dockerignore (runtime data was being copied into the image)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Runtime data is mounted as volumes — never baked into the image.
+data/
+
+# Local dev artifacts
+.venv/
+.git/
+.github/
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+tests/
+.env


### PR DESCRIPTION
Local `docker compose up --build` with a populated `./data/` directory ships the whole thing (18GB here) as build context and `COPY . .` bakes it into the image — the build failed outright on this machine. Runtime data is volume-mounted and must never be in the image; this also trims VCS/venv/test cruft from the context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)