### PR TITLE
fix: self-healing downloads + per-user cancel ref-counting (#31, #32)

### DIFF
--- a/alembic/versions/007_download_heartbeat.py
+++ b/alembic/versions/007_download_heartbeat.py
@@ -1,0 +1,30 @@
+"""Add videos.download_heartbeat_at for the stuck-download reaper
+
+Revision ID: 007_download_heartbeat
+Revises: 006_hotpath_indexes
+Create Date: 2026-06-27
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "007_download_heartbeat"
+down_revision: Union[str, None] = "006_hotpath_indexes"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Liveness timestamp for in-flight downloads. Nullable so the column can be
+    # added without backfilling: existing DOWNLOADING/CANCELLING rows get NULL,
+    # which the reaper treats as stale (those rows predate any live worker).
+    op.add_column(
+        "videos",
+        sa.Column("download_heartbeat_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("videos", "download_heartbeat_at")

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from fastapi import APIRouter, Depends, Header, HTTPException
 from fastapi.responses import Response
-from sqlalchemy import or_, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -21,6 +21,28 @@ from app.tasks.download_tasks import download_preview_task, download_video_task
 from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/videos", tags=["videos"])
+
+
+async def _ensure_active_ref(db: AsyncSession, user_id: str, video_id: str) -> None:
+    """Register (or reactivate) the caller's claim on a video.
+
+    The set of active (``removed_at IS NULL``) UserVideoRefs is the download's
+    reference count, so any endpoint that expresses "I want this video" must
+    leave the caller holding an active ref. Idempotent: creates the ref if
+    missing, clears ``removed_at`` if it was soft-deleted, and leaves an
+    already-active ref untouched.
+    """
+    now = utcnow_naive()
+    stmt = (
+        sqlite_insert(UserVideoRef)
+        .values(user_id=user_id, video_id=video_id, added_at=now, removed_at=None)
+        .on_conflict_do_update(
+            index_elements=["user_id", "video_id"],
+            set_={"removed_at": None},
+        )
+    )
+    await db.execute(stmt)
+    await db.commit()
 
 
 @router.get("/downloads", response_model=list[VideoOut])
@@ -121,6 +143,12 @@ async def trigger_download(
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
+    # Ownership: the caller now wants this (shared) video, so register their ref
+    # before anything else. This keeps the download ref-counted symmetrically
+    # with cancel, and attaches the caller to a download another user may have
+    # already started. Committed up front so it survives the 409 paths below.
+    await _ensure_active_ref(db, user.id, video_id)
+
     if video.status in ("PENDING", "DOWNLOADING"):
         raise HTTPException(status_code=409, detail="Download already in progress")
     if video.status == "CANCELLING":
@@ -150,23 +178,65 @@ async def cancel_download(
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
 
+    # Escape hatch (also covered by the reaper): cancelling a row that is
+    # already CANCELLING force-clears a teardown whose worker never confirmed it
+    # (e.g. the worker died mid-cancel). This is a recovery action, independent
+    # of ref-counting.
     if video.status == "CANCELLING":
-        # Escape hatch: a second cancel force-clears a cancel whose worker
-        # never confirmed (e.g. the worker died mid-download).
         video.status = "CATALOGED"
         await db.commit()
         return {"detail": "Download cancelled", "video_id": video_id}
 
+    # Drop ONLY the caller's intent — never another user's. The shared download
+    # is ref-counted by the set of active UserVideoRefs.
+    ref_result = await db.execute(
+        select(UserVideoRef).where(
+            UserVideoRef.user_id == user.id,
+            UserVideoRef.video_id == video_id,
+            UserVideoRef.removed_at.is_(None),
+        )
+    )
+    ref = ref_result.scalar_one_or_none()
+    if ref is not None:
+        ref.removed_at = utcnow_naive()
+        await db.commit()
+
+    # Not an active download? Nothing to interrupt, but dropping the ref may have
+    # orphaned an existing file — reuse the orphan check to remove it if so.
     if video.status not in ("PENDING", "DOWNLOADING"):
+        await check_and_delete_orphan(video_id, db)
         return {"detail": "Not in progress", "video_id": video_id}
 
-    # PENDING tasks never started — the worker's start guard skips CATALOGED.
-    # An in-flight download moves to CANCELLING until the worker confirms it
-    # has killed yt-dlp and cleaned up, blocking a concurrent re-download.
-    video.status = "CATALOGED" if video.status == "PENDING" else "CANCELLING"
+    # Only tear down the shared download when nobody is left who wants it. This
+    # also covers the scheduler: it downloads on subscribers' behalf, and those
+    # subscribers hold the refs, so their refs keep the download alive.
+    remaining = await db.scalar(
+        select(func.count())
+        .select_from(UserVideoRef)
+        .where(
+            UserVideoRef.video_id == video_id,
+            UserVideoRef.removed_at.is_(None),
+        )
+    )
+    if remaining and remaining > 0:
+        return {
+            "detail": "Cancelled for you; download continues for others",
+            "video_id": video_id,
+            "stopped": False,
+        }
+
+    # No active refs remain: truly cancel the shared download.
+    if video.status == "PENDING":
+        # Never started — the worker's start guard skips a CATALOGED row.
+        video.status = "CATALOGED"
+    else:  # DOWNLOADING
+        # Hand off to the worker: its cancel_check kills yt-dlp, cleans up
+        # partial files, then confirms CANCELLING -> CATALOGED. Blocks a
+        # concurrent re-download until the teardown completes.
+        video.status = "CANCELLING"
     await db.commit()
 
-    return {"detail": "Download cancelled", "video_id": video_id}
+    return {"detail": "Download cancelled", "video_id": video_id, "stopped": True}
 
 
 @router.post("/{video_id}/preview")

--- a/app/models/video.py
+++ b/app/models/video.py
@@ -30,6 +30,14 @@ class Video(Base):
     preview_file_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     preview_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
     downloaded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # Liveness signal for an in-flight download: set when the row enters
+    # DOWNLOADING and refreshed by the worker as yt-dlp produces output. The
+    # reaper treats a DOWNLOADING/CANCELLING row whose heartbeat has gone stale
+    # as stranded by a crashed worker and resets it. NULL means "no download
+    # has touched this row since the column was added".
+    download_heartbeat_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
 
     channel = relationship("Channel", back_populates="videos")

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -74,7 +74,10 @@ class _DownloadWatchdog(threading.Thread):
         self._poll_interval = poll_interval
         self._started_at = time.monotonic()
         self._last_output_at = self._started_at
-        self._stop = threading.Event()
+        # NB: must not be named ``_stop`` — that shadows ``threading.Thread._stop``,
+        # an internal method ``Thread.join()`` calls, which would raise
+        # "'Event' object is not callable" on some CPython versions.
+        self._stop_event = threading.Event()
         self.reason: str | None = None
 
     def note_output(self) -> None:
@@ -82,10 +85,10 @@ class _DownloadWatchdog(threading.Thread):
         self._last_output_at = time.monotonic()
 
     def stop(self) -> None:
-        self._stop.set()
+        self._stop_event.set()
 
     def run(self) -> None:
-        while not self._stop.wait(self._poll_interval):
+        while not self._stop_event.wait(self._poll_interval):
             if self._process.poll() is not None:
                 return  # process exited on its own; the reader is draining EOF
             now = time.monotonic()

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -5,6 +5,7 @@ import shutil
 import signal
 import subprocess
 import json
+import threading
 import time
 from collections.abc import Callable
 
@@ -13,6 +14,22 @@ import httpx
 from app.config import settings
 
 logger = logging.getLogger(__name__)
+
+# --- Download watchdog tuning ---------------------------------------------
+# A live yt-dlp/aria2c download prints stdout lines constantly while fetching,
+# plus a short quiet spell around the post-download stream-copy merge. A gap
+# longer than this means the process is wedged (dead socket, hung aria2c) rather
+# than busy, so we kill it. Generous enough to cover a slow merge of a large
+# file that produces no progress output.
+NO_OUTPUT_TIMEOUT_SECONDS = 300
+
+# Absolute ceiling on a single download regardless of progress. A legitimate
+# large download on a slow link can run long, so this is deliberately generous;
+# the Celery soft/hard time limits sit just above it as a coarser backstop.
+OVERALL_DEADLINE_SECONDS = 4 * 3600
+
+# How often the watchdog thread wakes to evaluate the timers and cancel flag.
+WATCHDOG_POLL_INTERVAL_SECONDS = 5.0
 
 
 class DownloadCancelled(Exception):
@@ -27,21 +44,93 @@ def _kill_process_group(process: subprocess.Popen) -> None:
         process.kill()
 
 
+class _DownloadWatchdog(threading.Thread):
+    """Kills a wedged download from a side thread.
+
+    The main thread blocks reading yt-dlp stdout line by line, which on its own
+    cannot detect a *silent* hang (process alive, socket dead, no output and no
+    EOF). This thread watches three conditions and kills the process group when
+    any trips; killing it closes the pipe and unblocks the reader. The reader
+    then inspects ``reason`` to decide what to raise.
+
+      * no stdout for ``no_output_timeout`` seconds -> "no_output"
+      * total runtime past ``overall_deadline`` seconds -> "deadline"
+      * ``cancel_check()`` returns True (cancelled via the API) -> "cancelled"
+    """
+
+    def __init__(
+        self,
+        process: subprocess.Popen,
+        cancel_check: Callable[[], bool] | None = None,
+        no_output_timeout: float = NO_OUTPUT_TIMEOUT_SECONDS,
+        overall_deadline: float = OVERALL_DEADLINE_SECONDS,
+        poll_interval: float = WATCHDOG_POLL_INTERVAL_SECONDS,
+    ) -> None:
+        super().__init__(daemon=True)
+        self._process = process
+        self._cancel_check = cancel_check
+        self._no_output_timeout = no_output_timeout
+        self._overall_deadline = overall_deadline
+        self._poll_interval = poll_interval
+        self._started_at = time.monotonic()
+        self._last_output_at = self._started_at
+        self._stop = threading.Event()
+        self.reason: str | None = None
+
+    def note_output(self) -> None:
+        """Record that the reader just saw a line (resets the stall timer)."""
+        self._last_output_at = time.monotonic()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def run(self) -> None:
+        while not self._stop.wait(self._poll_interval):
+            if self._process.poll() is not None:
+                return  # process exited on its own; the reader is draining EOF
+            now = time.monotonic()
+            if self._cancel_check is not None:
+                try:
+                    cancelled = self._cancel_check()
+                except Exception:
+                    cancelled = False
+                if cancelled:
+                    self.reason = "cancelled"
+                    _kill_process_group(self._process)
+                    return
+            if now - self._last_output_at > self._no_output_timeout:
+                self.reason = "no_output"
+                _kill_process_group(self._process)
+                return
+            if now - self._started_at > self._overall_deadline:
+                self.reason = "deadline"
+                _kill_process_group(self._process)
+                return
+
+
 def download_video(
     youtube_video_id: str,
     channel_slug: str,
     quality: str | None = None,
     progress_callback: Callable[[float], None] | None = None,
     cancel_check: Callable[[], bool] | None = None,
+    heartbeat_callback: Callable[[], None] | None = None,
 ) -> dict:
     """
     Download a video using yt-dlp. Returns metadata dict on success.
 
-    `cancel_check` is polled every ~5s while the download runs; when it
-    returns True, yt-dlp is killed, partial files are cleaned up, and
+    A watchdog thread runs alongside the stdout reader and kills yt-dlp if the
+    download stalls (no output for NO_OUTPUT_TIMEOUT_SECONDS), runs past
+    OVERALL_DEADLINE_SECONDS, or is cancelled. `cancel_check` is polled every
+    ~5s by that thread, so cancellation works even during a silent hang; when
+    it returns True, yt-dlp is killed, partial files are cleaned up, and
     DownloadCancelled is raised.
 
-    Raises RuntimeError on failure, DownloadCancelled on cancellation.
+    `heartbeat_callback` (if given) is invoked on every stdout line so the
+    caller can record a liveness timestamp the reaper can use to detect a
+    crashed worker.
+
+    Raises RuntimeError on failure or stall, DownloadCancelled on cancellation.
     """
     quality = quality or settings.media_quality
     output_dir = os.path.join(settings.media_path, channel_slug)
@@ -97,25 +186,26 @@ def download_video(
     # aria2c:        [#abc 1.7MiB/81MiB(2%) ...]
     progress_re = re.compile(r"\[download\]\s+([\d.]+)%|\((\d+)%\)")
     last_callback_time = 0.0
-    last_cancel_check_time = time.monotonic()
     last_line = ""
 
+    # Read the tuning constants at call time (not via the watchdog's default
+    # args, which bind at import) so they can be overridden in tests.
+    watchdog = _DownloadWatchdog(
+        process,
+        cancel_check=cancel_check,
+        no_output_timeout=NO_OUTPUT_TIMEOUT_SECONDS,
+        overall_deadline=OVERALL_DEADLINE_SECONDS,
+        poll_interval=WATCHDOG_POLL_INTERVAL_SECONDS,
+    )
+    watchdog.start()
+    stdout_lines = iter(process.stdout.readline, "") if process.stdout else iter(())
     try:
-        for line in process.stdout or []:
+        for line in stdout_lines:
+            watchdog.note_output()
             last_line = line
 
-            # Poll for cancellation every ~5s while output is flowing
-            if cancel_check is not None:
-                now = time.monotonic()
-                if now - last_cancel_check_time >= 5.0:
-                    last_cancel_check_time = now
-                    if cancel_check():
-                        _kill_process_group(process)
-                        process.wait()
-                        _cleanup_partial_files(output_dir, youtube_video_id)
-                        raise DownloadCancelled(
-                            f"Download cancelled for {youtube_video_id}"
-                        )
+            if heartbeat_callback is not None:
+                heartbeat_callback()
 
             m = progress_re.search(line)
             if m and progress_callback is not None:
@@ -125,11 +215,43 @@ def download_video(
                     pct = float(m.group(1) or m.group(2))
                     progress_callback(pct)
 
-        process.wait(timeout=3600)
+        # The reader saw EOF: either yt-dlp finished or the watchdog killed it.
+        # The process is already exiting, so this wait should return promptly.
+        process.wait(timeout=60)
     except subprocess.TimeoutExpired:
         _kill_process_group(process)
         process.wait()
-        raise RuntimeError(f"yt-dlp timed out for {youtube_video_id}")
+        raise RuntimeError(
+            f"yt-dlp did not exit after stream close: {youtube_video_id}"
+        )
+    finally:
+        watchdog.stop()
+        watchdog.join(timeout=10)
+        # Belt and suspenders: never leave yt-dlp/aria2c running if we bail out
+        # for any reason the loop above didn't handle (e.g. a Celery time-limit
+        # signal raising through the reader).
+        if process.poll() is None:
+            _kill_process_group(process)
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                pass
+
+    if watchdog.reason == "cancelled":
+        _cleanup_partial_files(output_dir, youtube_video_id)
+        raise DownloadCancelled(f"Download cancelled for {youtube_video_id}")
+    if watchdog.reason == "no_output":
+        _cleanup_partial_files(output_dir, youtube_video_id)
+        raise RuntimeError(
+            f"Download stalled (no output for {NO_OUTPUT_TIMEOUT_SECONDS}s): "
+            f"{youtube_video_id}"
+        )
+    if watchdog.reason == "deadline":
+        _cleanup_partial_files(output_dir, youtube_video_id)
+        raise RuntimeError(
+            f"Download exceeded {OVERALL_DEADLINE_SECONDS}s deadline: "
+            f"{youtube_video_id}"
+        )
 
     if process.returncode != 0:
         logger.error("yt-dlp failed for %s: %s", youtube_video_id, last_line)

--- a/app/services/download_reaper.py
+++ b/app/services/download_reaper.py
@@ -1,0 +1,77 @@
+"""Self-healing for downloads stranded by a crashed or killed worker.
+
+A worker that dies mid-download (OOM kill, container restart, SIGKILL) leaves
+its Video row stuck in DOWNLOADING or CANCELLING forever: the in-process
+watchdog and Celery time limits can't fire because the process is simply gone.
+The reaper detects these rows by a stale ``download_heartbeat_at`` and resets
+them so they can run again (DOWNLOADING) or settle (CANCELLING).
+"""
+
+import logging
+from datetime import datetime, timedelta
+
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from app.models.video import Video
+from app.utils.time import utcnow_naive
+
+logger = logging.getLogger(__name__)
+
+# How long a DOWNLOADING/CANCELLING row may go without a heartbeat before it is
+# treated as stranded. A healthy download refreshes its heartbeat on yt-dlp
+# output and only goes quiet during the brief post-download merge, so the worst
+# healthy gap is ~NO_OUTPUT_TIMEOUT_SECONDS (300s). This sits well above that to
+# avoid reaping a live download, while still recovering a crash within the hour.
+STUCK_DOWNLOAD_THRESHOLD_SECONDS = 1800  # 30 minutes
+
+
+def reap_stuck_downloads(db: Session, now: datetime | None = None) -> dict:
+    """Reset rows stranded by a dead worker. Returns a summary dict.
+
+    * DOWNLOADING -> PENDING and returned in ``requeue_ids`` so the caller can
+      re-enqueue the download (the worker start guard skips DOWNLOADING, so the
+      row must be PENDING again to be retried).
+    * CANCELLING -> CATALOGED: the cancel can never be confirmed by the dead
+      worker, so honor it and make the row re-downloadable.
+
+    The function performs no Celery I/O so it stays unit-testable; re-enqueueing
+    is left to the task wrapper.
+    """
+    now = now or utcnow_naive()
+    cutoff = now - timedelta(seconds=STUCK_DOWNLOAD_THRESHOLD_SECONDS)
+
+    stmt = select(Video).where(
+        Video.status.in_(("DOWNLOADING", "CANCELLING")),
+        or_(
+            Video.download_heartbeat_at.is_(None),
+            Video.download_heartbeat_at < cutoff,
+        ),
+    )
+    stuck = db.execute(stmt).scalars().all()
+
+    requeue_ids: list[str] = []
+    reset_cancelling = 0
+    for video in stuck:
+        if video.status == "CANCELLING":
+            video.status = "CATALOGED"
+            reset_cancelling += 1
+        else:  # DOWNLOADING
+            video.status = "PENDING"
+            requeue_ids.append(video.id)
+
+    if stuck:
+        db.commit()
+        logger.warning(
+            "Reaped %d stranded download(s): %d DOWNLOADING->PENDING, "
+            "%d CANCELLING->CATALOGED",
+            len(stuck),
+            len(requeue_ids),
+            reset_cancelling,
+        )
+
+    return {
+        "requeue_ids": requeue_ids,
+        "reset_downloading": len(requeue_ids),
+        "reset_cancelling": reset_cancelling,
+    }

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -34,4 +34,11 @@ celery_app.conf.beat_schedule = {
         "task": "app.tasks.download_tasks.refresh_stale_channel_metadata_task",
         "schedule": settings.metadata_refresh_interval_hours * 3600,
     },
+    # Self-heal downloads stranded by a crashed worker. Frequent and cheap (a
+    # single indexed query); recovery latency is this interval plus the reaper's
+    # staleness threshold.
+    "reap-stuck-downloads": {
+        "task": "app.tasks.download_tasks.reap_stuck_downloads_task",
+        "schedule": 300,  # every 5 minutes
+    },
 }

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -1,8 +1,10 @@
 import logging
 import os
+import time
 from datetime import datetime
 
-from sqlalchemy import create_engine, select
+from celery.signals import worker_ready
+from sqlalchemy import create_engine, select, update
 from sqlalchemy.orm import Session, sessionmaker
 
 from app.config import settings
@@ -17,10 +19,12 @@ from app.services.channel_poller import (
     refresh_stale_channel_metadata,
 )
 from app.services.download_manager import (
+    OVERALL_DEADLINE_SECONDS,
     DownloadCancelled,
     download_preview,
     download_video,
 )
+from app.services.download_reaper import reap_stuck_downloads
 from app.utils.time import utcnow_naive
 from app.services.progress_broadcaster import (
     publish_download_complete,
@@ -29,6 +33,11 @@ from app.services.progress_broadcaster import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Throttle how often the worker writes a download heartbeat to the DB. yt-dlp
+# emits output far more often than this; we only need a periodic liveness mark
+# for the reaper, not a write per line.
+HEARTBEAT_WRITE_INTERVAL_SECONDS = 30.0
 
 # Synchronous engine for Celery tasks
 _engine = create_engine(
@@ -120,6 +129,12 @@ def refresh_stale_channel_metadata_task(self) -> dict:
     autoretry_for=(RuntimeError,),
     retry_backoff=True,
     retry_backoff_max=600,
+    # Backstop for a task the in-process watchdog somehow can't unstick (e.g. a
+    # hang in our own code rather than yt-dlp). Sits just above the download
+    # watchdog's overall deadline so the watchdog normally fires first and can
+    # clean up; the soft limit raises a catchable error, the hard limit kills.
+    soft_time_limit=OVERALL_DEADLINE_SECONDS + 300,
+    time_limit=OVERALL_DEADLINE_SECONDS + 420,
 )
 def download_video_task(
     self,
@@ -167,8 +182,10 @@ def download_video_task(
                 os.remove(old_path)
                 logger.info("Removed old file for re-download: %s", old_path)
 
-        # Transition to DOWNLOADING
+        # Transition to DOWNLOADING and stamp the initial heartbeat so the
+        # reaper has a fresh liveness mark from the moment the row goes active.
         video.status = "DOWNLOADING"
+        video.download_heartbeat_at = utcnow_naive()
         db.commit()
 
         # Build progress callback if we know who triggered the download
@@ -192,6 +209,32 @@ def download_video_task(
             finally:
                 check_db.close()
 
+        last_heartbeat = [time.monotonic()]
+
+        def _heartbeat() -> None:
+            """Refresh the DB heartbeat so a crashed worker becomes detectable.
+
+            Uses its own short-lived session to avoid disturbing the task's main
+            transaction, and is throttled so a chatty download isn't a write
+            storm.
+            """
+            now_m = time.monotonic()
+            if now_m - last_heartbeat[0] < HEARTBEAT_WRITE_INTERVAL_SECONDS:
+                return
+            last_heartbeat[0] = now_m
+            hb_db = _get_sync_db()
+            try:
+                hb_db.execute(
+                    update(Video)
+                    .where(Video.id == video_id)
+                    .values(download_heartbeat_at=utcnow_naive())
+                )
+                hb_db.commit()
+            except Exception:
+                logger.debug("Heartbeat update failed for video %s", video_id)
+            finally:
+                hb_db.close()
+
         # Perform the download
         result = download_video(
             youtube_video_id=video.youtube_video_id,
@@ -199,6 +242,7 @@ def download_video_task(
             quality=quality or settings.media_quality,
             progress_callback=progress_cb,
             cancel_check=_is_cancelled,
+            heartbeat_callback=_heartbeat,
         )
 
         # Update video record with results
@@ -357,3 +401,39 @@ def download_preview_task(self, video_id: str, user_id: str) -> dict:
         raise exc
     finally:
         db.close()
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.reap_stuck_downloads_task",
+    bind=True,
+    max_retries=0,
+)
+def reap_stuck_downloads_task(self) -> dict:
+    """Recover downloads stranded by a crashed/killed worker.
+
+    Runs periodically (Celery beat) and once on worker startup. Resets stale
+    DOWNLOADING rows to PENDING and re-enqueues them, and settles stale
+    CANCELLING rows to CATALOGED.
+    """
+    db = _get_sync_db()
+    try:
+        result = reap_stuck_downloads(db)
+    except Exception:
+        logger.exception("Error in reap_stuck_downloads_task")
+        return {"status": "error"}
+    finally:
+        db.close()
+
+    for video_id in result["requeue_ids"]:
+        download_video_task.delay(video_id)
+
+    return {"status": "ok", **result}
+
+
+@worker_ready.connect
+def _reap_on_worker_startup(**_kwargs: object) -> None:
+    """On worker boot, recover anything a previous (crashed) worker stranded."""
+    try:
+        reap_stuck_downloads_task.delay()
+    except Exception:
+        logger.exception("Failed to schedule startup download reap")

--- a/tests/test_download_lifecycle.py
+++ b/tests/test_download_lifecycle.py
@@ -1,0 +1,235 @@
+"""Download reliability: watchdog, crash reaper, and per-user cancel (#31/#32)."""
+
+import contextlib
+import subprocess
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.database import async_session_factory
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from app.services import download_manager
+from app.services.download_manager import DownloadCancelled, download_video
+from app.services.download_reaper import (
+    STUCK_DOWNLOAD_THRESHOLD_SECONDS,
+    reap_stuck_downloads,
+)
+from app.tasks.download_tasks import _get_sync_db
+from app.utils.time import utcnow_naive
+from tests.helpers import seed_channel, seed_ref, seed_video
+
+
+# --- Task 1: download watchdog (silent-hang detection) ---------------------
+
+
+def _patch_command_to(monkeypatch, tmp_path, argv: list[str]) -> dict:
+    """Make download_video spawn ``argv`` instead of yt-dlp, returning a box
+    that captures the spawned process for assertions."""
+    monkeypatch.setattr(download_manager.settings, "media_path", str(tmp_path))
+    monkeypatch.setattr(download_manager, "WATCHDOG_POLL_INTERVAL_SECONDS", 0.05)
+    spawned: dict = {}
+    real_popen = subprocess.Popen
+
+    def fake_popen(cmd, **kwargs):
+        proc = real_popen(argv, **kwargs)
+        spawned["proc"] = proc
+        return proc
+
+    monkeypatch.setattr(download_manager.subprocess, "Popen", fake_popen)
+    return spawned
+
+
+def test_watchdog_kills_silently_hung_download(monkeypatch, tmp_path):
+    # A download that emits no output and never exits must be killed and the
+    # call must fail — the bug was that the post-loop wait() never ran on a hang.
+    monkeypatch.setattr(download_manager, "NO_OUTPUT_TIMEOUT_SECONDS", 0.3)
+    spawned = _patch_command_to(monkeypatch, tmp_path, ["sleep", "60"])
+
+    with pytest.raises(RuntimeError, match="stalled"):
+        download_video("vid123", "test-slug")
+
+    assert spawned["proc"].poll() is not None  # process was killed, not leaked
+
+
+def test_watchdog_honors_cancel_during_silent_hang(monkeypatch, tmp_path):
+    # Cancellation must work even when the process produces no output (the old
+    # per-line cancel check could never fire during a silent hang).
+    monkeypatch.setattr(download_manager, "NO_OUTPUT_TIMEOUT_SECONDS", 100.0)
+    spawned = _patch_command_to(monkeypatch, tmp_path, ["sleep", "60"])
+
+    with pytest.raises(DownloadCancelled):
+        download_video("vid123", "test-slug", cancel_check=lambda: True)
+
+    assert spawned["proc"].poll() is not None
+
+
+# --- Task 1: terminal failure path -----------------------------------------
+
+
+@pytest.fixture
+def eager_celery(monkeypatch):
+    from app.tasks.celery_app import celery_app
+
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", True)
+    monkeypatch.setattr(celery_app.conf, "task_eager_propagates", True)
+    return celery_app
+
+
+@pytest.mark.asyncio
+async def test_download_task_marks_failed_when_download_stalls(
+    client, make_user, monkeypatch, eager_celery
+):
+    await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="PENDING")
+    vid = video.id
+
+    import app.tasks.download_tasks as dt
+
+    def stalled(**kwargs):
+        raise RuntimeError("Download stalled (no output for 300s): x")
+
+    monkeypatch.setattr(dt, "download_video", stalled)
+    # No retries left -> the stall is terminal and the row must end FAILED.
+    monkeypatch.setattr(dt.download_video_task, "max_retries", 0)
+
+    with contextlib.suppress(Exception):
+        dt.download_video_task.delay(vid)
+
+    async with async_session_factory() as db:
+        status = (
+            await db.execute(select(Video.status).where(Video.id == vid))
+        ).scalar_one()
+    assert status == "FAILED"
+
+
+# --- Task 1: crash reaper ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reaper_resets_stranded_rows_and_leaves_fresh(client, make_user):
+    await make_user()
+    now = utcnow_naive()
+    stale = now - timedelta(seconds=STUCK_DOWNLOAD_THRESHOLD_SECONDS + 60)
+
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        stale_dl = await seed_video(db, channel, status="DOWNLOADING")
+        stale_cancel = await seed_video(db, channel, status="CANCELLING")
+        fresh_dl = await seed_video(db, channel, status="DOWNLOADING")
+        null_dl = await seed_video(db, channel, status="DOWNLOADING")
+        stale_dl.download_heartbeat_at = stale
+        stale_cancel.download_heartbeat_at = stale
+        fresh_dl.download_heartbeat_at = now
+        null_dl.download_heartbeat_at = None  # predates the column / never beat
+        await db.commit()
+        ids = {
+            "stale_dl": stale_dl.id,
+            "stale_cancel": stale_cancel.id,
+            "fresh_dl": fresh_dl.id,
+            "null_dl": null_dl.id,
+        }
+
+    # The reaper runs in Celery with a sync session, like the real task.
+    sync_db = _get_sync_db()
+    try:
+        result = reap_stuck_downloads(sync_db)
+    finally:
+        sync_db.close()
+
+    assert set(result["requeue_ids"]) == {ids["stale_dl"], ids["null_dl"]}
+    assert result["reset_cancelling"] == 1
+
+    async with async_session_factory() as db:
+        rows = (await db.execute(select(Video.id, Video.status))).all()
+    status_by_id = dict(rows)
+    assert status_by_id[ids["stale_dl"]] == "PENDING"
+    assert status_by_id[ids["null_dl"]] == "PENDING"
+    assert status_by_id[ids["stale_cancel"]] == "CATALOGED"
+    assert status_by_id[ids["fresh_dl"]] == "DOWNLOADING"  # live download untouched
+
+
+# --- Task 2: per-user cancel ref-counting -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_by_one_subscriber_does_not_stop_shared_download(
+    client, make_user
+):
+    user_a, headers_a = await make_user("A")
+    user_b, headers_b = await make_user("B")
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="DOWNLOADING")
+        await seed_ref(db, user_a["id"], video.id)
+        await seed_ref(db, user_b["id"], video.id)
+    vid = video.id
+
+    # A cancels: B still wants it, so the download keeps running.
+    resp = await client.post(f"/api/videos/{vid}/cancel", headers=headers_a)
+    assert resp.status_code == 200
+    assert resp.json()["stopped"] is False
+
+    async with async_session_factory() as db:
+        status = (
+            await db.execute(select(Video.status).where(Video.id == vid))
+        ).scalar_one()
+        a_ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user_a["id"],
+                    UserVideoRef.video_id == vid,
+                )
+            )
+        ).scalar_one()
+        b_ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user_b["id"],
+                    UserVideoRef.video_id == vid,
+                )
+            )
+        ).scalar_one()
+    assert status == "DOWNLOADING"  # B's download is untouched
+    assert a_ref.removed_at is not None  # A's intent was dropped
+    assert b_ref.removed_at is None  # B's intent survives
+
+    # B cancels too: nobody is left, so the shared download is torn down.
+    resp = await client.post(f"/api/videos/{vid}/cancel", headers=headers_b)
+    assert resp.status_code == 200
+    assert resp.json()["stopped"] is True
+
+    async with async_session_factory() as db:
+        status = (
+            await db.execute(select(Video.status).where(Video.id == vid))
+        ).scalar_one()
+    assert status == "CANCELLING"
+
+
+@pytest.mark.asyncio
+async def test_trigger_download_registers_active_ref(client, make_user, monkeypatch):
+    monkeypatch.setattr("app.api.videos.download_video_task.delay", MagicMock())
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+    vid = video.id
+
+    resp = await client.post(f"/api/videos/{vid}/download", headers=headers)
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        ref = (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user["id"],
+                    UserVideoRef.video_id == vid,
+                    UserVideoRef.removed_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+    assert ref is not None


### PR DESCRIPTION
Two backend download-reliability fixes (roadmap NEXT tier).

Fixes #31
Fixes #32

## #31 — Self-healing downloads
Root cause: the stdout read loop only called `process.wait(timeout)` *after* it exited, so a silent hang (process alive, socket dead, no output, no EOF) blocked the worker forever and the per-line cancel check couldn't fire. A crashed worker also stranded the row in DOWNLOADING indefinitely.

- **Watchdog thread** (`download_manager.py`) runs beside the reader and kills the process group on: no output for `NO_OUTPUT_TIMEOUT_SECONDS` (300s), runtime past `OVERALL_DEADLINE_SECONDS` (4h), or `cancel_check()` → True (so **cancel now works mid-hang**). Killing closes the pipe, unblocking the reader, which raises `RuntimeError` (stall/deadline) or `DownloadCancelled`. A `finally` always reaps the child.
- **Celery `soft_time_limit`/`time_limit`** sit just above the watchdog as a coarse backstop.
- **Heartbeat + reaper**: new `videos.download_heartbeat_at` column (stamped atomically with the DOWNLOADING transition, refreshed ~every 30s from yt-dlp output); `reap_stuck_downloads` resets rows whose heartbeat is stale > 30min (DOWNLOADING→PENDING + re-enqueue, CANCELLING→CATALOGED). Runs on `worker_ready` and every 5min via beat, so a crashed worker self-heals.
- Migration `007_download_heartbeat`.

## #32 — Per-user cancel/re-trigger ref-counting
Cancel previously mutated the shared `Video.status` with no ownership check, so one user's Cancel killed a download others still wanted. Built on the existing `UserVideoRef` (it *is* the reference count — no new table):

- **cancel_download**: drops only the caller's active ref; if any active refs remain, returns `{stopped: false}` **without touching `Video.status`** (covers the scheduler, which downloads on subscribers' behalf); only when none remain does it truly cancel (PENDING→CATALOGED, DOWNLOADING→CANCELLING). Keeps the CANCELLING escape-hatch and orphan cleanup.
- **trigger_download**: registers the caller's ref up front (idempotent upsert), symmetric with cancel.

Did not modify community PRs #56/#59/#66 (they add no ref-counting).

## Verification (local)
- `pytest -q` → **86 passed** (+6 new in `test_download_lifecycle.py`: watchdog kills a silent hang; cancel honored mid-hang; terminal stall → FAILED; reaper resets stranded rows; two-subscriber cancel keeps B's download alive then truly cancels on the last ref drop; trigger registers a ref).
- `alembic upgrade head` / `downgrade -1` round-trip on a throwaway DB.
- `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY