### PR TITLE
Poll-on-demand endpoints for pull-to-refresh

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -24,8 +24,14 @@ from app.schemas.channel import (
     ChannelSubscribe,
 )
 from app.schemas.video import VideoOut, VideoPagination
+from app.services.channel_poller import poll_single_channel
 from app.services.download_manager import fetch_channel_images, fetch_channel_metadata
-from app.tasks.download_tasks import poll_channel_task
+from app.tasks.download_tasks import (
+    _get_sync_db,
+    download_video_task,
+    poll_all_channels_task,
+    poll_channel_task,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -287,6 +293,61 @@ async def _subscribe_bulk_item(
         status="subscribed",
         channel_id=channel.id,
     )
+
+
+@router.post("/poll")
+async def poll_all_channels_now(
+    user: User = Depends(get_current_user),
+) -> dict:
+    """Kick off a background poll of every channel (pull-to-refresh)."""
+    try:
+        poll_all_channels_task.delay()
+    except Exception:
+        logger.exception("Could not enqueue poll-all task")
+        raise HTTPException(status_code=502, detail="Could not start poll")
+    return {"detail": "Poll started"}
+
+
+@router.post("/{channel_id}/poll")
+async def poll_channel_now(
+    channel_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Poll one channel synchronously so pull-to-refresh shows new uploads.
+
+    A single-channel poll is one yt-dlp call (a few seconds) — fast enough
+    to run inline. Auto-download candidates are enqueued exactly as the
+    scheduled poll task does.
+    """
+    result = await db.execute(select(Channel.id).where(Channel.id == channel_id))
+    if result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Channel not found")
+
+    def _run() -> dict:
+        sync_db = _get_sync_db()
+        try:
+            poll_result = poll_single_channel(channel_id, sync_db)
+        finally:
+            sync_db.close()
+        enqueue_failures = 0
+        for video_id in poll_result["auto_download_ids"]:
+            try:
+                download_video_task.delay(video_id)
+            except Exception:
+                enqueue_failures += 1
+                logger.exception("Could not enqueue auto-download %s", video_id)
+        return {
+            "detail": "Polled",
+            "cataloged": len(poll_result["cataloged_ids"]),
+            "auto_downloads": len(poll_result["auto_download_ids"]) - enqueue_failures,
+        }
+
+    try:
+        return await asyncio.to_thread(_run)
+    except Exception:
+        logger.exception("Poll failed for channel %s", channel_id)
+        raise HTTPException(status_code=502, detail="Poll failed")
 
 
 @router.post("/{channel_id}/refresh-images", response_model=ChannelDetail)

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -223,3 +223,47 @@ async def test_channel_videos_nulls_uploaded_at_sort_first(client, make_user):
     resp = await client.get(f"/api/channels/{channel.id}/videos", headers=headers)
     titles = [v["title"] for v in resp.json()["items"]]
     assert titles == ["Fresh Catalog", "Old"]
+
+
+# --- pull-to-refresh poll endpoints -------------------------------------------
+
+
+async def test_poll_channel_now_runs_poller_and_enqueues(
+    client, make_user, monkeypatch
+):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+
+    poll_mock = MagicMock(
+        return_value={"cataloged_ids": ["a", "b"], "auto_download_ids": ["a"]}
+    )
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.channels.poll_single_channel", poll_mock)
+    monkeypatch.setattr("app.api.channels.download_video_task.delay", delay_mock)
+
+    resp = await client.post(f"/api/channels/{channel.id}/poll", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"detail": "Polled", "cataloged": 2, "auto_downloads": 1}
+    poll_mock.assert_called_once()
+    delay_mock.assert_called_once_with("a")
+
+
+async def test_poll_channel_now_unknown_channel_404(client, make_user):
+    _, headers = await make_user()
+    resp = await client.post("/api/channels/nope/poll", headers=headers)
+    assert resp.status_code == 404
+
+
+async def test_poll_all_endpoint_enqueues_task(client, make_user, monkeypatch):
+    _, headers = await make_user()
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.channels.poll_all_channels_task.delay", delay_mock)
+    resp = await client.post("/api/channels/poll", headers=headers)
+    assert resp.status_code == 200
+    delay_mock.assert_called_once()
+
+
+async def test_poll_endpoints_require_auth(client):
+    assert (await client.post("/api/channels/poll")).status_code == 401
+    assert (await client.post("/api/channels/x/poll")).status_code == 401


### PR DESCRIPTION
Pull-to-refresh in the app should actually check YouTube for new content, not just re-read the database (requested after a 3-month-gap restart surfaced how stale the catalog can get between hourly polls).

- `POST /api/channels/{id}/poll` — synchronous single-channel poll (~one yt-dlp call), so refreshing a channel page shows new uploads in the same gesture; enqueues auto-downloads like the scheduled task
- `POST /api/channels/poll` — fire-and-forget all-channels poll for home/library refresh

Paired with the Flutter PR wiring RefreshIndicators to these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)