### PR TITLE
Sort freshly cataloged videos to the top of channel listings

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -413,10 +413,13 @@ async def list_channel_videos(
     total = total_result.scalar() or 0
 
     offset = (page - 1) * per_page
+    # Videos cataloged from flat-playlist polls have no upload date until
+    # they are downloaded; fall back to catalog time so freshly discovered
+    # episodes sort to the top instead of the bottom.
     result = await db.execute(
         select(Video)
         .where(Video.channel_id == channel_id)
-        .order_by(Video.uploaded_at.desc())
+        .order_by(func.coalesce(Video.uploaded_at, Video.created_at).desc())
         .offset(offset)
         .limit(per_page)
     )

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -70,7 +70,13 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
     cataloged_ids: list[str] = []
     new_video_ids: list[str] = []
 
-    for yt_vid in yt_videos:
+    # yt-dlp returns the channel feed newest-first. Cataloged videos have no
+    # upload date until downloaded, and listings fall back to created_at — so
+    # stamp each new row with a synthetic timestamp that decreases down the
+    # feed, preserving the feed order within this poll batch.
+    poll_started_at = utcnow_naive()
+
+    for index, yt_vid in enumerate(yt_videos):
         yt_video_id = yt_vid["youtube_video_id"]
         if not yt_video_id:
             continue
@@ -102,6 +108,7 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
             duration_seconds=yt_vid.get("duration_seconds", 0),
             uploaded_at=uploaded_at,
             status="CATALOGED",
+            created_at=poll_started_at - timedelta(seconds=index),
         )
         db.add(video)
         db.flush()

--- a/tests/test_channel_poller.py
+++ b/tests/test_channel_poller.py
@@ -85,3 +85,37 @@ def test_refresh_keeps_existing_name(mock_meta, mock_images):
 
     # Name should NOT be overwritten
     assert channel.name == "My Custom Name"
+
+
+def test_cataloged_batch_preserves_feed_order(monkeypatch):
+    """Within one poll, newer feed entries get later created_at stamps."""
+    from sqlalchemy import create_engine, select
+    from sqlalchemy.orm import sessionmaker
+
+    from app.models import Base
+    from app.models.video import Video
+    from app.services import channel_poller
+    from app.utils.time import utcnow_naive
+
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    channel = _make_channel(last_checked_at=utcnow_naive())
+    db.add(channel)
+    db.commit()
+
+    feed = {
+        "videos": [
+            {"youtube_video_id": "newest01234", "title": "Newest"},
+            {"youtube_video_id": "middle01234", "title": "Middle"},
+            {"youtube_video_id": "oldest01234", "title": "Oldest"},
+        ]
+    }
+    monkeypatch.setattr(channel_poller, "fetch_channel_videos", lambda _: feed)
+
+    channel_poller.poll_single_channel(channel.id, db)
+
+    rows = db.execute(select(Video)).scalars().all()
+    by_title = {v.title: v.created_at for v in rows}
+    assert by_title["Newest"] > by_title["Middle"] > by_title["Oldest"]
+    db.close()

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -201,3 +201,25 @@ def test_extract_channel_id_accepts_bare_handle_and_uc_id():
         == "UCBJycsmduvYEL83R_U4JriQ"
     )
     assert _extract_channel_id("not a channel") is None
+
+
+# --- cataloged videos sort by catalog time when upload date is unknown -------
+
+
+async def test_channel_videos_nulls_uploaded_at_sort_first(client, make_user):
+    from datetime import datetime, timedelta
+
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        old = await seed_video(
+            db, channel, title="Old", uploaded_at=datetime(2026, 3, 3)
+        )
+        fresh = await seed_video(db, channel, title="Fresh Catalog")
+        fresh.uploaded_at = None
+        fresh.created_at = old.created_at + timedelta(days=90)
+        await db.commit()
+
+    resp = await client.get(f"/api/channels/{channel.id}/videos", headers=headers)
+    titles = [v["title"] for v in resp.json()["items"]]
+    assert titles == ["Fresh Catalog", "Old"]


### PR DESCRIPTION
Found while restarting a backend that had been off since March: the catch-up poll cataloged 61 new videos, but they all sorted to the **bottom** of channel listings because flat-playlist cataloging leaves `uploaded_at` NULL (it's only populated on download) and the listing orders by `uploaded_at DESC`.

Order by `COALESCE(uploaded_at, created_at) DESC` instead — undated fresh catalog entries sort by discovery time, dated videos keep their order. Regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)