### PR TITLE
feat: per-user watch-later queue

### DIFF
--- a/alembic/versions/009_user_queue.py
+++ b/alembic/versions/009_user_queue.py
@@ -1,0 +1,41 @@
+"""User watch-later queue
+
+Revision ID: 009_user_queue
+Revises: 008_channel_rss_validators
+Create Date: 2026-06-27
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "009_user_queue"
+down_revision: Union[str, None] = "008_channel_rss_validators"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Per-user watch-later queue. Pure bookmark (no download ref-count), ordered
+    # oldest-first by added_at with video_id as a stable tiebreaker.
+    op.create_table(
+        "user_queue",
+        sa.Column(
+            "user_id", sa.String(36), sa.ForeignKey("users.id"), primary_key=True
+        ),
+        sa.Column(
+            "video_id", sa.String(36), sa.ForeignKey("videos.id"), primary_key=True
+        ),
+        sa.Column(
+            "added_at", sa.DateTime, nullable=False, server_default=sa.func.now()
+        ),
+    )
+    # Serves the listing's WHERE user_id + ORDER BY added_at; the (user_id,
+    # video_id) primary key cannot order by added_at.
+    op.create_index("ix_user_queue_user_added", "user_queue", ["user_id", "added_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_user_queue_user_added", table_name="user_queue")
+    op.drop_table("user_queue")

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -22,6 +22,7 @@ from app.models.recommendation import Recommendation
 from app.models.session import Session
 from app.models.subscription import UserSubscription
 from app.models.user import User
+from app.models.user_queue import UserQueue
 from app.models.user_video_ref import UserVideoRef
 from app.schemas.user import (
     UserCreate,
@@ -494,6 +495,7 @@ async def delete_profile(
     video_ids = list(refs_result.scalars().all())
 
     await db.execute(delete(UserVideoRef).where(UserVideoRef.user_id == user_id))
+    await db.execute(delete(UserQueue).where(UserQueue.user_id == user_id))
     await db.execute(
         delete(UserSubscription).where(UserSubscription.user_id == user_id)
     )

--- a/app/api/queue.py
+++ b/app/api/queue.py
@@ -1,0 +1,158 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import and_, delete, func, or_, select
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.auth import get_current_user
+from app.database import get_db
+from app.models.channel import Channel
+from app.models.user import User
+from app.models.user_queue import UserQueue
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from app.schemas.video import VideoOut, VideoSearchPage
+from app.utils.pagination import decode_cursor, encode_cursor
+from app.utils.time import utcnow_naive
+
+# Video-scoped mutations live under /api/videos (alongside /download, /cancel,
+# etc.); the listing is the top-level collection /api/queue. Both share the
+# "queue" tag so they group together in the OpenAPI docs.
+router = APIRouter(tags=["queue"])
+logger = logging.getLogger(__name__)
+
+
+@router.post("/api/videos/{video_id}/queue")
+async def add_to_queue(
+    video_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Append a video to the caller's watch-later queue.
+
+    Idempotent: re-adding a video already in the queue is a no-op that keeps its
+    original position (``added_at``). 404 if the video does not exist.
+    """
+    exists = await db.scalar(select(Video.id).where(Video.id == video_id))
+    if exists is None:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    stmt = (
+        sqlite_insert(UserQueue)
+        .values(user_id=user.id, video_id=video_id, added_at=utcnow_naive())
+        .on_conflict_do_nothing(index_elements=["user_id", "video_id"])
+    )
+    await db.execute(stmt)
+    await db.commit()
+    return {"detail": "Added to queue", "video_id": video_id}
+
+
+@router.delete("/api/videos/{video_id}/queue")
+async def remove_from_queue(
+    video_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Remove a video from the caller's queue.
+
+    Idempotent: succeeds with 200 whether or not the video was queued (and even
+    if the video does not exist), since the end state — not in the queue — is the
+    same either way.
+    """
+    await db.execute(
+        delete(UserQueue).where(
+            UserQueue.user_id == user.id,
+            UserQueue.video_id == video_id,
+        )
+    )
+    await db.commit()
+    return {"detail": "Removed from queue", "video_id": video_id}
+
+
+@router.get("/api/queue", response_model=VideoSearchPage)
+async def list_queue(
+    cursor: str | None = Query(None),
+    limit: int = Query(20, ge=1, le=100),
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> VideoSearchPage:
+    """The caller's watch-later queue, oldest-queued first.
+
+    Returns the cursor-paginated ``VideoSearchPage`` envelope (the project's
+    default; the offset ``VideoPagination`` is kept only for the legacy
+    channel-videos contract). Queue rows carry a natural ``(added_at, video_id)``
+    keyset that maps directly onto the shared cursor helpers. Each item's watch
+    progress is filled from the caller's active ref when one exists, so a queued
+    video the user has never opened still appears (with default progress).
+    """
+    sort_key = UserQueue.added_at
+
+    filters = [UserQueue.user_id == user.id]
+    total = (
+        await db.scalar(select(func.count()).select_from(UserQueue).where(*filters))
+        or 0
+    )
+
+    page_filters = list(filters)
+    if cursor:
+        decoded = decode_cursor(cursor)
+        if decoded is None:
+            raise HTTPException(status_code=400, detail="Invalid cursor")
+        cur_sort, cur_id = decoded
+        page_filters.append(
+            or_(
+                sort_key > cur_sort,
+                and_(sort_key == cur_sort, UserQueue.video_id > cur_id),
+            )
+        )
+
+    # Fetch one extra row to detect whether another page exists. The LEFT JOIN to
+    # the caller's active ref is what lets a queued-but-never-watched video still
+    # come back (with null/default progress).
+    result = await db.execute(
+        select(UserQueue, Video, Channel, UserVideoRef)
+        .join(Video, UserQueue.video_id == Video.id)
+        .join(Channel, Video.channel_id == Channel.id)
+        .outerjoin(
+            UserVideoRef,
+            and_(
+                UserVideoRef.video_id == UserQueue.video_id,
+                UserVideoRef.user_id == user.id,
+                UserVideoRef.removed_at.is_(None),
+            ),
+        )
+        .where(*page_filters)
+        .order_by(sort_key.asc(), UserQueue.video_id.asc())
+        .limit(limit + 1)
+    )
+    rows = result.all()
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+
+    items = [
+        VideoOut(
+            id=video.id,
+            youtube_video_id=video.youtube_video_id,
+            channel_id=video.channel_id,
+            title=video.title,
+            duration_seconds=video.duration_seconds,
+            uploaded_at=video.uploaded_at,
+            file_size_bytes=video.file_size_bytes or 0,
+            status=video.status,
+            preview_status=video.preview_status,
+            thumbnail_url=f"/data/thumbnails/{video.youtube_video_id}.jpg",
+            watch_position_seconds=ref.watch_position_seconds if ref else 0,
+            is_watched=ref.is_watched if ref else False,
+            last_watched_at=ref.last_watched_at if ref else None,
+            channel_name=channel.name,
+        )
+        for _queue_row, video, channel, ref in rows
+    ]
+
+    next_cursor = None
+    if has_more and rows:
+        last_queue_row = rows[-1][0]
+        next_cursor = encode_cursor(last_queue_row.added_at, last_queue_row.video_id)
+
+    return VideoSearchPage(items=items, total=total, next_cursor=next_cursor)

--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,17 @@ from starlette.exceptions import HTTPException as StarletteHTTPException
 
 import os
 
-from app.api import auth, channels, discover, feed, health, videos, websocket, youtube
+from app.api import (
+    auth,
+    channels,
+    discover,
+    feed,
+    health,
+    queue,
+    videos,
+    websocket,
+    youtube,
+)
 from app.config import settings
 from app.services.progress_broadcaster import start_progress_listener
 
@@ -106,6 +116,7 @@ app.include_router(health.router)
 app.include_router(auth.router)
 app.include_router(channels.router)
 app.include_router(videos.router)
+app.include_router(queue.router)
 app.include_router(feed.router)
 app.include_router(discover.router)
 app.include_router(websocket.router)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -11,5 +11,6 @@ from app.models.channel import Channel  # noqa: E402, F401
 from app.models.video import Video  # noqa: E402, F401
 from app.models.subscription import UserSubscription  # noqa: E402, F401
 from app.models.user_video_ref import UserVideoRef  # noqa: E402, F401
+from app.models.user_queue import UserQueue  # noqa: E402, F401
 from app.models.recommendation import Recommendation  # noqa: E402, F401
 from app.models.session import Session  # noqa: E402, F401

--- a/app/models/user_queue.py
+++ b/app/models/user_queue.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models import Base
+from app.utils.time import utcnow_naive
+
+
+class UserQueue(Base):
+    """A per-user watch-later queue entry.
+
+    One row per (user, video) the user has queued. Unlike ``UserVideoRef`` this
+    is a pure bookmark: it carries no download ref-count semantics, so queuing a
+    video never starts or keeps alive a download. The queue is ordered oldest
+    first by ``added_at`` (with ``video_id`` as a stable tiebreaker) so new
+    entries append at the end. Re-adding a video is a no-op that preserves its
+    original position.
+    """
+
+    __tablename__ = "user_queue"
+    __table_args__ = (Index("ix_user_queue_user_added", "user_id", "added_at"),)
+
+    user_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("users.id"), primary_key=True
+    )
+    video_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("videos.id"), primary_key=True
+    )
+    added_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.channel import Channel
 from app.models.subscription import UserSubscription
+from app.models.user_queue import UserQueue
 from app.models.user_video_ref import UserVideoRef
 from app.models.video import Video
 
@@ -108,3 +109,13 @@ async def seed_subscription(
     db.add(sub)
     await db.commit()
     return sub
+
+
+async def seed_queue(
+    db: AsyncSession, user_id: str, video_id: str, **kwargs: Any
+) -> UserQueue:
+    """Seed a watch-later queue row. Pass ``added_at`` for deterministic order."""
+    item = UserQueue(user_id=user_id, video_id=video_id, **kwargs)
+    db.add(item)
+    await db.commit()
+    return item

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,305 @@
+"""Watch-later queue: add/remove idempotency, ordering, isolation, pagination."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+
+from app.database import async_session_factory
+from app.models.user_queue import UserQueue
+from tests.helpers import seed_channel, seed_queue, seed_ref, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- add ---------------------------------------------------------------------
+
+
+async def test_add_and_list_queue(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, title="Watch This Later")
+
+    resp = await client.post(f"/api/videos/{video.id}/queue", headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    resp = await client.get("/api/queue", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["next_cursor"] is None
+    assert [v["id"] for v in body["items"]] == [video.id]
+    assert body["items"][0]["title"] == "Watch This Later"
+    assert body["items"][0]["channel_name"] == channel.name
+
+
+async def test_add_to_queue_idempotent(client, make_user):
+    """Re-adding the same video keeps a single row."""
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+
+    for _ in range(3):
+        resp = await client.post(f"/api/videos/{video.id}/queue", headers=headers)
+        assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        rows = (
+            (await db.execute(select(UserQueue).where(UserQueue.user_id == user["id"])))
+            .scalars()
+            .all()
+        )
+    assert len(rows) == 1
+
+    resp = await client.get("/api/queue", headers=headers)
+    assert resp.json()["total"] == 1
+
+
+async def test_add_to_queue_unknown_video_404(client, make_user):
+    _, headers = await make_user()
+    resp = await client.post("/api/videos/does-not-exist/queue", headers=headers)
+    assert resp.status_code == 404
+
+
+async def test_readd_preserves_position(client, make_user):
+    """An idempotent re-add must NOT move the video to the end of the queue."""
+    user, headers = await make_user()
+    base = datetime(2026, 1, 1, 12, 0, 0)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        a = await seed_video(db, channel, title="A")
+        b = await seed_video(db, channel, title="B")
+        c = await seed_video(db, channel, title="C")
+        await seed_queue(db, user["id"], a.id, added_at=base)
+        await seed_queue(db, user["id"], b.id, added_at=base + timedelta(minutes=1))
+        await seed_queue(db, user["id"], c.id, added_at=base + timedelta(minutes=2))
+
+    # Re-add A (the head). Its original, earliest added_at must be preserved, so
+    # the order stays A, B, C rather than B, C, A.
+    resp = await client.post(f"/api/videos/{a.id}/queue", headers=headers)
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/queue", headers=headers)
+    assert [v["title"] for v in resp.json()["items"]] == ["A", "B", "C"]
+
+
+# --- ordering ----------------------------------------------------------------
+
+
+async def test_queue_orders_by_added_at_not_insertion(client, make_user):
+    """Order is by added_at (oldest first), independent of row insert order."""
+    user, headers = await make_user()
+    base = datetime(2026, 3, 1, 9, 0, 0)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        a = await seed_video(db, channel, title="A")
+        b = await seed_video(db, channel, title="B")
+        c = await seed_video(db, channel, title="C")
+        # Insert out of order; added_at decides the result order.
+        await seed_queue(db, user["id"], c.id, added_at=base + timedelta(minutes=2))
+        await seed_queue(db, user["id"], a.id, added_at=base)
+        await seed_queue(db, user["id"], b.id, added_at=base + timedelta(minutes=1))
+
+    resp = await client.get("/api/queue", headers=headers)
+    assert [v["title"] for v in resp.json()["items"]] == ["A", "B", "C"]
+
+
+# --- remove ------------------------------------------------------------------
+
+
+async def test_remove_from_queue_idempotent(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+        await seed_queue(db, user["id"], video.id)
+
+    # First removal empties the queue.
+    resp = await client.delete(f"/api/videos/{video.id}/queue", headers=headers)
+    assert resp.status_code == 200
+    resp = await client.get("/api/queue", headers=headers)
+    assert resp.json()["total"] == 0
+
+    # Removing again is a no-op success (idempotent).
+    resp = await client.delete(f"/api/videos/{video.id}/queue", headers=headers)
+    assert resp.status_code == 200
+
+
+async def test_remove_unknown_video_is_idempotent_not_404(client, make_user):
+    """Removing a video that was never queued (or doesn't exist) still 200s."""
+    _, headers = await make_user()
+    resp = await client.delete("/api/videos/does-not-exist/queue", headers=headers)
+    assert resp.status_code == 200
+
+
+# --- per-user isolation ------------------------------------------------------
+
+
+async def test_queue_is_per_user(client, make_user):
+    user_a, headers_a = await make_user("A")
+    user_b, headers_b = await make_user("B")
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        shared = await seed_video(db, channel, title="Shared")
+        only_b = await seed_video(db, channel, title="OnlyB")
+        # Both queue the shared video; only B queues the second.
+        await seed_queue(db, user_a["id"], shared.id)
+        await seed_queue(db, user_b["id"], shared.id)
+        await seed_queue(db, user_b["id"], only_b.id)
+
+    resp = await client.get("/api/queue", headers=headers_a)
+    assert {v["id"] for v in resp.json()["items"]} == {shared.id}
+
+    resp = await client.get("/api/queue", headers=headers_b)
+    assert {v["id"] for v in resp.json()["items"]} == {shared.id, only_b.id}
+
+    # A removing the shared video must not touch B's identical entry.
+    resp = await client.delete(f"/api/videos/{shared.id}/queue", headers=headers_a)
+    assert resp.status_code == 200
+
+    resp = await client.get("/api/queue", headers=headers_a)
+    assert resp.json()["total"] == 0
+    resp = await client.get("/api/queue", headers=headers_b)
+    assert {v["id"] for v in resp.json()["items"]} == {shared.id, only_b.id}
+
+
+async def test_deleting_profile_clears_queue(client, make_user):
+    """Profile deletion must remove the user's queue rows.
+
+    With SQLite foreign keys enforced, a leftover queue row would make the
+    users-row delete fail, so this also guards the FK-safe cleanup order.
+    """
+    await make_user("Admin")  # keep an admin around so the victim can be deleted
+    victim, victim_headers = await make_user("Victim")
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+        await seed_queue(db, victim["id"], video.id)
+
+    resp = await client.delete(
+        f"/api/auth/profiles/{victim['id']}", headers=victim_headers
+    )
+    assert resp.status_code == 200
+
+    async with async_session_factory() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(UserQueue).where(UserQueue.user_id == victim["id"])
+                )
+            )
+            .scalars()
+            .all()
+        )
+    assert rows == []
+
+
+# --- progress population (queue is independent of download refs) --------------
+
+
+async def test_queue_item_progress_and_works_without_ref(client, make_user):
+    """A queued video surfaces watch progress when a ref exists, and still
+    appears (with default progress) when the user holds no ref."""
+    user, headers = await make_user()
+    base = datetime(2026, 4, 1, 0, 0, 0)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        watched = await seed_video(db, channel, title="Watched")
+        never = await seed_video(db, channel, title="Never Opened")
+        await seed_queue(db, user["id"], watched.id, added_at=base)
+        await seed_queue(db, user["id"], never.id, added_at=base + timedelta(minutes=1))
+        # A ref only for the first video.
+        await seed_ref(
+            db, user["id"], watched.id, watch_position_seconds=42, is_watched=True
+        )
+
+    resp = await client.get("/api/queue", headers=headers)
+    items = {v["title"]: v for v in resp.json()["items"]}
+    assert set(items) == {"Watched", "Never Opened"}
+    assert items["Watched"]["watch_position_seconds"] == 42
+    assert items["Watched"]["is_watched"] is True
+    assert items["Never Opened"]["watch_position_seconds"] == 0
+    assert items["Never Opened"]["is_watched"] is False
+
+
+async def test_queue_ignores_soft_deleted_ref(client, make_user):
+    """A soft-deleted ref must not leak progress; the item still appears."""
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, title="Soft Deleted Ref")
+        await seed_queue(db, user["id"], video.id)
+        await seed_ref(
+            db,
+            user["id"],
+            video.id,
+            watch_position_seconds=99,
+            removed_at=datetime(2026, 1, 1),
+        )
+
+    resp = await client.get("/api/queue", headers=headers)
+    items = resp.json()["items"]
+    assert [v["id"] for v in items] == [video.id]
+    assert items[0]["watch_position_seconds"] == 0
+
+
+# --- pagination --------------------------------------------------------------
+
+
+async def test_queue_pagination_cursor(client, make_user):
+    user, headers = await make_user()
+    base = datetime(2026, 5, 1, 12, 0, 0)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        for i in range(5):
+            v = await seed_video(db, channel, title=f"Ep {i}")
+            await seed_queue(db, user["id"], v.id, added_at=base + timedelta(minutes=i))
+
+    seen: list[str] = []
+    cursor = None
+    pages = 0
+    while True:
+        params = {"limit": 2}
+        if cursor:
+            params["cursor"] = cursor
+        resp = await client.get("/api/queue", params=params, headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 5  # total is stable across pages
+        seen.extend(v["title"] for v in body["items"])
+        cursor = body["next_cursor"]
+        pages += 1
+        if cursor is None:
+            break
+        assert pages < 10  # guard against an infinite loop
+
+    # Oldest-first (FIFO), every item exactly once.
+    assert seen == ["Ep 0", "Ep 1", "Ep 2", "Ep 3", "Ep 4"]
+    assert len(seen) == len(set(seen))
+
+
+async def test_queue_invalid_cursor_400(client, make_user):
+    _, headers = await make_user()
+    resp = await client.get(
+        "/api/queue", params={"cursor": "not-a-valid-cursor"}, headers=headers
+    )
+    assert resp.status_code == 400
+
+
+async def test_queue_empty(client, make_user):
+    _, headers = await make_user()
+    resp = await client.get("/api/queue", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"items": [], "total": 0, "next_cursor": None}
+
+
+# --- auth --------------------------------------------------------------------
+
+
+async def test_queue_endpoints_require_auth(client):
+    assert (await client.get("/api/queue")).status_code == 401
+    assert (await client.post("/api/videos/x/queue")).status_code == 401
+    assert (await client.delete("/api/videos/x/queue")).status_code == 401


### PR DESCRIPTION
Per-user watch-later queue (roadmap LATER tier, #2). Additive — new `user_queue` table + migration `009`.

## Endpoints
- `POST /api/videos/{id}/queue` — add to the caller's queue (idempotent; appends). 404 on unknown video.
- `DELETE /api/videos/{id}/queue` — remove (idempotent).
- `GET /api/queue` — the caller's queue in order, returning the existing `VideoSearchPage` cursor envelope (`{items, total, next_cursor}`).

Per-user scoped; queue rows are cleaned up when a profile is deleted. Ordered by `added_at` (indexed `ix_user_queue_user_added`).

## Verification (local)
- `pytest -q` → **170 passed** (+15 in `test_queue.py`: add/remove idempotency, ordering, per-user isolation, pagination, 404 on unknown video, auth required).
- `alembic` up/down round-trip clean · `ruff` clean.

Client UIs ("Add to Queue" + a Queue rail + player auto-advance) consume these in a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY