### PR TITLE
feat: full-text search across channels and videos

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -32,6 +32,7 @@ from app.tasks.download_tasks import (
     poll_all_channels_task,
     poll_channel_task,
 )
+from app.utils.search import escape_like
 
 logger = logging.getLogger(__name__)
 
@@ -85,10 +86,17 @@ async def _ensure_refs_for_channel(
 
 @router.get("", response_model=list[ChannelOut])
 async def list_channels(
+    q: str | None = Query(
+        None, description="Filter by channel name (case-insensitive)"
+    ),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[ChannelOut]:
-    result = await db.execute(select(Channel).order_by(Channel.name))
+    stmt = select(Channel)
+    if q and q.strip():
+        pattern = f"%{escape_like(q.strip())}%"
+        stmt = stmt.where(Channel.name.ilike(pattern, escape="\\"))
+    result = await db.execute(stmt.order_by(Channel.name))
     channels = result.scalars().all()
 
     # Per-channel video counts in a single GROUP BY query

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -3,9 +3,9 @@ import logging
 import os
 from datetime import timedelta
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import Response
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -13,14 +13,23 @@ from sqlalchemy.orm import selectinload
 from app.api.auth import get_current_user, validate_token
 from app.config import settings
 from app.database import get_db
+from app.models.channel import Channel
 from app.models.user import User
 from app.models.user_video_ref import UserVideoRef
 from app.models.video import Video
-from app.schemas.video import DownloadRequest, VideoDetail, VideoOut, VideoProgress
+from app.schemas.video import (
+    DownloadRequest,
+    VideoDetail,
+    VideoOut,
+    VideoProgress,
+    VideoSearchPage,
+)
 from app.services.media_server import build_media_response
 from app.services.progress_broadcaster import publish_progress_updated
 from app.services.storage import check_and_delete_orphan
 from app.tasks.download_tasks import download_preview_task, download_video_task
+from app.utils.pagination import decode_cursor, encode_cursor
+from app.utils.search import escape_like
 from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/videos", tags=["videos"])
@@ -47,6 +56,108 @@ async def _ensure_active_ref(db: AsyncSession, user_id: str, video_id: str) -> N
     )
     await db.execute(stmt)
     await db.commit()
+
+
+@router.get("", response_model=VideoSearchPage)
+async def search_videos(
+    q: str | None = Query(None, description="Match video title or channel name"),
+    status: str | None = Query(None, description="Exact video status"),
+    watched: bool | None = Query(None, description="Filter by watched state"),
+    channel_id: str | None = Query(None),
+    cursor: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> VideoSearchPage:
+    """Search the caller's video library by title and/or channel name.
+
+    Scoped to the user's active refs (like the feed endpoints), so results are
+    only videos the user holds. An empty/absent ``q`` lists the whole library
+    (subject to the other filters). Ordered newest-first with cursor pagination.
+    """
+    sort_key = func.coalesce(Video.uploaded_at, Video.created_at)
+
+    filters = [
+        UserVideoRef.user_id == user.id,
+        UserVideoRef.removed_at.is_(None),
+    ]
+    if q and q.strip():
+        pattern = f"%{escape_like(q.strip())}%"
+        filters.append(
+            or_(
+                Video.title.ilike(pattern, escape="\\"),
+                Channel.name.ilike(pattern, escape="\\"),
+            )
+        )
+    if status:
+        filters.append(Video.status == status)
+    if watched is not None:
+        filters.append(UserVideoRef.is_watched == watched)
+    if channel_id:
+        filters.append(Video.channel_id == channel_id)
+
+    total = (
+        await db.scalar(
+            select(func.count())
+            .select_from(UserVideoRef)
+            .join(Video, UserVideoRef.video_id == Video.id)
+            .join(Channel, Video.channel_id == Channel.id)
+            .where(*filters)
+        )
+        or 0
+    )
+
+    page_filters = list(filters)
+    if cursor:
+        decoded = decode_cursor(cursor)
+        if decoded is None:
+            raise HTTPException(status_code=400, detail="Invalid cursor")
+        cur_sort, cur_id = decoded
+        page_filters.append(
+            or_(sort_key < cur_sort, and_(sort_key == cur_sort, Video.id < cur_id))
+        )
+
+    # Fetch one extra row to detect whether another page exists.
+    result = await db.execute(
+        select(UserVideoRef, Video, Channel)
+        .join(Video, UserVideoRef.video_id == Video.id)
+        .join(Channel, Video.channel_id == Channel.id)
+        .where(*page_filters)
+        .order_by(sort_key.desc(), Video.id.desc())
+        .limit(limit + 1)
+    )
+    rows = result.all()
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+
+    items = [
+        VideoOut(
+            id=video.id,
+            youtube_video_id=video.youtube_video_id,
+            channel_id=video.channel_id,
+            title=video.title,
+            duration_seconds=video.duration_seconds,
+            uploaded_at=video.uploaded_at,
+            file_size_bytes=video.file_size_bytes or 0,
+            status=video.status,
+            preview_status=video.preview_status,
+            thumbnail_url=f"/data/thumbnails/{video.youtube_video_id}.jpg",
+            watch_position_seconds=ref.watch_position_seconds,
+            is_watched=ref.is_watched,
+            last_watched_at=ref.last_watched_at,
+            channel_name=channel.name,
+        )
+        for ref, video, channel in rows
+    ]
+
+    next_cursor = None
+    if has_more and rows:
+        _, last_video, _ = rows[-1]
+        next_cursor = encode_cursor(
+            last_video.uploaded_at or last_video.created_at, last_video.id
+        )
+
+    return VideoSearchPage(items=items, total=total, next_cursor=next_cursor)
 
 
 @router.get("/downloads", response_model=list[VideoOut])

--- a/app/schemas/video.py
+++ b/app/schemas/video.py
@@ -43,3 +43,15 @@ class VideoPagination(BaseModel):
     total: int
     page: int
     per_page: int
+
+
+class VideoSearchPage(BaseModel):
+    """Cursor-paginated search results.
+
+    ``next_cursor`` is an opaque token for the next page, or ``None`` on the last
+    page. ``total`` is the full count of matching rows, independent of the cursor.
+    """
+
+    items: list[VideoOut]
+    total: int
+    next_cursor: str | None = None

--- a/app/utils/pagination.py
+++ b/app/utils/pagination.py
@@ -1,0 +1,31 @@
+"""Opaque cursor helpers for keyset pagination.
+
+Video listings order by ``(coalesce(uploaded_at, created_at) DESC, id DESC)``.
+A cursor encodes the sort value and id of the last row on a page so the next
+page can resume with a keyset predicate instead of an OFFSET (which degrades on
+deep pages). Tokens are base64 of ``"<iso-datetime>|<id>"`` — opaque to clients,
+trivially decodable here.
+"""
+
+import base64
+from datetime import datetime
+
+
+def encode_cursor(sort_value: datetime, item_id: str) -> str:
+    """Encode the (sort_value, id) of the last row on a page into a token."""
+    raw = f"{sort_value.isoformat()}|{item_id}"
+    return base64.urlsafe_b64encode(raw.encode()).decode()
+
+
+def decode_cursor(token: str) -> tuple[datetime, str] | None:
+    """Decode a cursor token, or return None if it is malformed.
+
+    ``id`` is a UUID and the datetime is ISO-8601, so neither contains the ``|``
+    separator; splitting once is unambiguous.
+    """
+    try:
+        raw = base64.urlsafe_b64decode(token.encode()).decode()
+        sort_str, item_id = raw.split("|", 1)
+        return datetime.fromisoformat(sort_str), item_id
+    except (ValueError, TypeError):
+        return None

--- a/app/utils/search.py
+++ b/app/utils/search.py
@@ -1,0 +1,12 @@
+"""Helpers for the case-insensitive LIKE search used by the listing endpoints."""
+
+
+def escape_like(value: str) -> str:
+    """Escape LIKE wildcards so user input is matched literally.
+
+    Without this a user typing ``%`` or ``_`` would inject wildcards. Pair the
+    result with an explicit escape char, e.g.::
+
+        col.ilike(f"%{escape_like(q)}%", escape="\\\\")
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,257 @@
+"""Search + cursor-pagination tests for channels and videos."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.database import async_session_factory
+from app.utils.pagination import decode_cursor, encode_cursor
+from app.utils.search import escape_like
+from tests.helpers import seed_channel, seed_ref, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- channel name search -----------------------------------------------------
+
+
+async def test_channels_filter_by_name_case_insensitive(client, make_user):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        await seed_channel(db, name="Linus Tech Tips", youtube_channel_id="UCltt")
+        await seed_channel(db, name="Marques Brownlee", youtube_channel_id="UCmkbhd")
+
+    resp = await client.get("/api/channels", params={"q": "linus"}, headers=headers)
+    assert resp.status_code == 200
+    names = [c["name"] for c in resp.json()]
+    assert names == ["Linus Tech Tips"]
+
+    # Case-insensitive, substring anywhere in the name.
+    resp = await client.get("/api/channels", params={"q": "BROWN"}, headers=headers)
+    assert [c["name"] for c in resp.json()] == ["Marques Brownlee"]
+
+
+async def test_channels_no_query_returns_all(client, make_user):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        await seed_channel(db, name="Alpha", youtube_channel_id="UCa")
+        await seed_channel(db, name="Beta", youtube_channel_id="UCb")
+
+    resp = await client.get("/api/channels", headers=headers)
+    assert resp.status_code == 200
+    assert sorted(c["name"] for c in resp.json()) == ["Alpha", "Beta"]
+
+
+async def test_channels_query_escapes_like_wildcards(client, make_user):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        await seed_channel(db, name="100% Cotton", youtube_channel_id="UC1")
+        await seed_channel(db, name="Plain Channel", youtube_channel_id="UC2")
+
+    # A literal "%" must not behave as a wildcard matching everything.
+    resp = await client.get("/api/channels", params={"q": "%"}, headers=headers)
+    assert [c["name"] for c in resp.json()] == ["100% Cotton"]
+
+
+# --- video search ------------------------------------------------------------
+
+
+async def test_video_search_by_title(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        match = await seed_video(db, channel, title="Rust Programming Tutorial")
+        other = await seed_video(db, channel, title="Cooking with Gas")
+        await seed_ref(db, user["id"], match.id)
+        await seed_ref(db, user["id"], other.id)
+
+    resp = await client.get("/api/videos", params={"q": "rust"}, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert [v["title"] for v in body["items"]] == ["Rust Programming Tutorial"]
+    assert body["next_cursor"] is None
+
+
+async def test_video_search_matches_channel_name(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, name="The Rust Foundation")
+        video = await seed_video(db, channel, title="Unrelated Title")
+        await seed_ref(db, user["id"], video.id)
+
+    resp = await client.get("/api/videos", params={"q": "rust"}, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [v["id"] for v in body["items"]] == [video.id]
+    assert body["items"][0]["channel_name"] == "The Rust Foundation"
+
+
+async def test_video_search_scoped_to_user(client, make_user):
+    """Only the caller's active refs are searchable."""
+    user_a, headers_a = await make_user("A")
+    user_b, headers_b = await make_user("B")
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        owned = await seed_video(db, channel, title="Shared Topic A")
+        foreign = await seed_video(db, channel, title="Shared Topic B")
+        removed = await seed_video(db, channel, title="Shared Topic C")
+        await seed_ref(db, user_a["id"], owned.id)
+        await seed_ref(db, user_b["id"], foreign.id)
+        # A soft-deleted ref must not surface in A's results.
+        await seed_ref(db, user_a["id"], removed.id, removed_at=datetime(2026, 1, 1))
+
+    resp = await client.get("/api/videos", params={"q": "shared"}, headers=headers_a)
+    assert [v["title"] for v in resp.json()["items"]] == ["Shared Topic A"]
+
+
+async def test_video_search_empty_query_lists_library(client, make_user):
+    """Absent/blank q returns the whole library, not an error or empty list."""
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        v1 = await seed_video(db, channel, title="One")
+        v2 = await seed_video(db, channel, title="Two")
+        await seed_ref(db, user["id"], v1.id)
+        await seed_ref(db, user["id"], v2.id)
+
+    for params in ({}, {"q": ""}, {"q": "   "}):
+        resp = await client.get("/api/videos", params=params, headers=headers)
+        assert resp.status_code == 200, params
+        assert resp.json()["total"] == 2, params
+
+
+async def test_video_search_filters_status_watched_channel(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        ch1 = await seed_channel(db, youtube_channel_id="UCone")
+        ch2 = await seed_channel(db, youtube_channel_id="UCtwo")
+        complete = await seed_video(db, ch1, title="Done", status="COMPLETE")
+        cataloged = await seed_video(db, ch1, title="Todo", status="CATALOGED")
+        other_ch = await seed_video(db, ch2, title="Elsewhere", status="COMPLETE")
+        await seed_ref(db, user["id"], complete.id, is_watched=True)
+        await seed_ref(db, user["id"], cataloged.id, is_watched=False)
+        await seed_ref(db, user["id"], other_ch.id, is_watched=False)
+
+    # status filter
+    resp = await client.get(
+        "/api/videos", params={"status": "CATALOGED"}, headers=headers
+    )
+    assert [v["title"] for v in resp.json()["items"]] == ["Todo"]
+
+    # watched filter (per-user)
+    resp = await client.get("/api/videos", params={"watched": "true"}, headers=headers)
+    assert [v["title"] for v in resp.json()["items"]] == ["Done"]
+
+    resp = await client.get("/api/videos", params={"watched": "false"}, headers=headers)
+    assert sorted(v["title"] for v in resp.json()["items"]) == ["Elsewhere", "Todo"]
+
+    # channel_id filter
+    resp = await client.get(
+        "/api/videos", params={"channel_id": ch2.id}, headers=headers
+    )
+    assert [v["title"] for v in resp.json()["items"]] == ["Elsewhere"]
+
+
+async def test_video_search_pagination_cursor(client, make_user):
+    user, headers = await make_user()
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        # Five videos, strictly increasing upload time => deterministic order.
+        for i in range(5):
+            v = await seed_video(
+                db, channel, title=f"Ep {i}", uploaded_at=base + timedelta(hours=i)
+            )
+            await seed_ref(db, user["id"], v.id)
+
+    seen: list[str] = []
+    cursor = None
+    pages = 0
+    while True:
+        params = {"limit": 2}
+        if cursor:
+            params["cursor"] = cursor
+        resp = await client.get("/api/videos", params=params, headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 5  # total is stable across pages
+        seen.extend(v["title"] for v in body["items"])
+        cursor = body["next_cursor"]
+        pages += 1
+        if cursor is None:
+            break
+        assert pages < 10  # guard against an infinite loop
+
+    # Newest-first, every item exactly once.
+    assert seen == ["Ep 4", "Ep 3", "Ep 2", "Ep 1", "Ep 0"]
+    assert len(seen) == len(set(seen))
+
+
+async def test_video_search_invalid_cursor_returns_400(client, make_user):
+    _, headers = await make_user()
+    resp = await client.get(
+        "/api/videos", params={"cursor": "not-a-valid-cursor"}, headers=headers
+    )
+    assert resp.status_code == 400
+
+
+async def test_video_search_requires_auth(client):
+    resp = await client.get("/api/videos")
+    assert resp.status_code == 401
+
+
+# --- channel videos stay on offset pagination (unchanged contract) -----------
+
+
+async def test_channel_videos_offset_pagination_unchanged(client, make_user):
+    """GET /api/channels/{id}/videos keeps its original page/per_page contract."""
+    user, headers = await make_user()
+    base = datetime(2026, 2, 1, 8, 0, 0)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        for i in range(3):
+            await seed_video(
+                db, channel, title=f"V{i}", uploaded_at=base + timedelta(hours=i)
+            )
+
+    resp = await client.get(
+        f"/api/channels/{channel.id}/videos",
+        params={"page": 1, "per_page": 2},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 3
+    assert body["page"] == 1
+    assert body["per_page"] == 2
+    assert "next_cursor" not in body  # the cursor envelope is /api/videos-only
+    assert [v["title"] for v in body["items"]] == ["V2", "V1"]
+
+    resp = await client.get(
+        f"/api/channels/{channel.id}/videos",
+        params={"page": 2, "per_page": 2},
+        headers=headers,
+    )
+    body2 = resp.json()
+    assert body2["page"] == 2
+    assert [v["title"] for v in body2["items"]] == ["V0"]
+
+
+# --- cursor + escape helpers (unit) ------------------------------------------
+
+
+def test_cursor_roundtrip():
+    dt = datetime(2026, 6, 27, 13, 14, 15, 123456)
+    token = encode_cursor(dt, "abc-123")
+    assert decode_cursor(token) == (dt, "abc-123")
+
+
+def test_decode_cursor_rejects_garbage():
+    assert decode_cursor("@@@not-base64@@@") is None
+    assert decode_cursor("") is None
+
+
+def test_escape_like_neutralizes_wildcards():
+    assert escape_like("100%_x") == "100\\%\\_x"
+    assert escape_like("a\\b") == "a\\\\b"


### PR DESCRIPTION
Full-text search (roadmap LATER tier, #1). **Purely additive** — no migration, no model changes, and the existing `GET /api/channels/{id}/videos` contract is untouched (its diff vs main is empty), so current iOS/tvOS clients keep working.

## Endpoints
- `GET /api/channels?q=<str>` — optional case-insensitive name filter (input is LIKE-escaped so a literal `%` isn't a wildcard). Response unchanged: `list[ChannelOut]`.
- `GET /api/videos` — **new** search endpoint. Params: `q` (matches video title or channel name), `status`, `watched`, `channel_id`, `cursor`, `limit` (1–100, default 20). User-scoped to active refs; empty `q` lists the whole library; ordered newest-first. Response `VideoSearchPage`:
  ```
  { "items": VideoOut[], "total": int, "next_cursor": string | null }
  ```
  `next_cursor` is an opaque base64 token (`<iso-datetime>|<id>`) — pass back as `?cursor=`; `null` = last page; invalid cursor → 400.

## Implementation note
LIKE-based (not FTS5), deliberately: video search is user-scoped (joins `UserVideoRef`, so the candidate set is already tiny), results order by recency (FTS bm25 relevance would go unused), and FTS would need cross-table sync triggers duplicated in the test path — fragile for zero gain at personal-library scale. FTS5 *is* available if we ever need it.

## Verification (local)
- `pytest -q` → **127 passed** (+15 in `test_search.py`: channel/video search, case-insensitivity, wildcard-escape, user-scoping, filters, multi-page cursor walk, empty query, invalid cursor → 400, auth required; plus a test asserting channel-videos offset pagination is unchanged).
- `alembic upgrade head` / `downgrade -1` round-trip clean (head stays at 007 — no new migration).
- `ruff check` / `ruff format --check` clean.

Client search UIs (Flutter search field, tvOS Search surface) consume these in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY