### PR TITLE
fix: PIN brute-force defense — IP-scoped backoff + close user-existence oracle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,11 @@ CHECK_INTERVAL_MINUTES=60
 PUID=1000
 PGID=1000
 
+# Trust X-Forwarded-For when rate-limiting PIN attempts by client IP.
+# Enable ONLY when behind a single trusted reverse proxy that sets this header.
+# Leave false if clients can reach the app directly (they could forge it).
+TRUST_PROXY_HEADERS=false
+
 # Redis URL (internal; override only if using external Redis)
 REDIS_URL=redis://localhost:6379/0
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -2,15 +2,17 @@ import asyncio
 import hashlib
 import hmac
 import logging
+import math
 import os
 import secrets
 import time
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
 
 import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,11 +44,38 @@ _SCRYPT_P = 1
 # Refresh sessions.last_seen_at at most this often.
 _LAST_SEEN_REFRESH = timedelta(hours=1)
 
-# In-memory PIN rate limiting: after N consecutive failures, lock for a bit.
-_PIN_MAX_FAILURES = 5
-_PIN_LOCKOUT_SECONDS = 30.0
-_pin_failures: dict[str, int] = {}
-_pin_lockouts: dict[str, float] = {}
+# --- PIN brute-force throttle ----------------------------------------------
+#
+# PIN attempts are rate-limited per (client IP, target user) with exponential
+# backoff. Keying on the IP — not the user id alone — is deliberate: the old
+# per-user lock could be tripped by ANYONE who knew a user_id, and /profiles
+# lists every user_id, so an attacker could lock a household member out at will
+# (an account-lockout DoS). Folding the user_id into the key as well keeps a
+# shared household device able to switch to another profile while one is backed
+# off, and still throttles guessing of any single PIN. Because attacker and
+# victim have different IPs, an attacker can no longer lock out the victim.
+#
+# The store is in-process: counters are lost on restart and NOT shared across
+# workers. Kept this way on purpose so tests / local dev need no running Redis.
+# TODO: back this with the existing Redis (settings.redis_url) for multi-worker
+# coordination and restart persistence once a Redis is guaranteed in all envs.
+_PIN_MAX_FAILURES = 5  # failures allowed before the first lockout kicks in
+_PIN_LOCKOUT_BASE_SECONDS = 30.0  # first lockout window; doubles each failure
+_PIN_LOCKOUT_MAX_SECONDS = 3600.0  # cap on the exponential backoff (1 hour)
+_PIN_FAILURE_RESET_SECONDS = 3600.0  # forget an idle key's history after this
+_PIN_THROTTLE_SOFT_CAP = 1024  # prune stale keys once the map grows past this
+
+
+@dataclass
+class _PinThrottle:
+    """Per-key brute-force state. Times are ``time.monotonic`` seconds."""
+
+    failures: int = 0
+    locked_until: float = 0.0  # 0.0 means not currently locked
+    last_failure: float = 0.0
+
+
+_pin_throttle: dict[str, _PinThrottle] = {}
 
 
 def _hash_pin(pin: str) -> str:
@@ -56,6 +85,13 @@ def _hash_pin(pin: str) -> str:
         pin.encode(), salt=salt, n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P
     )
     return f"scrypt${salt.hex()}${digest.hex()}"
+
+
+# A valid scrypt hash of a random, unguessable secret. When /select is given a
+# user_id that does not exist we verify the supplied PIN against this instead of
+# returning early, so a missing user costs the same scrypt work — and yields the
+# same response — as a wrong PIN. It can never match a real attempt.
+_DUMMY_PIN_HASH = _hash_pin(secrets.token_urlsafe(32))
 
 
 def _is_legacy_pin_hash(stored: str) -> bool:
@@ -87,30 +123,96 @@ def _hash_token(token: str) -> str:
     return hashlib.sha256(token.encode()).hexdigest()
 
 
-def _check_pin_rate_limit(user_id: str) -> None:
-    """Raise 429 while the user is locked out from PIN attempts."""
-    locked_until = _pin_lockouts.get(user_id)
-    if locked_until is None:
+def _client_ip(request: Request) -> str:
+    """Best-effort client IP used to key PIN rate limiting.
+
+    Defaults to the real TCP peer (``request.client.host``), which the client
+    cannot forge. Only when ``settings.trust_proxy_headers`` is set — i.e. the
+    operator has put NullFeed behind a single trusted reverse proxy that appends
+    ``X-Forwarded-For`` — do we use the rightmost XFF entry, which is the address
+    that trusted proxy actually observed. The leftmost entries are never trusted
+    because a client can forge them. Do NOT enable ``trust_proxy_headers`` if
+    clients can reach the app directly: they could then spoof their rate-limit
+    key and evade the throttle.
+    """
+    if settings.trust_proxy_headers:
+        forwarded = request.headers.get("x-forwarded-for", "")
+        hops = [hop.strip() for hop in forwarded.split(",") if hop.strip()]
+        if hops:
+            return hops[-1]
+    if request.client is not None:
+        return request.client.host
+    return "unknown"
+
+
+def _pin_rate_key(request: Request, user_id: str) -> str:
+    """Throttle key: client IP + target user_id (neither contains '|')."""
+    return f"{_client_ip(request)}|{user_id}"
+
+
+def _prune_pin_throttle(now: float) -> None:
+    """Drop long-idle entries so the map can't grow without bound (IP churn)."""
+    if len(_pin_throttle) <= _PIN_THROTTLE_SOFT_CAP:
         return
-    if time.monotonic() < locked_until:
+    stale = [
+        key
+        for key, state in _pin_throttle.items()
+        if now >= state.locked_until
+        and now - state.last_failure >= _PIN_FAILURE_RESET_SECONDS
+    ]
+    for key in stale:
+        _pin_throttle.pop(key, None)
+
+
+def _check_pin_rate_limit(key: str) -> None:
+    """Raise 429 (with Retry-After) while this key is in a backoff window."""
+    state = _pin_throttle.get(key)
+    if state is None:
+        return
+    now = time.monotonic()
+    if state.locked_until and now < state.locked_until:
+        retry_after = max(1, math.ceil(state.locked_until - now))
         raise HTTPException(
             status_code=429,
-            detail="Too many failed PIN attempts. Try again in 30 seconds.",
+            detail="Too many failed PIN attempts. Try again later.",
+            headers={"Retry-After": str(retry_after)},
         )
-    _pin_lockouts.pop(user_id, None)
-    _pin_failures.pop(user_id, None)
+    # The lockout (if any) has elapsed. Once a key has been idle long enough,
+    # forget it so honest users get a clean slate; otherwise keep the running
+    # failure count so continued abuse keeps escalating the backoff.
+    if now - state.last_failure >= _PIN_FAILURE_RESET_SECONDS:
+        _pin_throttle.pop(key, None)
 
 
-def _record_pin_failure(user_id: str) -> None:
-    count = _pin_failures.get(user_id, 0) + 1
-    _pin_failures[user_id] = count
-    if count >= _PIN_MAX_FAILURES:
-        _pin_lockouts[user_id] = time.monotonic() + _PIN_LOCKOUT_SECONDS
+def _record_pin_failure(key: str) -> None:
+    """Count a failed PIN attempt and (re)arm an exponential backoff lockout."""
+    now = time.monotonic()
+    state = _pin_throttle.setdefault(key, _PinThrottle())
+    state.failures += 1
+    state.last_failure = now
+    if state.failures >= _PIN_MAX_FAILURES:
+        backoff = min(
+            _PIN_LOCKOUT_BASE_SECONDS * 2 ** (state.failures - _PIN_MAX_FAILURES),
+            _PIN_LOCKOUT_MAX_SECONDS,
+        )
+        state.locked_until = now + backoff
+    _prune_pin_throttle(now)
 
 
-def _clear_pin_failures(user_id: str) -> None:
-    _pin_failures.pop(user_id, None)
-    _pin_lockouts.pop(user_id, None)
+def _reset_pin_throttle(key: str) -> None:
+    """Clear a single key's history (called after a correct PIN)."""
+    _pin_throttle.pop(key, None)
+
+
+def _reset_pin_throttle_for_user(user_id: str) -> None:
+    """Clear every IP's throttle for a user (PIN changed/removed or deleted).
+
+    Without this, an admin resetting a forgotten PIN would leave the locked-out
+    device backing off until the window elapses.
+    """
+    suffix = f"|{user_id}"
+    for key in [k for k in _pin_throttle if k.endswith(suffix)]:
+        _pin_throttle.pop(key, None)
 
 
 def _session_is_expired(session: Session, now: datetime) -> bool:
@@ -203,25 +305,40 @@ async def list_profiles(db: AsyncSession = Depends(get_db)) -> list[UserProfile]
 @router.post("/select", response_model=UserSession)
 async def select_profile(
     body: UserSelect,
+    request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> UserSession:
+    rate_key = _pin_rate_key(request, body.user_id)
+    _check_pin_rate_limit(rate_key)
+
     result = await db.execute(select(User).where(User.id == body.user_id))
     user = result.scalar_one_or_none()
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
 
-    if user.pin_hash:
-        _check_pin_rate_limit(user.id)
+    # A missing user is treated exactly like a PIN-protected user whose PIN can
+    # never match: same status, message, and scrypt cost, so /select can't be
+    # used as a user-existence/timing oracle. (PIN-less users that DO exist stay
+    # distinguishable, but that is inherent — they carry no secret — and is
+    # already public via /profiles.)
+    stored_hash = user.pin_hash if user is not None else _DUMMY_PIN_HASH
+
+    if stored_hash:
         if not body.pin:
             raise HTTPException(status_code=403, detail="PIN required")
-        if not _verify_pin(body.pin, user.pin_hash):
-            _record_pin_failure(user.id)
+        if not _verify_pin(body.pin, stored_hash):
+            _record_pin_failure(rate_key)
             raise HTTPException(status_code=403, detail="Incorrect PIN")
-        _clear_pin_failures(user.id)
+        _reset_pin_throttle(rate_key)
+        if user is None:
+            # _DUMMY_PIN_HASH must never verify; refuse defensively if it did.
+            raise HTTPException(status_code=403, detail="Incorrect PIN")
         # Upgrade legacy SHA-256 hashes to scrypt on successful verification.
-        if _is_legacy_pin_hash(user.pin_hash):
+        # (stored_hash is user.pin_hash here, narrowed to str by `if stored_hash`.)
+        if _is_legacy_pin_hash(stored_hash):
             user.pin_hash = _hash_pin(body.pin)
 
+    # Reached only for a PIN-less existing user or a verified PIN, so the user
+    # row is always present here.
+    assert user is not None
     token = secrets.token_urlsafe(32)
     db.add(Session(token_hash=_hash_token(token), user_id=user.id))
     await db.commit()
@@ -330,10 +447,10 @@ async def update_profile(
         target.avatar_url = body.avatar_url
     if body.remove_pin:
         target.pin_hash = None
-        _clear_pin_failures(target.id)
+        _reset_pin_throttle_for_user(target.id)
     elif body.pin is not None:
         target.pin_hash = _hash_pin(body.pin)
-        _clear_pin_failures(target.id)
+        _reset_pin_throttle_for_user(target.id)
 
     await db.commit()
     await db.refresh(target)
@@ -391,5 +508,5 @@ async def delete_profile(
         except Exception:
             logger.exception("Orphan cleanup failed for video %s", video_id)
 
-    _clear_pin_failures(user_id)
+    _reset_pin_throttle_for_user(user_id)
     return {"detail": "Profile deleted"}

--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,12 @@ class Settings(BaseSettings):
     session_absolute_ttl_days: int = 30
     session_idle_ttl_days: int = 14
 
+    # Trust X-Forwarded-For when deriving the client IP for PIN rate limiting.
+    # Enable ONLY when running behind a single trusted reverse proxy that sets
+    # this header; if clients can reach the app directly they could forge it to
+    # evade the throttle. Off by default -> the real socket peer is used.
+    trust_proxy_headers: bool = False
+
     # File permissions
     puid: int = 1000
     pgid: int = 1000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,7 @@ from app.models import Base
 def _reset_in_memory_state():
     """Clear per-process caches/counters that would leak between tests."""
     yield
-    auth_api._pin_failures.clear()
-    auth_api._pin_lockouts.clear()
+    auth_api._pin_throttle.clear()
     youtube_import._resolve_cache.clear()
     youtube_import._suggestions_cache.clear()
     websocket_api._connections.clear()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -9,6 +9,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 
+import app.api.auth as auth_api
 import app.services.youtube_import as youtube_import
 from app.api.auth import _hash_token
 from app.config import settings
@@ -127,22 +128,91 @@ async def test_legacy_sha256_pin_verifies_and_upgrades(client):
 
 
 async def test_pin_rate_limit_429_after_five_failures(client):
+    """A burst of wrong PINs from one IP eventually backs off with a 429."""
     resp = await client.post(
         "/api/auth/create", json={"display_name": "Locked", "pin": "1234"}
     )
     user_id = resp.json()["id"]
 
+    # Every request shares the test client's IP, so they land on one throttle
+    # key and accumulate toward the lockout threshold.
     for _ in range(5):
         resp = await client.post(
             "/api/auth/select", json={"user_id": user_id, "pin": "0000"}
         )
         assert resp.status_code == 403
 
-    # Even the correct PIN is rejected during the lockout window.
+    # Even the correct PIN is rejected during the lockout window, with a
+    # Retry-After hint for when to try again.
     resp = await client.post(
         "/api/auth/select", json={"user_id": user_id, "pin": "1234"}
     )
     assert resp.status_code == 429
+    assert int(resp.headers["Retry-After"]) > 0
+
+
+async def test_pin_lockout_is_scoped_to_client_ip(client):
+    """One IP's failures must not lock another IP out of the same profile."""
+    resp = await client.post(
+        "/api/auth/create", json={"display_name": "Shared", "pin": "1234"}
+    )
+    user_id = resp.json()["id"]
+
+    # The default client (127.0.0.1) trips its own lockout.
+    for _ in range(5):
+        r = await client.post(
+            "/api/auth/select", json={"user_id": user_id, "pin": "0000"}
+        )
+        assert r.status_code == 403
+    r = await client.post("/api/auth/select", json={"user_id": user_id, "pin": "1234"})
+    assert r.status_code == 429
+
+    # A request from a different source IP can still authenticate. (The old
+    # per-user lock would have rejected this — the account-lockout DoS.)
+    transport = ASGITransport(app=app, client=("203.0.113.9", 5555))
+    async with AsyncClient(transport=transport, base_url="http://test") as other_ip:
+        r = await other_ip.post(
+            "/api/auth/select", json={"user_id": user_id, "pin": "1234"}
+        )
+        assert r.status_code == 200
+        assert r.json()["token"]
+
+
+async def test_select_is_not_a_user_existence_oracle(client):
+    """A wrong PIN and an unknown user must be indistinguishable on /select."""
+    resp = await client.post(
+        "/api/auth/create", json={"display_name": "Real", "pin": "1234"}
+    )
+    real_id = resp.json()["id"]
+    ghost_id = str(uuid.uuid4())  # never created
+
+    # With a PIN supplied: wrong-PIN vs. unknown-user return identical bodies
+    # (same status + detail + code), so there is no 404 "User not found" leak.
+    wrong = await client.post(
+        "/api/auth/select", json={"user_id": real_id, "pin": "0000"}
+    )
+    ghost = await client.post(
+        "/api/auth/select", json={"user_id": ghost_id, "pin": "0000"}
+    )
+    assert wrong.status_code == ghost.status_code == 403
+    assert wrong.json() == ghost.json()
+
+    # With no PIN supplied: both look like a PIN-protected profile awaiting one.
+    wrong_np = await client.post("/api/auth/select", json={"user_id": real_id})
+    ghost_np = await client.post("/api/auth/select", json={"user_id": ghost_id})
+    assert wrong_np.status_code == ghost_np.status_code == 403
+    assert wrong_np.json() == ghost_np.json()
+
+    # Probing an unknown user is throttled exactly like a real one, so the
+    # endpoint can't be hammered to cheaply confirm non-existence.
+    probe_id = str(uuid.uuid4())
+    statuses = []
+    for _ in range(auth_api._PIN_MAX_FAILURES + 1):
+        r = await client.post(
+            "/api/auth/select", json={"user_id": probe_id, "pin": "0000"}
+        )
+        statuses.append(r.status_code)
+    assert 429 in statuses
 
 
 async def test_me_and_logout(client, make_user):

--- a/tests/test_pin_throttle.py
+++ b/tests/test_pin_throttle.py
@@ -1,0 +1,138 @@
+"""Unit tests for the in-process PIN brute-force throttle.
+
+These exercise the throttle helpers directly (no HTTP/event loop) so the clock
+can be driven deterministically via a patched ``time.monotonic``. The autouse
+``_reset_in_memory_state`` fixture in conftest clears the throttle map between
+tests.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+import app.api.auth as auth_api
+
+
+def _fake_request(host: str | None = "198.51.100.4", xff: str | None = None):
+    """A minimal stand-in for starlette's Request (only what _client_ip reads)."""
+    headers = {"x-forwarded-for": xff} if xff is not None else {}
+    client = SimpleNamespace(host=host) if host is not None else None
+    return SimpleNamespace(headers=headers, client=client)
+
+
+def test_client_ip_uses_socket_peer_by_default(monkeypatch):
+    monkeypatch.setattr(auth_api.settings, "trust_proxy_headers", False)
+    req = _fake_request(host="10.0.0.5", xff="1.1.1.1, 2.2.2.2")
+    # XFF is ignored unless a proxy is trusted, so a client can't forge its key.
+    assert auth_api._client_ip(req) == "10.0.0.5"
+
+
+def test_client_ip_trusts_rightmost_xff_when_enabled(monkeypatch):
+    monkeypatch.setattr(auth_api.settings, "trust_proxy_headers", True)
+    # The rightmost entry is what the trusted proxy observed; the leftmost ones
+    # are attacker-controllable and must never be used.
+    req = _fake_request(host="10.0.0.5", xff="1.1.1.1, 2.2.2.2, 3.3.3.3")
+    assert auth_api._client_ip(req) == "3.3.3.3"
+
+
+def test_client_ip_falls_back_when_no_peer(monkeypatch):
+    monkeypatch.setattr(auth_api.settings, "trust_proxy_headers", False)
+    assert auth_api._client_ip(_fake_request(host=None)) == "unknown"
+
+
+def test_pin_rate_key_combines_ip_and_user():
+    req = _fake_request(host="10.0.0.5")
+    assert auth_api._pin_rate_key(req, "user-123") == "10.0.0.5|user-123"
+
+
+def test_backoff_is_exponential_and_per_key(monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(auth_api.time, "monotonic", lambda: clock["t"])
+
+    victim = "10.0.0.1|user-x"
+    other_ip = "10.0.0.2|user-x"  # same user, different source IP
+
+    # Failures below the threshold never lock the key.
+    for _ in range(auth_api._PIN_MAX_FAILURES - 1):
+        auth_api._record_pin_failure(victim)
+        auth_api._check_pin_rate_limit(victim)  # must not raise
+
+    # The threshold failure arms the base lockout window.
+    auth_api._record_pin_failure(victim)
+    with pytest.raises(HTTPException) as first:
+        auth_api._check_pin_rate_limit(victim)
+    assert first.value.status_code == 429
+    base = int(first.value.headers["Retry-After"])
+    assert 0 < base <= auth_api._PIN_LOCKOUT_BASE_SECONDS
+
+    # A different source IP for the same user is unaffected by the failures.
+    auth_api._check_pin_rate_limit(other_ip)  # must not raise
+
+    # After the window elapses the lock clears but the failure count is kept,
+    # so the next failure escalates (roughly doubles) the backoff.
+    clock["t"] += auth_api._PIN_LOCKOUT_BASE_SECONDS + 1
+    auth_api._check_pin_rate_limit(victim)  # expired -> no raise
+    auth_api._record_pin_failure(victim)
+    with pytest.raises(HTTPException) as second:
+        auth_api._check_pin_rate_limit(victim)
+    assert int(second.value.headers["Retry-After"]) > base
+
+
+def test_backoff_is_capped(monkeypatch):
+    clock = {"t": 0.0}
+    monkeypatch.setattr(auth_api.time, "monotonic", lambda: clock["t"])
+    key = "10.0.0.9|user-z"
+    # Drive far past the doubling range; the lockout must not exceed the cap.
+    for _ in range(40):
+        auth_api._record_pin_failure(key)
+    with pytest.raises(HTTPException) as exc:
+        auth_api._check_pin_rate_limit(key)
+    assert int(exc.value.headers["Retry-After"]) <= auth_api._PIN_LOCKOUT_MAX_SECONDS
+
+
+def test_correct_pin_reset_clears_backoff(monkeypatch):
+    clock = {"t": 5000.0}
+    monkeypatch.setattr(auth_api.time, "monotonic", lambda: clock["t"])
+    key = "10.0.0.7|user-y"
+    for _ in range(auth_api._PIN_MAX_FAILURES):
+        auth_api._record_pin_failure(key)
+    with pytest.raises(HTTPException):
+        auth_api._check_pin_rate_limit(key)
+
+    auth_api._reset_pin_throttle(key)
+    auth_api._check_pin_rate_limit(key)  # cleared -> no raise
+
+
+def test_idle_key_is_forgotten_after_reset_window(monkeypatch):
+    clock = {"t": 100.0}
+    monkeypatch.setattr(auth_api.time, "monotonic", lambda: clock["t"])
+    key = "10.0.0.3|user-w"
+    for _ in range(auth_api._PIN_MAX_FAILURES):
+        auth_api._record_pin_failure(key)
+
+    # Long after the lockout (and any further activity), the key is dropped so
+    # an honest user gets a clean slate.
+    clock["t"] += auth_api._PIN_FAILURE_RESET_SECONDS + 1
+    auth_api._check_pin_rate_limit(key)  # no raise; also prunes the entry
+    assert key not in auth_api._pin_throttle
+
+
+def test_reset_for_user_clears_all_ips(monkeypatch):
+    clock = {"t": 9000.0}
+    monkeypatch.setattr(auth_api.time, "monotonic", lambda: clock["t"])
+    victim_a = "10.0.0.1|victim"
+    victim_b = "10.0.0.2|victim"
+    bystander = "10.0.0.1|bystander"
+    for key in (victim_a, victim_b, bystander):
+        for _ in range(auth_api._PIN_MAX_FAILURES):
+            auth_api._record_pin_failure(key)
+
+    auth_api._reset_pin_throttle_for_user("victim")
+
+    # Both of the victim's keys (across IPs) are cleared...
+    auth_api._check_pin_rate_limit(victim_a)  # no raise
+    auth_api._check_pin_rate_limit(victim_b)  # no raise
+    # ...but an unrelated user's lockout is left intact.
+    with pytest.raises(HTTPException):
+        auth_api._check_pin_rate_limit(bystander)


### PR DESCRIPTION
Hardens PIN brute-force defense (roadmap LATER tier, #11). Additive — no schema/migration.

## Problem
PIN lockout was keyed by the unauthenticated `user_id` from the request, so anyone reachable could repeatedly fail PINs to lock a specific household member out (account-lockout DoS). `/select` also returned 404 for missing users, making it a user-existence oracle.

## Fix
- **Throttle keyed by client IP + target user_id**, so an attacker's IP can't lock out the victim's profile; a shared device can still switch profiles while one is backed off. Per-user entries cleared on PIN change/delete.
- **Exponential backoff**: first lockout at the 5th failure (30s), doubling (60s/120s/…) capped at 1h; failure count persists across expiry; idle keys forgotten after 1h; memory bounded under IP churn. `429` now carries `Retry-After`.
- **Client IP**: `request.client.host` (unspoofable socket peer) by default; opt-in `TRUST_PROXY_HEADERS` uses the **rightmost** `X-Forwarded-For` hop (client-forgeable leftmost entries never trusted).
- **Oracle closed**: a missing user is checked against a precomputed dummy scrypt hash, so it costs the same work and returns an identical 403 as a real wrong-PIN attempt; repeated probes back off identically.
- Kept **in-process** per the no-live-Redis constraint, with a TODO to move counters to the existing Redis for multi-worker/restart persistence.

## Verification (local)
- `pytest -q` → **155 passed** (+ `test_pin_throttle.py` 9 tests; `test_pin_lockout_is_scoped_to_client_ip`, `test_select_is_not_a_user_existence_oracle`, and the 429-burst test updated with a `Retry-After` assertion).
- `ruff` + `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY