### PR TITLE
perf: parallel per-channel poll fan-out + batched ref-ensure

### DIFF
--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -72,15 +72,15 @@ def _backoff_failed_channel(channel_id: str, db: Session) -> None:
         db.rollback()
 
 
-def poll_all_channels(db: Session, *, due_only: bool = False) -> list[str]:
-    """Poll subscribed channels and return aggregated auto-download video IDs.
+def list_channel_ids_to_poll(db: Session, *, due_only: bool = False) -> list[str]:
+    """Return the distinct subscribed channel ids that should be polled.
 
-    When ``due_only`` is set (the periodic beat), only channels whose
-    ``next_poll_at`` has passed are polled, so each frequent run does work
-    proportional to how many channels are actually due instead of re-polling
-    every channel every time. When unset (an explicit "refresh everything"
-    request, e.g. pull-to-refresh) every subscribed channel is polled now,
-    regardless of its schedule.
+    When ``due_only`` is set (the periodic beat) only channels whose adaptive
+    schedule has come due (``next_poll_at <= now``) are returned — a cheap,
+    indexed query the beat runs on every wake to decide how much work to fan
+    out. When unset (an explicit "refresh everything" request, e.g.
+    pull-to-refresh) every subscribed channel is returned regardless of its
+    schedule. This is the work list the beat dispatches one per-channel job per.
     """
     stmt = (
         select(Channel.id)
@@ -90,7 +90,19 @@ def poll_all_channels(db: Session, *, due_only: bool = False) -> list[str]:
     if due_only:
         stmt = stmt.where(Channel.next_poll_at <= utcnow_naive())
 
-    channel_ids = [row[0] for row in db.execute(stmt).all()]
+    return [row[0] for row in db.execute(stmt).all()]
+
+
+def poll_all_channels(db: Session, *, due_only: bool = False) -> list[str]:
+    """Poll subscribed channels in-process and return auto-download video IDs.
+
+    Synchronous reference path: every due (or every subscribed, when
+    ``due_only`` is unset) channel is polled sequentially on the one ``db``
+    session. Production fans the same work out into isolated per-channel Celery
+    jobs (see ``app.tasks.download_tasks.poll_all_channels_task``); this helper
+    is retained for direct/inline use and is exercised by the adaptive tests.
+    """
+    channel_ids = list_channel_ids_to_poll(db, due_only=due_only)
     logger.info("Polling %d channels (due_only=%s)", len(channel_ids), due_only)
 
     all_auto_download_ids: list[str] = []
@@ -145,6 +157,25 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
     cataloged_ids: list[str] = []
     new_video_ids: list[str] = []
     new_videos_for_events: list[dict] = []
+    # Every video this poll touched (new rows plus already-cataloged ones seen
+    # in the feed); a single batched ref-ensure runs over them after the loop.
+    video_ids_for_refs: list[str] = []
+
+    # Batch the existence check: one query maps every feed id we already have to
+    # its row id, replacing the per-video SELECT. id_by_ytid also absorbs rows
+    # created during this loop so a duplicate feed entry resolves as existing
+    # instead of being inserted twice.
+    feed_ids = [v["youtube_video_id"] for v in yt_videos if v.get("youtube_video_id")]
+    id_by_ytid: dict[str, str] = {}
+    if feed_ids:
+        id_by_ytid = {
+            ytid: row_id
+            for row_id, ytid in db.execute(
+                select(Video.id, Video.youtube_video_id).where(
+                    Video.youtube_video_id.in_(feed_ids)
+                )
+            ).all()
+        }
 
     # yt-dlp returns the channel feed newest-first. Cataloged videos have no
     # upload date until downloaded, and listings fall back to created_at — so
@@ -157,14 +188,11 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
         if not yt_video_id:
             continue
 
-        # Check if video already exists
-        existing = db.execute(
-            select(Video).where(Video.youtube_video_id == yt_video_id)
-        ).scalar_one_or_none()
-
-        if existing:
-            # Video exists; ensure all subscribers have a reference.
-            _ensure_user_refs(existing, channel_id, db)
+        existing_id = id_by_ytid.get(yt_video_id)
+        if existing_id is not None:
+            # Already cataloged (or created earlier in this same feed batch);
+            # just ensure refs exist for it in the batched pass below.
+            video_ids_for_refs.append(existing_id)
             continue
 
         # Parse upload_date into uploaded_at (stored as naive UTC)
@@ -188,10 +216,10 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
         )
         db.add(video)
         db.flush()
+        # Record so a duplicate id later in this same feed resolves as existing.
+        id_by_ytid[yt_video_id] = video.id
 
-        # Create user video refs for all subscribers
-        _ensure_user_refs(video, channel_id, db)
-
+        video_ids_for_refs.append(video.id)
         new_video_ids.append(video.id)
         cataloged_ids.append(video.id)
         new_videos_for_events.append(
@@ -202,6 +230,10 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
             }
         )
         logger.info("New video cataloged: %s (%s)", yt_video_id, video.title)
+
+    # One batched ref-ensure over every video this poll touched, instead of the
+    # per-video, per-subscriber N+1 the old per-video helper issued.
+    _ensure_user_refs_bulk(video_ids_for_refs, channel_id, db)
 
     # Determine auto-download candidates based on subscriber tracking modes
     auto_download_ids: list[str] = []
@@ -452,23 +484,44 @@ def _emit_new_episode_events(channel_id: str, videos: list[dict], db: Session) -
         )
 
 
-def _ensure_user_refs(video: Video, channel_id: str, db: Session) -> None:
-    """Ensure all subscribers of a channel have a UserVideoRef for this video."""
-    sub_result = db.execute(
-        select(UserSubscription.user_id).where(
-            UserSubscription.channel_id == channel_id
-        )
+def _ensure_user_refs_bulk(video_ids: list[str], channel_id: str, db: Session) -> None:
+    """Ensure every subscriber of the channel has a UserVideoRef per video.
+
+    Batched to a bounded number of queries regardless of how many videos this
+    poll touched or how many subscribers the channel has: one query for the
+    subscriber ids and one for the refs that already exist across the whole
+    (subscriber x video) set, then a single set-difference insert. Replaces the
+    per-video, per-subscriber N+1 the old per-video helper issued; mirrors the
+    batched pattern in app/api/channels.py::_ensure_refs_for_channel.
+
+    Keeps the prior create-if-missing semantics: an already-present ref is left
+    untouched, so a soft-removed ref (removed_at set) is not resurrected.
+    """
+    unique_video_ids = list(dict.fromkeys(video_ids))
+    if not unique_video_ids:
+        return
+
+    subscriber_ids = [
+        row[0]
+        for row in db.execute(
+            select(UserSubscription.user_id).where(
+                UserSubscription.channel_id == channel_id
+            )
+        ).all()
+    ]
+    if not subscriber_ids:
+        return
+
+    existing_pairs = set(
+        db.execute(
+            select(UserVideoRef.user_id, UserVideoRef.video_id).where(
+                UserVideoRef.user_id.in_(subscriber_ids),
+                UserVideoRef.video_id.in_(unique_video_ids),
+            )
+        ).all()
     )
-    subscriber_ids = [row[0] for row in sub_result.all()]
 
     for user_id in subscriber_ids:
-        existing_ref = db.execute(
-            select(UserVideoRef).where(
-                UserVideoRef.user_id == user_id,
-                UserVideoRef.video_id == video.id,
-            )
-        ).scalar_one_or_none()
-
-        if not existing_ref:
-            ref = UserVideoRef(user_id=user_id, video_id=video.id)
-            db.add(ref)
+        for video_id in unique_video_ids:
+            if (user_id, video_id) not in existing_pairs:
+                db.add(UserVideoRef(user_id=user_id, video_id=video_id))

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -3,6 +3,7 @@ import os
 import time
 from datetime import datetime
 
+from celery import group
 from celery.signals import worker_ready
 from sqlalchemy import create_engine, select, update
 from sqlalchemy.orm import Session, sessionmaker
@@ -14,7 +15,8 @@ from app.models.channel import Channel
 from app.models.subscription import UserSubscription
 from app.models.video import Video
 from app.services.channel_poller import (
-    poll_all_channels,
+    _backoff_failed_channel,
+    list_channel_ids_to_poll,
     poll_single_channel,
     refresh_stale_channel_metadata,
 )
@@ -58,29 +60,34 @@ def _get_sync_db() -> Session:
     max_retries=0,
 )
 def poll_all_channels_task(self, due_only: bool = False) -> dict:
-    """Poll subscribed channels for new videos.
+    """Fan the channel poll out into one isolated per-channel job each.
 
-    The beat passes ``due_only=True`` so each frequent run only polls channels
-    whose adaptive schedule has come due. An explicit "refresh everything"
-    request (the pull-to-refresh endpoint) calls it with the default
-    ``due_only=False`` to poll every subscribed channel now.
+    The beat passes ``due_only=True`` so each frequent run only enumerates the
+    channels whose adaptive schedule has come due; the pull-to-refresh "poll
+    all" endpoint calls it with the default ``due_only=False`` to refresh every
+    subscribed channel now. Either way this task does only the cheap, indexed
+    due-check here and dispatches a Celery GROUP of ``poll_channel_task`` jobs,
+    one per channel. Each job runs on its OWN DB session, so a single slow or
+    stuck channel (yt-dlp/RSS) no longer blocks or aborts the others, and each
+    job reschedules and enqueues auto-downloads for its own channel.
     """
     db = _get_sync_db()
     try:
-        auto_download_ids = poll_all_channels(db, due_only=due_only)
-
-        # Only enqueue auto-download candidates (not blanket PENDING sweep)
-        enqueued = 0
-        for video_id in auto_download_ids:
-            download_video_task.delay(video_id)
-            enqueued += 1
-
-        return {"status": "ok", "enqueued": enqueued}
+        channel_ids = list_channel_ids_to_poll(db, due_only=due_only)
     except Exception:
-        logger.exception("Error in poll_all_channels_task")
+        logger.exception("Error enumerating channels to poll")
         return {"status": "error"}
     finally:
         db.close()
+
+    if not channel_ids:
+        return {"status": "ok", "dispatched": 0}
+
+    group(poll_channel_task.s(channel_id) for channel_id in channel_ids).apply_async()
+    logger.info(
+        "Dispatched %d per-channel poll jobs (due_only=%s)", len(channel_ids), due_only
+    )
+    return {"status": "ok", "dispatched": len(channel_ids)}
 
 
 @celery_app.task(
@@ -89,7 +96,15 @@ def poll_all_channels_task(self, due_only: bool = False) -> dict:
     max_retries=0,
 )
 def poll_channel_task(self, channel_id: str) -> dict:
-    """Poll a single channel and enqueue downloads for auto-download candidates."""
+    """Poll a single channel and enqueue downloads for auto-download candidates.
+
+    The unit of work the periodic fan-out dispatches (also the immediate poll on
+    subscribe). Runs on its own DB session and absorbs its own failures so one
+    channel can't affect another: on error it rolls back and widens the
+    channel's adaptive cadence — exactly what the old sequential loop did — so a
+    persistently broken channel backs off instead of being re-dispatched every
+    beat.
+    """
     db = _get_sync_db()
     try:
         result = poll_single_channel(channel_id, db)
@@ -105,6 +120,8 @@ def poll_channel_task(self, channel_id: str) -> dict:
         }
     except Exception:
         logger.exception("Error polling channel %s", channel_id)
+        db.rollback()
+        _backoff_failed_channel(channel_id, db)
         return {"status": "error"}
     finally:
         db.close()

--- a/tests/test_parallel_poll.py
+++ b/tests/test_parallel_poll.py
@@ -1,0 +1,348 @@
+"""Tests for the parallel per-channel poll fan-out.
+
+The periodic beat no longer polls every due channel sequentially on one
+session; it enumerates the due channel ids (cheap, indexed) and dispatches a
+Celery GROUP of per-channel ``poll_channel_task`` jobs, each on its OWN DB
+session. These tests drive that fan-out in eager mode (``task_always_eager``,
+so the group executes inline) over a shared in-memory SQLite, and cover:
+
+* the beat dispatches exactly the due channels (and all of them when forced);
+* one channel's failure is isolated — a healthy channel still polls and
+  reschedules while the broken one backs off instead of hot-looping;
+* the batched ref-ensure issues a bounded number of queries.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, event, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from app.services import channel_poller
+from app.utils.time import utcnow_naive
+
+_UC_ID = "UCabc1230000000000000000"
+
+
+@pytest.fixture
+def eager_celery(monkeypatch):
+    """Run tasks (and the dispatched group) inline instead of via the broker."""
+    from app.tasks.celery_app import celery_app
+
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", True)
+    monkeypatch.setattr(celery_app.conf, "task_eager_propagates", True)
+    return celery_app
+
+
+@pytest.fixture
+def task_db(monkeypatch):
+    """A shared in-memory DB wired into the Celery tasks' ``_get_sync_db``.
+
+    StaticPool keeps a single connection so every session the eager tasks open
+    sees the same data. No SQLite pragmas are registered (foreign keys stay
+    off), matching the other poller unit tests, so subscriptions and refs can be
+    seeded without real user rows.
+    """
+    import app.tasks.download_tasks as dt
+
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session_local = sessionmaker(bind=engine)
+    monkeypatch.setattr(dt, "_get_sync_db", lambda: session_local())
+    # Never touch the real download path during eager fan-out.
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr(dt.download_video_task, "delay", MagicMock())
+    return session_local
+
+
+def _cadence(monkeypatch, *, floor=15, cap=240, factor=2.0):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "poll_interval_floor_minutes", floor)
+    monkeypatch.setattr(settings, "poll_interval_cap_minutes", cap)
+    monkeypatch.setattr(settings, "poll_interval_backoff_factor", factor)
+
+
+def _seed_channel(session_local, *, next_poll_at, **overrides) -> Channel:
+    db = session_local()
+    suffix = uuid.uuid4().hex[:8]
+    channel = Channel(
+        id=str(uuid.uuid4()),
+        youtube_channel_id=f"{_UC_ID}{suffix}",
+        name="Test",
+        slug=f"test-{suffix}",
+        next_poll_at=next_poll_at,
+        poll_interval_minutes=overrides.pop("poll_interval_minutes", 30),
+        last_checked_at=overrides.pop("last_checked_at", None),
+    )
+    for key, value in overrides.items():
+        setattr(channel, key, value)
+    db.add(channel)
+    db.add(UserSubscription(user_id="u1", channel_id=channel.id))
+    db.commit()
+    db.refresh(channel)
+    db.close()
+    return channel
+
+
+# --- fan-out enumeration ----------------------------------------------------
+
+
+def test_beat_dispatches_one_job_per_due_channel(eager_celery, task_db, monkeypatch):
+    """due_only fans out a job for each due channel and skips the rest."""
+    import app.tasks.download_tasks as dt
+
+    due_a = _seed_channel(task_db, next_poll_at=_past())
+    due_b = _seed_channel(task_db, next_poll_at=_past())
+    not_due = _seed_channel(task_db, next_poll_at=_future())
+
+    polled: list[str] = []
+
+    def record(channel_id, _db):
+        polled.append(channel_id)
+        return {"cataloged_ids": [], "auto_download_ids": []}
+
+    monkeypatch.setattr(dt, "poll_single_channel", record)
+
+    result = dt.poll_all_channels_task.apply_async(kwargs={"due_only": True}).get()
+
+    assert result == {"status": "ok", "dispatched": 2}
+    assert set(polled) == {due_a.id, due_b.id}
+    assert not_due.id not in polled
+
+
+def test_force_poll_dispatches_every_channel(eager_celery, task_db, monkeypatch):
+    """due_only=False (pull-to-refresh poll-all) fans out for every channel."""
+    import app.tasks.download_tasks as dt
+
+    due = _seed_channel(task_db, next_poll_at=_past())
+    not_due = _seed_channel(task_db, next_poll_at=_future())
+
+    polled: list[str] = []
+    monkeypatch.setattr(
+        dt,
+        "poll_single_channel",
+        lambda cid, _db: (
+            polled.append(cid) or {"cataloged_ids": [], "auto_download_ids": []}
+        ),
+    )
+
+    result = dt.poll_all_channels_task.apply_async(kwargs={"due_only": False}).get()
+
+    assert result == {"status": "ok", "dispatched": 2}
+    assert set(polled) == {due.id, not_due.id}
+
+
+def test_beat_with_no_due_channels_dispatches_nothing(eager_celery, task_db):
+    import app.tasks.download_tasks as dt
+
+    _seed_channel(task_db, next_poll_at=_future())
+
+    result = dt.poll_all_channels_task.apply_async(kwargs={"due_only": True}).get()
+
+    assert result == {"status": "ok", "dispatched": 0}
+
+
+# --- isolation: one stuck channel must not block/abort the others -----------
+
+
+def test_failing_channel_job_does_not_abort_others(eager_celery, task_db, monkeypatch):
+    """A channel whose poll raises is isolated: the healthy channel still polls
+    and reschedules toward the floor, while the broken one backs off toward the
+    cap instead of hot-looping the beat."""
+    _cadence(monkeypatch, floor=15, cap=240, factor=2.0)
+    import app.tasks.download_tasks as dt
+
+    good = _seed_channel(
+        task_db,
+        next_poll_at=_past(),
+        poll_interval_minutes=30,
+        last_checked_at=utcnow_naive(),
+    )
+    bad = _seed_channel(
+        task_db,
+        next_poll_at=_past(),
+        poll_interval_minutes=30,
+        last_checked_at=utcnow_naive(),
+    )
+
+    good_yt = good.youtube_channel_id
+    new_vid = "GOODNEW0001"
+
+    def fake_rss(channel_id, etag=None, last_modified=None):
+        if channel_id == good_yt:
+            return {
+                "status": "ok",
+                "entries": [{"youtube_video_id": new_vid}],
+                "etag": None,
+                "last_modified": None,
+            }
+        raise RuntimeError("yt-dlp/RSS hung for this channel")
+
+    monkeypatch.setattr(channel_poller, "fetch_channel_rss", fake_rss)
+    monkeypatch.setattr(
+        channel_poller,
+        "fetch_videos_metadata",
+        lambda ids: [
+            {
+                "youtube_video_id": vid,
+                "title": vid,
+                "duration_seconds": 0,
+                "upload_date": None,
+            }
+            for vid in ids
+        ],
+    )
+    from unittest.mock import MagicMock
+
+    monkeypatch.setattr(channel_poller, "publish_new_episode", MagicMock())
+
+    before = utcnow_naive()
+    dt.poll_all_channels_task.apply_async(kwargs={"due_only": True}).get()
+
+    db = task_db()
+    try:
+        # The healthy channel polled despite the other failing: its new video is
+        # cataloged and its cadence shortened toward the floor.
+        good_after = db.get(Channel, good.id)
+        good_videos = (
+            db.execute(select(Video).where(Video.channel_id == good.id)).scalars().all()
+        )
+        assert [v.youtube_video_id for v in good_videos] == [new_vid]
+        assert good_after.poll_interval_minutes == 15  # 30 / 2, found_new
+        assert good_after.next_poll_at > before
+
+        # The broken channel cataloged nothing and was backed off (interval
+        # widened, next poll pushed into the future) rather than left due.
+        bad_after = db.get(Channel, bad.id)
+        bad_videos = (
+            db.execute(select(Video).where(Video.channel_id == bad.id)).scalars().all()
+        )
+        assert bad_videos == []
+        assert bad_after.poll_interval_minutes == 60  # 30 * 2, backed off
+        assert bad_after.next_poll_at > before
+    finally:
+        db.close()
+
+    # The healthy channel's new upload was enqueued for auto-download exactly
+    # once; the failed channel enqueued nothing.
+    assert dt.download_video_task.delay.call_count == 1
+    (enqueued_id,) = dt.download_video_task.delay.call_args.args
+    assert enqueued_id == good_videos[0].id
+
+
+def test_per_channel_job_reschedules_its_own_channel(
+    eager_celery, task_db, monkeypatch
+):
+    """A single due channel polled via the fan-out reschedules itself (304 ->
+    empty poll -> cadence widens, last_checked stamped, next poll in future)."""
+    _cadence(monkeypatch, floor=15, cap=240, factor=2.0)
+    import app.tasks.download_tasks as dt
+
+    ch = _seed_channel(
+        task_db,
+        next_poll_at=_past(),
+        poll_interval_minutes=60,
+        last_checked_at=utcnow_naive(),
+    )
+    monkeypatch.setattr(
+        channel_poller, "fetch_channel_rss", lambda *a, **k: {"status": "not_modified"}
+    )
+
+    before = utcnow_naive()
+    result = dt.poll_all_channels_task.apply_async(kwargs={"due_only": True}).get()
+    assert result == {"status": "ok", "dispatched": 1}
+
+    db = task_db()
+    try:
+        after = db.get(Channel, ch.id)
+        assert after.poll_interval_minutes == 120  # 60 * 2, empty poll
+        assert after.next_poll_at > before
+        assert after.last_checked_at is not None
+    finally:
+        db.close()
+
+
+# --- batched ref-ensure: bounded query count --------------------------------
+
+
+@pytest.mark.parametrize("n_subs,n_videos", [(1, 1), (3, 5), (8, 8)])
+def test_ensure_user_refs_bulk_is_bounded(n_subs, n_videos):
+    """The batched ref-ensure issues a constant 2 SELECTs regardless of how many
+    subscribers or videos it covers (vs the old per-video, per-subscriber N+1)."""
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+
+    selects: list[str] = []
+
+    @event.listens_for(engine, "before_cursor_execute")
+    def _count(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            selects.append(statement)
+
+    db = sessionmaker(bind=engine)()
+    channel_id = str(uuid.uuid4())
+    db.add(
+        Channel(
+            id=channel_id,
+            youtube_channel_id=_UC_ID,
+            name="Test",
+            slug="test",
+        )
+    )
+    for i in range(n_subs):
+        db.add(UserSubscription(user_id=f"u{i}", channel_id=channel_id))
+    video_ids = []
+    for i in range(n_videos):
+        vid_id = str(uuid.uuid4())
+        db.add(
+            Video(
+                id=vid_id,
+                youtube_video_id=f"vid{i:08d}",
+                channel_id=channel_id,
+                title=f"v{i}",
+                status="CATALOGED",
+            )
+        )
+        video_ids.append(vid_id)
+    db.commit()
+
+    # Ids captured as plain strings above, so passing them triggers no
+    # post-commit attribute reload that would skew the SELECT count.
+    selects.clear()
+    channel_poller._ensure_user_refs_bulk(video_ids, channel_id, db)
+    db.flush()
+
+    # One SELECT for subscriber ids + one for existing (subscriber x video)
+    # pairs. Bounded — independent of n_subs and n_videos.
+    assert len(selects) == 2
+
+    refs = db.execute(select(UserVideoRef)).scalars().all()
+    assert len(refs) == n_subs * n_videos
+    db.close()
+
+
+# --- helpers ----------------------------------------------------------------
+
+
+def _past():
+    from datetime import timedelta
+
+    return utcnow_naive() - timedelta(minutes=1)
+
+
+def _future():
+    from datetime import timedelta
+
+    return utcnow_naive() + timedelta(hours=2)


### PR DESCRIPTION
Parallelize channel polling (roadmap LATER tier, #8). Behavioral only — no migration.

## Fan-out
`poll_all_channels_task` (the beat + the pull-to-refresh `POST /api/channels/poll` target) now does only the cheap indexed due-check (`list_channel_ids_to_poll`), then dispatches a Celery `group` of `poll_channel_task(channel_id)` jobs — one per channel, each with its own DB session. So a slow channel no longer delays the rest. Both the beat (`due_only=True`) and manual poll-all (`due_only=False`) get parallelism; single-channel `POST /api/channels/{id}/poll` keeps its synchronous path.

## Isolation
Each per-channel job has its own session + try/except; on failure it rolls back and calls `_backoff_failed_channel` (preserving the hot-loop protection by widening cadence) — a sibling's transaction is never touched. Discovery stays timeout-bounded (RSS 15s, yt-dlp 120s), so a slow channel pins one bounded worker slot, not the loop. RSS/304 fast path, first-catalog fallback, `new_episode` events, and auto-download gating are all preserved.

## Batched ref-ensure
Replaced the per-video `_ensure_user_refs` (N+1) with `_ensure_user_refs_bulk`: 1 query for subscribers + 1 for existing (subscriber×video) pairs + a set-difference insert — **2 SELECTs regardless of scale** (verified at (1,1)/(3,5)/(8,8)). Also collapsed the per-video existence check into one `in_()` lookup.

## Verification (local)
- `pytest -q` → **190 passed** (+8: beat dispatches exactly due channels; a failing-channel job is isolated while a healthy one still catalogs + shortens cadence; bulk ref-ensure stays at 2 SELECTs).
- `ruff` clean · no migration (sanity-checked alembic round-trip anyway).

FYI: per-channel poll jobs share the worker pool with downloads; a dedicated poll queue could guarantee throughput later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY