### PR TITLE
feat: adaptive per-channel poll cadence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,15 @@ DOWNLOAD_CONCURRENCY=2
 # Default download quality: 720p | 1080p | 4k | best
 MEDIA_QUALITY=1080p
 
-# How often (in minutes) to poll subscribed channels for new uploads
-CHECK_INTERVAL_MINUTES=60
+# Adaptive channel polling.
+# The scheduler wakes every CHECK_INTERVAL_MINUTES and polls only the channels
+# that are due. Each channel's interval adapts within the floor/cap below: it
+# shrinks toward the floor when new uploads are found and grows toward the cap
+# when a poll turns up nothing. Keep CHECK_INTERVAL_MINUTES <= the floor.
+CHECK_INTERVAL_MINUTES=5
+POLL_INTERVAL_FLOOR_MINUTES=15
+POLL_INTERVAL_CAP_MINUTES=240
+POLL_INTERVAL_BACKOFF_FACTOR=2.0
 
 # User/group ID for file permissions (Unraid standard)
 PUID=1000

--- a/alembic/versions/010_channel_poll_cadence.py
+++ b/alembic/versions/010_channel_poll_cadence.py
@@ -1,0 +1,63 @@
+"""Adaptive per-channel poll cadence: channels.next_poll_at / poll_interval_minutes
+
+Revision ID: 010_channel_poll_cadence
+Revises: 009_user_queue
+Create Date: 2026-06-27
+"""
+
+from datetime import datetime, timezone
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "010_channel_poll_cadence"
+down_revision: Union[str, None] = "009_user_queue"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Per-channel adaptive poll cadence. next_poll_at gates which channels the
+    # beat polls (only those due, next_poll_at <= now); poll_interval_minutes is
+    # the current spacing, adjusted by multiplicative backoff after each poll.
+    #
+    # next_poll_at backfills existing rows to "now" so every channel is
+    # immediately due exactly once and then settles onto its own schedule. The
+    # default is a constant captured at migration time rather than CURRENT_
+    # TIMESTAMP because SQLite forbids a non-constant default on ADD COLUMN; the
+    # ORM supplies its own per-row default for future inserts, so this constant
+    # only ever applies to the rows that exist right now.
+    now_literal = (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0, tzinfo=None)
+        .isoformat(sep=" ")
+    )
+    op.add_column(
+        "channels",
+        sa.Column(
+            "next_poll_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=now_literal,
+        ),
+    )
+    # Seed the interval at the floor default so a freshly migrated channel starts
+    # responsive and only backs off if its polls keep coming up empty.
+    op.add_column(
+        "channels",
+        sa.Column(
+            "poll_interval_minutes",
+            sa.Integer(),
+            nullable=False,
+            server_default="15",
+        ),
+    )
+    # Serves the beat's WHERE next_poll_at <= now due-check.
+    op.create_index("ix_channels_next_poll_at", "channels", ["next_poll_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_channels_next_poll_at", table_name="channels")
+    op.drop_column("channels", "poll_interval_minutes")
+    op.drop_column("channels", "next_poll_at")

--- a/app/config.py
+++ b/app/config.py
@@ -15,8 +15,21 @@ class Settings(BaseSettings):
     catalog_fetch_count: int = 50
     download_concurrency: int = 2
     media_quality: str = "1080p"
-    check_interval_minutes: int = 60
     metadata_refresh_interval_hours: int = 12
+
+    # Polling cadence (adaptive, per channel).
+    # The beat wakes every check_interval_minutes and polls only the channels
+    # that are DUE (next_poll_at <= now); each wake is cheap (a due-check query
+    # plus, for due channels, an RSS conditional GET that usually 304s). After a
+    # poll, a channel's interval moves by poll_interval_backoff_factor: it is
+    # divided (toward the floor) when new uploads are found and multiplied
+    # (toward the cap) when the poll is empty, so busy channels settle near the
+    # floor and dormant ones near the cap. Keep check_interval_minutes <= the
+    # floor so a channel that comes due is polled promptly.
+    check_interval_minutes: int = 5
+    poll_interval_floor_minutes: int = 15
+    poll_interval_cap_minutes: int = 240
+    poll_interval_backoff_factor: float = 2.0
 
     # Auth sessions
     # A session is rejected once it is older than the absolute TTL (since

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -1,10 +1,11 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, String, Text
+from sqlalchemy import DateTime, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
+from app.utils.time import utcnow_naive
 
 
 class Channel(Base):
@@ -30,6 +31,17 @@ class Channel(Base):
     # feed returns 304 Not Modified and the poll short-circuits with no yt-dlp.
     rss_etag: Mapped[str | None] = mapped_column(String(255), nullable=True)
     rss_last_modified: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Adaptive poll cadence. The beat polls only channels whose next_poll_at has
+    # passed; poll_interval_minutes is the current spacing, narrowed toward the
+    # floor after a poll that finds uploads and widened toward the cap after an
+    # empty one. Defaults make a newly added channel due immediately and start it
+    # at the responsive floor (mirrors settings.poll_interval_floor_minutes).
+    next_poll_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=utcnow_naive, index=True
+    )
+    poll_interval_minutes: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=15
+    )
 
     videos = relationship("Video", back_populates="channel", lazy="select")
     subscriptions = relationship(

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -29,16 +29,69 @@ def _as_naive_utc(value: datetime | None) -> datetime | None:
     return value
 
 
-def poll_all_channels(db: Session) -> list[str]:
-    """Poll all channels that have at least one subscriber.
-    Returns aggregated list of auto-download video IDs."""
-    result = db.execute(
+def _reschedule_channel(channel: Channel, *, found_new: bool) -> None:
+    """Recompute a channel's next poll time from this poll's outcome.
+
+    Multiplicative backoff bounded by a configurable floor and cap: a poll that
+    found new uploads divides the interval by the backoff factor (toward the
+    floor, since the channel looks active); an empty poll multiplies it (toward
+    the cap, since the channel looks dormant). With the beat polling only DUE
+    channels, the effective cadence converges on each channel's observed upload
+    frequency. Mutates the channel in place; the caller commits.
+    """
+    from app.config import settings
+
+    floor = settings.poll_interval_floor_minutes
+    # Coerce the bounds so a misconfiguration can never invert them or divide by
+    # zero, which would otherwise produce a nonsensical schedule.
+    cap = max(floor, settings.poll_interval_cap_minutes)
+    factor = settings.poll_interval_backoff_factor or 1.0
+
+    current = channel.poll_interval_minutes or floor
+    interval = current / factor if found_new else current * factor
+    interval = max(floor, min(cap, int(round(interval))))
+
+    channel.poll_interval_minutes = interval
+    channel.next_poll_at = utcnow_naive() + timedelta(minutes=interval)
+
+
+def _backoff_failed_channel(channel_id: str, db: Session) -> None:
+    """Push a failed channel's next poll out so it doesn't retry every beat.
+
+    Called after a poll raised and the session was rolled back, so it reloads
+    the channel in a fresh transaction. Best-effort: a failure here must not
+    abort the rest of the batch, so it only logs.
+    """
+    try:
+        channel = db.get(Channel, channel_id)
+        if channel is not None:
+            _reschedule_channel(channel, found_new=False)
+            db.commit()
+    except Exception:
+        logger.exception("Could not back off failed channel %s", channel_id)
+        db.rollback()
+
+
+def poll_all_channels(db: Session, *, due_only: bool = False) -> list[str]:
+    """Poll subscribed channels and return aggregated auto-download video IDs.
+
+    When ``due_only`` is set (the periodic beat), only channels whose
+    ``next_poll_at`` has passed are polled, so each frequent run does work
+    proportional to how many channels are actually due instead of re-polling
+    every channel every time. When unset (an explicit "refresh everything"
+    request, e.g. pull-to-refresh) every subscribed channel is polled now,
+    regardless of its schedule.
+    """
+    stmt = (
         select(Channel.id)
         .join(UserSubscription, UserSubscription.channel_id == Channel.id)
         .distinct()
     )
-    channel_ids = [row[0] for row in result.all()]
-    logger.info("Polling %d channels", len(channel_ids))
+    if due_only:
+        stmt = stmt.where(Channel.next_poll_at <= utcnow_naive())
+
+    channel_ids = [row[0] for row in db.execute(stmt).all()]
+    logger.info("Polling %d channels (due_only=%s)", len(channel_ids), due_only)
 
     all_auto_download_ids: list[str] = []
     for channel_id in channel_ids:
@@ -48,6 +101,10 @@ def poll_all_channels(db: Session) -> list[str]:
         except Exception:
             logger.exception("Error polling channel %s", channel_id)
             db.rollback()
+            # The frequent beat would otherwise retry a persistently failing
+            # channel every wake; widen its cadence so it backs off like an
+            # empty poll instead of hot-looping.
+            _backoff_failed_channel(channel_id, db)
 
     return all_auto_download_ids
 
@@ -77,7 +134,12 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
         yt_videos = _discover_routine(channel, db)
         if yt_videos is None:
             # 304 Not Modified, or the feed surfaced no unseen videos: nothing
-            # to catalog. Validators + last_checked_at were already persisted.
+            # to catalog. Record the poll and, since it was empty, widen the
+            # cadence toward the cap. _discover_routine refreshed any validators
+            # on the session; this commit persists them alongside next_poll_at.
+            channel.last_checked_at = utcnow_naive()
+            _reschedule_channel(channel, found_new=False)
+            db.commit()
             return {"cataloged_ids": [], "auto_download_ids": []}
 
     cataloged_ids: list[str] = []
@@ -149,6 +211,9 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
         )
 
     channel.last_checked_at = utcnow_naive()
+    # New rows -> the channel looks active, shorten toward the floor; an empty
+    # poll -> looks dormant, lengthen toward the cap.
+    _reschedule_channel(channel, found_new=bool(cataloged_ids))
     db.commit()
 
     # Notify subscribers about genuinely new episodes — never the back catalog
@@ -166,9 +231,10 @@ def _discover_routine(channel: Channel, db: Session) -> list[dict] | None:
       * a list of yt-dlp metadata dicts for genuinely-new video IDs (newest
         first) for the caller to catalog;
       * ``None`` when there is nothing to catalog — a 304 Not Modified, or a
-        fresh feed with no unseen video IDs. In that case the channel's
-        validators and ``last_checked_at`` are updated and committed here, so
-        the caller can return immediately.
+        fresh feed with no unseen video IDs. On the ``ok`` path the refreshed
+        HTTP validators are written to the session so the caller's commit
+        persists them; the caller records ``last_checked_at``, reschedules the
+        channel, and commits.
 
     Falls back to a full yt-dlp listing when RSS is unavailable for the channel
     (handle/username id, network error, or unparseable feed), preserving the
@@ -186,12 +252,10 @@ def _discover_routine(channel: Channel, db: Session) -> list[dict] | None:
 
     if rss["status"] == "not_modified":
         # Feed unchanged since the last poll: no new uploads, no work to do.
-        channel.last_checked_at = utcnow_naive()
-        db.commit()
         return None
 
     # status == "ok": refresh the stored validators so the next poll can 304.
-    # These persist as part of the caller's commit (new IDs) or below (none).
+    # These persist as part of the caller's single commit.
     channel.rss_etag = rss["etag"]
     channel.rss_last_modified = rss["last_modified"]
 
@@ -211,8 +275,6 @@ def _discover_routine(channel: Channel, db: Session) -> list[dict] | None:
         new_ids = [vid for vid in feed_ids if vid not in existing]
 
     if not new_ids:
-        channel.last_checked_at = utcnow_naive()
-        db.commit()
         return None
 
     logger.info("RSS surfaced %d new video(s) for channel %s", len(new_ids), channel.id)

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -26,9 +26,13 @@ celery_app.conf.update(
 
 # Periodic tasks
 celery_app.conf.beat_schedule = {
-    "poll-all-channels": {
+    # Wake frequently and poll only channels whose adaptive schedule is due.
+    # Each wake is cheap: a due-check query plus, for due channels, an RSS
+    # conditional GET that usually 304s.
+    "poll-due-channels": {
         "task": "app.tasks.download_tasks.poll_all_channels_task",
         "schedule": settings.check_interval_minutes * 60,
+        "kwargs": {"due_only": True},
     },
     "refresh-stale-channel-metadata": {
         "task": "app.tasks.download_tasks.refresh_stale_channel_metadata_task",

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -57,11 +57,17 @@ def _get_sync_db() -> Session:
     bind=True,
     max_retries=0,
 )
-def poll_all_channels_task(self) -> dict:
-    """Periodic task: poll all subscribed channels for new videos."""
+def poll_all_channels_task(self, due_only: bool = False) -> dict:
+    """Poll subscribed channels for new videos.
+
+    The beat passes ``due_only=True`` so each frequent run only polls channels
+    whose adaptive schedule has come due. An explicit "refresh everything"
+    request (the pull-to-refresh endpoint) calls it with the default
+    ``due_only=False`` to poll every subscribed channel now.
+    """
     db = _get_sync_db()
     try:
-        auto_download_ids = poll_all_channels(db)
+        auto_download_ids = poll_all_channels(db, due_only=due_only)
 
         # Only enqueue auto-download candidates (not blanket PENDING sweep)
         enqueued = 0

--- a/tests/test_adaptive_poll.py
+++ b/tests/test_adaptive_poll.py
@@ -1,0 +1,258 @@
+"""Tests for adaptive per-channel poll cadence.
+
+Covers the reschedule algorithm (multiplicative backoff bounded by floor/cap),
+due-only channel selection in poll_all_channels, the end-to-end cadence updates
+from poll_single_channel, and the failed-poll backoff that keeps the frequent
+beat from hot-looping a broken channel.
+"""
+
+import uuid
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.services import channel_poller
+from app.utils.time import utcnow_naive
+
+_UC_ID = "UCabc1230000000000000000"
+
+
+def _cadence(monkeypatch, *, floor=15, cap=240, factor=2.0):
+    """Pin the cadence settings so assertions are independent of the defaults."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "poll_interval_floor_minutes", floor)
+    monkeypatch.setattr(settings, "poll_interval_cap_minutes", cap)
+    monkeypatch.setattr(settings, "poll_interval_backoff_factor", factor)
+
+
+def _bare_channel(**overrides) -> Channel:
+    """A Channel instance with no DB session (for pure reschedule tests)."""
+    ch = Channel(id="c-1", youtube_channel_id="UCx", name="x", slug="x")
+    for key, value in overrides.items():
+        setattr(ch, key, value)
+    return ch
+
+
+def _mem_session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _add_channel(
+    db,
+    *,
+    next_poll_at,
+    poll_interval_minutes=15,
+    youtube_channel_id=_UC_ID,
+    last_checked_at=None,
+    subscriber="u1",
+) -> Channel:
+    suffix = uuid.uuid4().hex[:8]
+    channel = Channel(
+        id=str(uuid.uuid4()),
+        youtube_channel_id=f"{youtube_channel_id}{suffix}",
+        name="Test",
+        slug=f"test-{suffix}",
+        next_poll_at=next_poll_at,
+        poll_interval_minutes=poll_interval_minutes,
+        last_checked_at=last_checked_at,
+    )
+    db.add(channel)
+    if subscriber:
+        db.add(UserSubscription(user_id=subscriber, channel_id=channel.id))
+    db.commit()
+    return channel
+
+
+# --- reschedule algorithm --------------------------------------------------
+
+
+def test_reschedule_shortens_toward_floor_on_new_upload(monkeypatch):
+    _cadence(monkeypatch)
+    ch = _bare_channel(poll_interval_minutes=120)
+    before = utcnow_naive()
+
+    channel_poller._reschedule_channel(ch, found_new=True)
+
+    assert ch.poll_interval_minutes == 60  # 120 / 2
+    assert ch.next_poll_at >= before + timedelta(minutes=60) - timedelta(seconds=5)
+
+
+def test_reschedule_lengthens_toward_cap_on_empty_poll(monkeypatch):
+    _cadence(monkeypatch)
+    ch = _bare_channel(poll_interval_minutes=60)
+    before = utcnow_naive()
+
+    channel_poller._reschedule_channel(ch, found_new=False)
+
+    assert ch.poll_interval_minutes == 120  # 60 * 2
+    assert ch.next_poll_at >= before + timedelta(minutes=120) - timedelta(seconds=5)
+
+
+def test_reschedule_never_goes_below_floor(monkeypatch):
+    _cadence(monkeypatch, floor=15, cap=240, factor=2.0)
+    ch = _bare_channel(poll_interval_minutes=15)
+
+    channel_poller._reschedule_channel(ch, found_new=True)
+
+    assert ch.poll_interval_minutes == 15
+
+
+def test_reschedule_never_exceeds_cap(monkeypatch):
+    _cadence(monkeypatch, floor=15, cap=240, factor=2.0)
+    ch = _bare_channel(poll_interval_minutes=240)
+
+    channel_poller._reschedule_channel(ch, found_new=False)
+
+    assert ch.poll_interval_minutes == 240
+
+
+def test_reschedule_clamps_inverted_bounds(monkeypatch):
+    # cap < floor is a misconfiguration; the floor must still win.
+    _cadence(monkeypatch, floor=30, cap=10, factor=2.0)
+    ch = _bare_channel(poll_interval_minutes=20)
+
+    channel_poller._reschedule_channel(ch, found_new=False)
+
+    assert ch.poll_interval_minutes == 30
+
+
+# --- due-only selection in poll_all_channels -------------------------------
+
+
+def test_due_only_polls_only_due_channels(monkeypatch):
+    db = _mem_session()
+    due = _add_channel(db, next_poll_at=utcnow_naive() - timedelta(minutes=1))
+    _add_channel(db, next_poll_at=utcnow_naive() + timedelta(hours=2))
+
+    polled: list[str] = []
+
+    def fake_poll(channel_id, _db):
+        polled.append(channel_id)
+        return {"cataloged_ids": [], "auto_download_ids": []}
+
+    monkeypatch.setattr(channel_poller, "poll_single_channel", fake_poll)
+
+    channel_poller.poll_all_channels(db, due_only=True)
+
+    assert polled == [due.id]
+    db.close()
+
+
+def test_force_poll_ignores_schedule_and_polls_all(monkeypatch):
+    db = _mem_session()
+    due = _add_channel(db, next_poll_at=utcnow_naive() - timedelta(minutes=1))
+    not_due = _add_channel(db, next_poll_at=utcnow_naive() + timedelta(hours=2))
+
+    polled: list[str] = []
+
+    def fake_poll(channel_id, _db):
+        polled.append(channel_id)
+        return {"cataloged_ids": [], "auto_download_ids": []}
+
+    monkeypatch.setattr(channel_poller, "poll_single_channel", fake_poll)
+
+    channel_poller.poll_all_channels(db, due_only=False)
+
+    assert set(polled) == {due.id, not_due.id}
+    db.close()
+
+
+def test_failed_poll_backs_off_instead_of_hot_looping(monkeypatch):
+    _cadence(monkeypatch, floor=15, cap=240, factor=2.0)
+    db = _mem_session()
+    ch = _add_channel(
+        db,
+        next_poll_at=utcnow_naive() - timedelta(minutes=1),
+        poll_interval_minutes=30,
+    )
+
+    def boom(channel_id, _db):
+        raise RuntimeError("yt-dlp blew up")
+
+    monkeypatch.setattr(channel_poller, "poll_single_channel", boom)
+    before = utcnow_naive()
+
+    channel_poller.poll_all_channels(db, due_only=True)
+
+    db.refresh(ch)
+    # Backed off like an empty poll (30 * 2) and pushed into the future so the
+    # next beat won't immediately retry it.
+    assert ch.poll_interval_minutes == 60
+    assert ch.next_poll_at > before
+    db.close()
+
+
+# --- end-to-end cadence updates via poll_single_channel --------------------
+
+
+def test_routine_304_poll_lengthens_cadence(monkeypatch):
+    _cadence(monkeypatch, floor=15, cap=240, factor=2.0)
+    db = _mem_session()
+    ch = _add_channel(
+        db,
+        next_poll_at=utcnow_naive() - timedelta(minutes=1),
+        poll_interval_minutes=60,
+        last_checked_at=utcnow_naive(),
+    )
+    monkeypatch.setattr(
+        channel_poller, "fetch_channel_rss", lambda *a, **k: {"status": "not_modified"}
+    )
+    before = utcnow_naive()
+
+    channel_poller.poll_single_channel(ch.id, db)
+
+    db.refresh(ch)
+    assert ch.poll_interval_minutes == 120  # 60 * 2
+    assert ch.next_poll_at >= before + timedelta(minutes=120) - timedelta(seconds=5)
+    assert ch.last_checked_at is not None
+    db.close()
+
+
+def test_routine_new_upload_poll_shortens_cadence(monkeypatch):
+    _cadence(monkeypatch, floor=15, cap=240, factor=2.0)
+    db = _mem_session()
+    ch = _add_channel(
+        db,
+        next_poll_at=utcnow_naive() - timedelta(minutes=1),
+        poll_interval_minutes=120,
+        last_checked_at=utcnow_naive(),
+    )
+    monkeypatch.setattr(
+        channel_poller,
+        "fetch_channel_rss",
+        lambda *a, **k: {
+            "status": "ok",
+            "entries": [{"youtube_video_id": "NEW00000001"}],
+            "etag": None,
+            "last_modified": None,
+        },
+    )
+    monkeypatch.setattr(
+        channel_poller,
+        "fetch_videos_metadata",
+        lambda ids: [
+            {
+                "youtube_video_id": vid,
+                "title": vid,
+                "duration_seconds": 0,
+                "upload_date": None,
+            }
+            for vid in ids
+        ],
+    )
+    monkeypatch.setattr(channel_poller, "publish_new_episode", MagicMock())
+
+    result = channel_poller.poll_single_channel(ch.id, db)
+
+    assert len(result["cataloged_ids"]) == 1
+    db.refresh(ch)
+    assert ch.poll_interval_minutes == 60  # 120 / 2
+    db.close()


### PR DESCRIPTION
Adaptive per-channel polling (roadmap LATER tier, #6 / issue #15). Additive — migration 010.

## Cadence
After each poll, `_reschedule_channel` adjusts the interval (multiplicative, bounded): new videos → shorten toward a **15m floor**; empty poll (304 / no new) → lengthen toward a **4h cap** (factor 2.0). Failed polls back off too, so the now-frequent beat can't hot-loop a broken channel. Floor/cap/factor are configurable and coerced so a misconfig can't invert them.

## Due-only beat
`poll_all_channels(due_only=…)`: the beat (`poll-due-channels`, every 5m) polls only channels with `next_poll_at <= now`; the **pull-to-refresh "poll all" endpoint still force-polls every channel** (`due_only=False`), preserving that behavior. Pairs with the merged RSS path so a due-check + 304 is very cheap.

## Migration 010
Adds `channels.next_poll_at` (NOT NULL, backfilled to now so all channels are immediately due) + `poll_interval_minutes` + index `ix_channels_next_poll_at`.

## Note
Repurposed `check_interval_minutes` (60 → 5) as the beat **wake** interval (it was only referenced by the beat); per-channel cadence is now what governs polling frequency. `.env.example` updated. Flag if you'd rather a new `poll_beat_interval_minutes` setting.

## Verification (local)
- `pytest -q` → **180 passed** (+10: due-only vs force-all, shorten/lengthen, floor/cap bounds, failed-poll backoff, 304-lengthens, new-upload-shortens).
- `alembic` up/down round-trip clean · `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY