### PR TITLE
perf: bound /new-episodes with a SQL window function

### DIFF
--- a/alembic/versions/011_videos_channel_uploaded_index.py
+++ b/alembic/versions/011_videos_channel_uploaded_index.py
@@ -1,0 +1,31 @@
+"""Composite index videos(channel_id, uploaded_at) for the /new-episodes window query
+
+Revision ID: 011_videos_channel_uploaded_index
+Revises: 010_channel_poll_cadence
+Create Date: 2026-06-28
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "011_videos_channel_uploaded_index"
+down_revision: Union[str, None] = "010_channel_poll_cadence"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # /new-episodes picks the newest unwatched video per channel with a window
+    # function (PARTITION BY channel_id ORDER BY uploaded_at DESC). This
+    # composite index lets SQLite satisfy that partition+order directly instead
+    # of scanning every video in the subscribed library.
+    op.create_index(
+        "ix_videos_channel_id_uploaded_at",
+        "videos",
+        ["channel_id", "uploaded_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_videos_channel_id_uploaded_at", table_name="videos")

--- a/app/api/feed.py
+++ b/app/api/feed.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.auth import get_current_user
@@ -89,12 +89,24 @@ async def _new_episodes_items(
     if not subscribed_ids:
         return []
 
-    # One query for all unwatched videos across subscribed channels; keep the
-    # newest unwatched video per channel.
-    result = await db.execute(
-        select(UserVideoRef, Video, Channel)
-        .join(Video, UserVideoRef.video_id == Video.id)
-        .join(Channel, Video.channel_id == Channel.id)
+    # Rank each unwatched, completed video within its channel so the dedup-to-
+    # newest-per-channel happens in SQL. The window function runs over the
+    # already-filtered set (this user's unwatched, non-removed, COMPLETE videos
+    # in subscribed channels), so rank 1 is the newest *unwatched* per channel.
+    # Pushing this into the DB keeps latency tied to ``limit`` rather than the
+    # size of the subscribed library (the old code loaded every such row and
+    # deduped in Python).
+    ranked = (
+        select(
+            Video.id.label("video_id"),
+            func.row_number()
+            .over(
+                partition_by=Video.channel_id,
+                order_by=(Video.uploaded_at.desc(), Video.id.desc()),
+            )
+            .label("rn"),
+        )
+        .join(UserVideoRef, UserVideoRef.video_id == Video.id)
         .where(
             UserVideoRef.user_id == user.id,
             UserVideoRef.removed_at.is_(None),
@@ -102,25 +114,29 @@ async def _new_episodes_items(
             Video.channel_id.in_(subscribed_ids),
             Video.status == "COMPLETE",
         )
-        .order_by(Video.uploaded_at.desc().nullslast())
+        .subquery()
     )
 
-    items = []
-    seen_channels: set[str] = set()
-    for ref, video, channel in result.all():
-        if channel.id in seen_channels:
-            continue
-        seen_channels.add(channel.id)
-        items.append(
-            FeedItem(
-                channel=_channel_out(channel),
-                video=_video_out(video, ref),
-            )
+    result = await db.execute(
+        select(UserVideoRef, Video, Channel)
+        .join(Video, UserVideoRef.video_id == Video.id)
+        .join(Channel, Video.channel_id == Channel.id)
+        .join(ranked, ranked.c.video_id == Video.id)
+        .where(
+            UserVideoRef.user_id == user.id,
+            ranked.c.rn == 1,
         )
-        if len(items) >= limit:
-            break
+        .order_by(Video.uploaded_at.desc().nullslast())
+        .limit(limit)
+    )
 
-    return items
+    return [
+        FeedItem(
+            channel=_channel_out(channel),
+            video=_video_out(video, ref),
+        )
+        for ref, video, channel in result.all()
+    ]
 
 
 async def _recently_added_items(

--- a/app/models/video.py
+++ b/app/models/video.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import BigInteger, DateTime, ForeignKey, Integer, JSON, String
+from sqlalchemy import BigInteger, DateTime, ForeignKey, Index, Integer, JSON, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
@@ -10,6 +10,12 @@ from app.utils.time import utcnow_naive
 
 class Video(Base):
     __tablename__ = "videos"
+    __table_args__ = (
+        # /new-episodes ranks each channel's unwatched videos with a window
+        # function (PARTITION BY channel_id ORDER BY uploaded_at DESC) to pick
+        # the newest per channel; this composite serves that partition+order.
+        Index("ix_videos_channel_id_uploaded_at", "channel_id", "uploaded_at"),
+    )
 
     id: Mapped[str] = mapped_column(
         String(36), primary_key=True, default=lambda: str(uuid.uuid4())

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -94,3 +94,102 @@ async def test_home_feed_aggregates_all_sections(client, make_user):
 
 async def test_home_feed_requires_auth(client):
     assert (await client.get("/api/feed/home")).status_code == 401
+
+
+async def test_new_episodes_newest_per_channel_and_bounded_by_limit(client, make_user):
+    """With a large library, the result is the newest unwatched video per
+    channel, capped at ``limit`` and ordered by upload recency — regardless of
+    how many videos each channel holds (the SQL window-function dedup)."""
+    user, headers = await make_user()
+    now = utcnow_naive()
+    channel_count = 6
+    videos_per_channel = 5
+
+    expected_newest: dict[str, str] = {}  # channel_id -> newest unwatched video id
+    channels = []
+    async with async_session_factory() as db:
+        for c in range(channel_count):
+            channel = await seed_channel(db, name=f"Channel {c}")
+            await seed_subscription(db, user["id"], channel.id)
+            channels.append(channel)
+            # Channel c's newest upload is at (now - c hours), so channel 0 has
+            # the most recent newest video, channel 1 the next, and so on.
+            newest = None
+            for v in range(videos_per_channel):
+                uploaded = now - timedelta(hours=c, days=v)
+                video = await seed_video(
+                    db, channel, status="COMPLETE", uploaded_at=uploaded
+                )
+                await seed_ref(db, user["id"], video.id)
+                if v == 0:
+                    newest = video
+            assert newest is not None
+            expected_newest[channel.id] = newest.id
+
+    limit = 4
+    resp = await client.get(f"/api/feed/new-episodes?limit={limit}", headers=headers)
+    assert resp.status_code == 200
+    items = resp.json()
+
+    # Bounded by limit even though the library has channel_count * vids rows.
+    assert len(items) == limit
+    # No channel appears twice (dedup happened in SQL).
+    channel_ids = [item["channel"]["id"] for item in items]
+    assert len(set(channel_ids)) == len(channel_ids)
+    # Each returned video is its channel's newest unwatched upload.
+    for item in items:
+        assert item["video"]["id"] == expected_newest[item["video"]["channel_id"]]
+    # Ordered by upload recency: the first ``limit`` channels (0..limit-1).
+    assert channel_ids == [channels[i].id for i in range(limit)]
+
+
+async def test_new_episodes_ranks_only_unwatched_complete_in_channel(client, make_user):
+    """The window-function ranking runs over the filtered set, so a channel's
+    newest *eligible* video wins even when more-recent uploads are watched,
+    removed, or still downloading."""
+    user, headers = await make_user()
+    now = utcnow_naive()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        await seed_subscription(db, user["id"], channel.id)
+
+        # Newer than the answer, but each disqualified for a different reason.
+        watched = await seed_video(db, channel, status="COMPLETE", uploaded_at=now)
+        await seed_ref(db, user["id"], watched.id, is_watched=True)
+        removed = await seed_video(
+            db, channel, status="COMPLETE", uploaded_at=now - timedelta(hours=1)
+        )
+        await seed_ref(db, user["id"], removed.id, removed_at=now)
+        downloading = await seed_video(
+            db, channel, status="DOWNLOADING", uploaded_at=now - timedelta(hours=2)
+        )
+        await seed_ref(db, user["id"], downloading.id)
+
+        # The newest video that is unwatched, present, and COMPLETE.
+        answer = await seed_video(
+            db, channel, status="COMPLETE", uploaded_at=now - timedelta(hours=3)
+        )
+        await seed_ref(db, user["id"], answer.id)
+        # An older COMPLETE/unwatched video must lose to ``answer``.
+        await seed_ref(
+            db,
+            user["id"],
+            (
+                await seed_video(
+                    db,
+                    channel,
+                    status="COMPLETE",
+                    uploaded_at=now - timedelta(hours=4),
+                )
+            ).id,
+        )
+
+        # A video in a channel the user is not subscribed to is ignored.
+        other_channel = await seed_channel(db, name="Unsubscribed")
+        unsub = await seed_video(db, other_channel, status="COMPLETE", uploaded_at=now)
+        await seed_ref(db, user["id"], unsub.id)
+
+    resp = await client.get("/api/feed/new-episodes", headers=headers)
+    assert resp.status_code == 200
+    items = resp.json()
+    assert [item["video"]["id"] for item in items] == [answer.id]


### PR DESCRIPTION
Bound the /new-episodes query (roadmap LATER tier, #9). Additive — migration 011 (index only).

## Change
`_new_episodes_items` previously loaded every unwatched COMPLETE video for subscribed channels, then deduped to newest-per-channel + truncated in Python — latency grew with library size. Now a subquery ranks rows with `row_number() OVER (PARTITION BY channel_id ORDER BY uploaded_at DESC, id DESC)` over the already-filtered set; the outer query takes `rn == 1`, orders `uploaded_at DESC NULLS LAST`, and `LIMIT`s — so the DB returns ~limit rows and Python only builds those. Ordering, per-channel dedup, and response shape unchanged (the `id DESC` tiebreak just makes the per-channel pick deterministic).

Migration `011_videos_channel_uploaded_index` adds `ix_videos_channel_id_uploaded_at` on `videos(channel_id, uploaded_at)` (also in `__table_args__`). SQLite 3.51 supports window functions.

## Verification (local)
- `pytest -q` → **182 passed** (existing /new-episodes tests unchanged; +2: bounded ≤ limit + newest-per-channel over a 6×5 library; ranking runs over the filtered set).
- `alembic` up/down round-trip clean · `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY