### PR TITLE
fix(deps): patch 7 CVEs in yt-dlp and python-multipart

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ alembic==1.14.1
 aiosqlite==0.20.0
 celery==5.4.0
 redis==5.2.1
-yt-dlp==2026.2.21
+yt-dlp==2026.6.9
 anthropic==0.43.0
 pydantic==2.10.4
 pydantic-settings==2.7.1
-python-multipart==0.0.27
+python-multipart==0.0.32
 websockets==14.1
 httpx==0.28.1
 passlib==1.7.4


### PR DESCRIPTION
Standalone infra fix (kept separate from feature PRs). `pip-audit` reports 7 known vulnerabilities in two pinned dependencies on `main` — newly disclosed since the pins were last set, so CI's Dependency Audit now fails on every PR.

| Package | From | To | Advisories |
|---------|------|----|-----------|
| yt-dlp | 2026.2.21 | **2026.6.9** | CVE-2026-50019, CVE-2026-50023, CVE-2026-50574, GHSA-69qj-pvh9-c5wg |
| python-multipart | 0.0.27 | **0.0.32** | CVE-2026-53538, CVE-2026-53539, CVE-2026-53540 |

## Why these versions
- **yt-dlp 2026.6.9** is the advisory fix version and the current latest, which also clears the non-blocking "yt-dlp Version Check" warning.
- **python-multipart 0.0.32** covers all three CVEs; fastapi 0.135.1 only requires `>=0.0.18`, so it's compatible.

## Verification (local)
- `pip-audit -r requirements.txt` → **No known vulnerabilities found**
- `pytest -q` against the bumped versions → **80 passed**

Supersedes the partial dependabot bump #48 (yt-dlp 2026.3.17, which is older than the 2026.6.9 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY