### PR TITLE
perf: drop speculative eager-loads and add hot-path indexes

### DIFF
--- a/alembic/versions/006_hotpath_indexes.py
+++ b/alembic/versions/006_hotpath_indexes.py
@@ -1,0 +1,40 @@
+"""Hot-path indexes: user_subscriptions.channel_id and user_video_refs(video_id, removed_at)
+
+Revision ID: 006_hotpath_indexes
+Revises: 005_profiles_and_hardening
+Create Date: 2026-06-27
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "006_hotpath_indexes"
+down_revision: Union[str, None] = "005_profiles_and_hardening"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Subscriber lookups filter user_subscriptions by channel_id alone, which the
+    # (user_id, channel_id) primary key cannot serve (user_id is the lead column).
+    op.create_index(
+        "ix_user_subscriptions_channel_id", "user_subscriptions", ["channel_id"]
+    )
+
+    # Orphan cleanup filters user_video_refs by (video_id, removed_at IS NULL).
+    # The standalone removed_at index is never used as a lead column by any query
+    # (every removed_at filter is paired with user_id or video_id), so replace it
+    # with the composite that the orphan check can actually use.
+    op.drop_index("ix_user_video_refs_removed", table_name="user_video_refs")
+    op.create_index(
+        "ix_user_video_refs_video_id_removed",
+        "user_video_refs",
+        ["video_id", "removed_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_video_refs_video_id_removed", table_name="user_video_refs")
+    op.create_index("ix_user_video_refs_removed", "user_video_refs", ["removed_at"])
+    op.drop_index("ix_user_subscriptions_channel_id", table_name="user_subscriptions")

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -26,7 +26,7 @@ class Channel(Base):
         DateTime, nullable=True
     )
 
-    videos = relationship("Video", back_populates="channel", lazy="selectin")
+    videos = relationship("Video", back_populates="channel", lazy="select")
     subscriptions = relationship(
-        "UserSubscription", back_populates="channel", lazy="selectin"
+        "UserSubscription", back_populates="channel", lazy="select"
     )

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy import DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
@@ -9,6 +9,7 @@ from app.utils.time import utcnow_naive
 
 class UserSubscription(Base):
     __tablename__ = "user_subscriptions"
+    __table_args__ = (Index("ix_user_subscriptions_channel_id", "channel_id"),)
 
     user_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("users.id"), primary_key=True

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -21,9 +21,9 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
 
     subscriptions = relationship(
-        "UserSubscription", back_populates="user", lazy="selectin"
+        "UserSubscription", back_populates="user", lazy="select"
     )
-    video_refs = relationship("UserVideoRef", back_populates="user", lazy="selectin")
+    video_refs = relationship("UserVideoRef", back_populates="user", lazy="select")
 
     @property
     def has_pin(self) -> bool:

--- a/app/models/user_video_ref.py
+++ b/app/models/user_video_ref.py
@@ -9,7 +9,9 @@ from app.utils.time import utcnow_naive
 
 class UserVideoRef(Base):
     __tablename__ = "user_video_refs"
-    __table_args__ = (Index("ix_user_video_refs_removed", "removed_at"),)
+    __table_args__ = (
+        Index("ix_user_video_refs_video_id_removed", "video_id", "removed_at"),
+    )
 
     user_id: Mapped[str] = mapped_column(
         String(36), ForeignKey("users.id"), primary_key=True

--- a/app/models/video.py
+++ b/app/models/video.py
@@ -33,4 +33,4 @@ class Video(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
 
     channel = relationship("Channel", back_populates="videos")
-    user_refs = relationship("UserVideoRef", back_populates="video", lazy="selectin")
+    user_refs = relationship("UserVideoRef", back_populates="video", lazy="select")


### PR DESCRIPTION
Backend performance work from the roadmap audit (NOW #6 + #7). No behavior change — purely query-efficiency.

## 1. Remove speculative eager-loads
All 5 collection relationships were `lazy="selectin"`, so they fired on **every** request (including `get_current_user` on every authenticated call) and cascade-loaded whole tables — yet nothing serializes them. Flipped to `lazy="select"`:

- `User.subscriptions`, `User.video_refs`
- `Channel.videos`, `Channel.subscriptions`
- `Video.user_refs`

Verified across `app/api`, `app/schemas`, `app/services`, and tests that these attributes are never read during serialization. The only relationship read at serialization time is `Video.channel` (not one of the five), which is already covered by explicit `selectinload(Video.channel)` at its query sites — so no new `selectinload` was needed.

## 2. Hot-path indexes (migration `006_hotpath_indexes`)
- **Create** `ix_user_subscriptions_channel_id` on `user_subscriptions(channel_id)` — subscriber lookups filter `channel_id` alone, which the `(user_id, channel_id)` PK can't serve (user_id leads).
- **Drop** the redundant standalone `ix_user_video_refs_removed` and **create** composite `ix_user_video_refs_video_id_removed(video_id, removed_at)` — the orphan-cleanup query filters exactly `(video_id, removed_at IS NULL)`. No query leads with `removed_at`, and it's low-selectivity.
- Models' `__table_args__` updated to match; `downgrade()` restores the exact pre-006 schema.

## Verification (local)
- `pytest -q`: **80 passed**
- `ruff check` / `ruff format --check`: clean
- `mypy app/`: no issues
- Alembic round-trip on a throwaway DB: `upgrade head` (001→006) and `downgrade -1` both verified, indexes present/absent as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY