### PR TITLE
feat: enforce per-subscription retention policy

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,14 @@ class Settings(BaseSettings):
     poll_interval_cap_minutes: int = 240
     poll_interval_backoff_factor: float = 2.0
 
+    # Retention enforcement
+    # How often the retention sweep runs (Celery beat, in hours). Each run
+    # applies every subscription's retention_policy: e.g. KEEP_LAST_N keeps the
+    # newest N downloaded videos and soft-removes the user's refs to the rest,
+    # letting the orphan cleanup reclaim files no other user still wants.
+    # Reclaiming disk is not urgent, so a few hours' latency is plenty.
+    retention_interval_hours: int = 6
+
     # Auth sessions
     # A session is rejected once it is older than the absolute TTL (since
     # creation) or has been idle longer than the idle TTL (since last activity).

--- a/app/services/retention.py
+++ b/app/services/retention.py
@@ -1,0 +1,141 @@
+"""Apply each subscription's retention policy.
+
+The ``retention_policy`` / ``retention_count`` fields on a ``UserSubscription``
+let a self-hoster bound how many downloaded videos a channel keeps on disk. This
+module is the enforcement the periodic Celery task drives: for every
+subscription that sets a policy, it soft-removes the user's ``UserVideoRef`` for
+the downloaded videos the policy no longer keeps, then reuses the orphan cleanup
+(:func:`app.services.storage.check_and_delete_orphan_sync`) to reclaim any file
+no remaining active ref still wants. Doing it this way keeps the ref-count the
+single source of truth for shared downloads: soft-removing one user's ref never
+deletes a file another user is still holding.
+
+Retention is scoped per subscription (per user, per channel) because that is
+where the fields live, and it only ever considers videos the user actually
+downloaded (``status == "COMPLETE"``) — cataloged-but-not-downloaded videos
+occupy no disk and are left untouched.
+
+Like the other reapers this does no Celery I/O so it stays unit-testable; the
+scheduling lives in the task wrapper.
+"""
+
+import logging
+from datetime import datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session as DBSession
+
+from app.models.subscription import UserSubscription
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from app.services.storage import check_and_delete_orphan_sync
+from app.utils.time import utcnow_naive
+
+logger = logging.getLogger(__name__)
+
+# Known retention policies (the wire values the clients send).
+KEEP_ALL = "KEEP_ALL"  # default — keep everything, nothing to enforce
+KEEP_LAST_N = "KEEP_LAST_N"  # keep the newest N downloaded videos
+# KEEP_WATCHED is a client-defined value but is intentionally NOT enforced here:
+# its only sensible reading ("delete videos you have not watched yet") is
+# destructive, so we treat it as a no-op until the product semantics are pinned
+# down rather than risk removing videos a user still intends to watch.
+KEEP_WATCHED = "KEEP_WATCHED"
+
+
+def _refs_to_drop_for_subscription(
+    db: DBSession, sub: UserSubscription
+) -> list[UserVideoRef]:
+    """Return the active refs this subscription's policy says to soft-remove.
+
+    Only the user's *downloaded* (``COMPLETE``) videos in the channel are
+    considered. Returns an empty list for policies that keep everything, are
+    unconfigured, or are not enforced.
+    """
+    if sub.retention_policy == KEEP_LAST_N:
+        keep = sub.retention_count
+        # Without a positive count there is nothing to enforce; a non-positive
+        # count is treated as a misconfiguration rather than "delete all".
+        if keep is None or keep < 1:
+            return []
+        # The user's downloaded videos in this channel, newest first. Sort key
+        # mirrors how the app presents videos (upload date, falling back to
+        # catalog time) with a stable id tiebreak so "newest N" is deterministic.
+        refs = (
+            db.execute(
+                select(UserVideoRef)
+                .join(Video, UserVideoRef.video_id == Video.id)
+                .where(
+                    Video.channel_id == sub.channel_id,
+                    Video.status == "COMPLETE",
+                    UserVideoRef.user_id == sub.user_id,
+                    UserVideoRef.removed_at.is_(None),
+                )
+                .order_by(
+                    func.coalesce(Video.uploaded_at, Video.created_at).desc(),
+                    Video.id.desc(),
+                )
+            )
+            .scalars()
+            .all()
+        )
+        # Keep the newest `keep`; everything older is dropped.
+        return list(refs[keep:])
+
+    # KEEP_ALL, KEEP_WATCHED, or an unknown value: nothing to drop.
+    return []
+
+
+def enforce_retention(db: DBSession, now: datetime | None = None) -> dict:
+    """Apply every subscription's retention policy. Returns a summary dict.
+
+    Soft-removes the refs each policy no longer keeps (committed in one batch),
+    then runs the orphan cleanup on the affected videos so files no other active
+    ref still wants are reclaimed and their rows reset to ``CATALOGED``.
+    """
+    now = now or utcnow_naive()
+
+    # Only subscriptions that actually set a policy can do work.
+    subs = (
+        db.execute(
+            select(UserSubscription).where(
+                UserSubscription.retention_policy != KEEP_ALL
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    affected_video_ids: set[str] = set()
+    refs_removed = 0
+    for sub in subs:
+        for ref in _refs_to_drop_for_subscription(db, sub):
+            ref.removed_at = now
+            affected_video_ids.add(ref.video_id)
+            refs_removed += 1
+
+    if refs_removed:
+        db.commit()
+
+    # Reuse the existing orphan cleanup: it deletes the file and resets the row
+    # only when no active ref remains, so a video another user still holds is
+    # left intact (shared downloads stay ref-counted).
+    reclaimed = 0
+    for video_id in affected_video_ids:
+        if check_and_delete_orphan_sync(video_id, db):
+            reclaimed += 1
+
+    if refs_removed:
+        logger.info(
+            "Retention sweep: %d subscription(s) with a policy, "
+            "%d ref(s) soft-removed, %d file(s) reclaimed",
+            len(subs),
+            refs_removed,
+            reclaimed,
+        )
+
+    return {
+        "subscriptions": len(subs),
+        "refs_removed": refs_removed,
+        "reclaimed": reclaimed,
+    }

--- a/app/services/storage.py
+++ b/app/services/storage.py
@@ -3,6 +3,7 @@ import os
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session as DBSession
 
 from app.config import settings
 from app.models.user_video_ref import UserVideoRef
@@ -11,30 +12,13 @@ from app.models.video import Video
 logger = logging.getLogger(__name__)
 
 
-async def check_and_delete_orphan(video_id: str, db: AsyncSession) -> bool:
+def _reclaim_orphan_artifacts(video: Video) -> None:
+    """Delete a video's on-disk artifacts and reset its row to CATALOGED.
+
+    Pure filesystem + attribute mutation: the caller owns the session and the
+    commit. Shared by the async (API) and sync (Celery) orphan-cleanup entry
+    points so the reclamation logic lives in exactly one place.
     """
-    Check if a video has any remaining active references.
-    If not, delete the physical file from disk and clean up thumbnails.
-    Returns True if the file was deleted.
-    """
-    # Count active (non-removed) references
-    result = await db.execute(
-        select(UserVideoRef).where(
-            UserVideoRef.video_id == video_id,
-            UserVideoRef.removed_at.is_(None),
-        )
-    )
-    active_refs = result.scalars().all()
-
-    if active_refs:
-        return False
-
-    # No active references remain; delete from disk.
-    video_result = await db.execute(select(Video).where(Video.id == video_id))
-    video = video_result.scalar_one_or_none()
-    if not video:
-        return False
-
     # Delete preview file
     if video.preview_file_path:
         preview_path = video.preview_file_path
@@ -85,7 +69,68 @@ async def check_and_delete_orphan(video_id: str, db: AsyncSession) -> bool:
     video.file_size_bytes = None
     video.preview_file_path = None
     video.preview_status = None
+
+
+async def check_and_delete_orphan(video_id: str, db: AsyncSession) -> bool:
+    """
+    Check if a video has any remaining active references.
+    If not, delete the physical file from disk and clean up thumbnails.
+    Returns True if the file was deleted.
+    """
+    # Count active (non-removed) references
+    result = await db.execute(
+        select(UserVideoRef).where(
+            UserVideoRef.video_id == video_id,
+            UserVideoRef.removed_at.is_(None),
+        )
+    )
+    if result.scalars().first() is not None:
+        return False
+
+    # No active references remain; delete from disk.
+    video_result = await db.execute(select(Video).where(Video.id == video_id))
+    video = video_result.scalar_one_or_none()
+    if not video:
+        return False
+
+    _reclaim_orphan_artifacts(video)
     await db.commit()
+
+    logger.info(
+        "Orphan cleanup complete for video %s (%s)",
+        video_id,
+        video.youtube_video_id,
+    )
+    return True
+
+
+def check_and_delete_orphan_sync(video_id: str, db: DBSession) -> bool:
+    """Synchronous twin of :func:`check_and_delete_orphan` for Celery tasks.
+
+    Celery runs on a synchronous SQLAlchemy ``Session``, so the async version
+    cannot be awaited there. Same contract: when no active reference remains,
+    delete the on-disk artifacts and reset the row; returns True when a file was
+    reclaimed.
+    """
+    active = (
+        db.execute(
+            select(UserVideoRef).where(
+                UserVideoRef.video_id == video_id,
+                UserVideoRef.removed_at.is_(None),
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if active is not None:
+        return False
+
+    video = db.get(Video, video_id)
+    if not video:
+        return False
+
+    _reclaim_orphan_artifacts(video)
+    db.commit()
 
     logger.info(
         "Orphan cleanup complete for video %s (%s)",

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -51,4 +51,12 @@ celery_app.conf.beat_schedule = {
         "task": "app.tasks.download_tasks.reap_expired_sessions_task",
         "schedule": 3600,  # hourly
     },
+    # Apply each subscription's retention_policy (e.g. KEEP_LAST_N): soft-remove
+    # the user's refs to downloaded videos beyond the policy so the orphan
+    # cleanup can reclaim files nobody else still wants. Cheap (indexed queries
+    # over the few subscriptions that set a policy); a few hours' latency is fine.
+    "enforce-retention": {
+        "task": "app.tasks.download_tasks.enforce_retention_task",
+        "schedule": settings.retention_interval_hours * 3600,
+    },
 }

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -27,6 +27,7 @@ from app.services.download_manager import (
     download_video,
 )
 from app.services.download_reaper import reap_stuck_downloads
+from app.services.retention import enforce_retention
 from app.services.session_reaper import reap_expired_sessions
 from app.utils.time import utcnow_naive
 from app.services.progress_broadcaster import (
@@ -452,6 +453,29 @@ def reap_stuck_downloads_task(self) -> dict:
         download_video_task.delay(video_id)
 
     return {"status": "ok", **result}
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.enforce_retention_task",
+    bind=True,
+    max_retries=0,
+)
+def enforce_retention_task(self) -> dict:
+    """Periodic task: apply each subscription's retention policy.
+
+    Soft-removes the user's refs to downloaded videos the policy no longer keeps
+    (e.g. beyond the newest N for KEEP_LAST_N), then reuses the orphan cleanup to
+    reclaim any file no remaining active ref still wants.
+    """
+    db = _get_sync_db()
+    try:
+        result = enforce_retention(db)
+        return {"status": "ok", **result}
+    except Exception:
+        logger.exception("Error in enforce_retention_task")
+        return {"status": "error"}
+    finally:
+        db.close()
 
 
 @celery_app.task(

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,242 @@
+"""Tests for retention-policy enforcement (issue #12).
+
+These exercise the synchronous sweep directly (the way the Celery task does),
+against an in-memory SQLite session plus real files under the temp media paths
+that conftest configures, so the full path is covered: soft-remove the refs a
+policy drops, then reclaim via the shared orphan cleanup.
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.config import settings
+from app.models import Base
+from app.models.subscription import UserSubscription
+from app.models.user_video_ref import UserVideoRef
+from app.models.video import Video
+from app.services.retention import KEEP_ALL, KEEP_LAST_N, enforce_retention
+from app.utils.time import utcnow_naive
+
+CHANNEL_ID = "chan-1"
+
+
+def _make_db():
+    # In-memory SQLite without FK pragmas, so refs/subscriptions need no backing
+    # user/channel rows (mirrors tests/test_session_reaper.py).
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _write(path: str, data: bytes = b"data") -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(data)
+
+
+def _abs_media(rel_path: str) -> str:
+    return os.path.join(settings.media_path, rel_path)
+
+
+def _abs_thumb(youtube_video_id: str) -> str:
+    return os.path.join(settings.thumbnails_path, f"{youtube_video_id}.jpg")
+
+
+def _seed_downloaded_video(db, uploaded_at: datetime, channel_id: str = CHANNEL_ID):
+    """Create a COMPLETE video with a media file and thumbnail on disk."""
+    vid_id = str(uuid.uuid4())
+    yt_id = f"yt{uuid.uuid4().hex[:9]}"
+    rel_path = f"{channel_id}/{vid_id}.mp4"
+    _write(_abs_media(rel_path))
+    _write(_abs_thumb(yt_id), b"thumb")
+    video = Video(
+        id=vid_id,
+        youtube_video_id=yt_id,
+        channel_id=channel_id,
+        title="V",
+        status="COMPLETE",
+        file_path=rel_path,
+        file_size_bytes=4,
+        uploaded_at=uploaded_at,
+    )
+    db.add(video)
+    db.commit()
+    return video
+
+
+def _seed_cataloged_video(db, channel_id: str = CHANNEL_ID):
+    """Create a cataloged (never-downloaded) video — no file on disk."""
+    video = Video(
+        id=str(uuid.uuid4()),
+        youtube_video_id=f"yt{uuid.uuid4().hex[:9]}",
+        channel_id=channel_id,
+        title="V",
+        status="CATALOGED",
+    )
+    db.add(video)
+    db.commit()
+    return video
+
+
+def _seed_ref(db, user_id: str, video_id: str) -> None:
+    db.add(UserVideoRef(user_id=user_id, video_id=video_id))
+    db.commit()
+
+
+def _seed_sub(
+    db, user_id: str, policy: str, count: int | None, channel_id: str = CHANNEL_ID
+) -> None:
+    db.add(
+        UserSubscription(
+            user_id=user_id,
+            channel_id=channel_id,
+            retention_policy=policy,
+            retention_count=count,
+        )
+    )
+    db.commit()
+
+
+def _ref(db, user_id: str, video_id: str) -> UserVideoRef:
+    return db.execute(
+        select(UserVideoRef).where(
+            UserVideoRef.user_id == user_id,
+            UserVideoRef.video_id == video_id,
+        )
+    ).scalar_one()
+
+
+def test_keep_last_n_keeps_newest_and_reclaims_the_rest():
+    db = _make_db()
+    base = utcnow_naive()
+    v_old = _seed_downloaded_video(db, base - timedelta(days=3))
+    v_mid = _seed_downloaded_video(db, base - timedelta(days=2))
+    v_new = _seed_downloaded_video(db, base - timedelta(days=1))
+    for v in (v_old, v_mid, v_new):
+        _seed_ref(db, "u1", v.id)
+    _seed_sub(db, "u1", KEEP_LAST_N, 2)
+
+    # Capture on-disk paths before the sweep nulls file_path on reclaimed rows.
+    old_media = _abs_media(v_old.file_path)
+    old_thumb = _abs_thumb(v_old.youtube_video_id)
+    mid_media = _abs_media(v_mid.file_path)
+    new_media = _abs_media(v_new.file_path)
+
+    result = enforce_retention(db)
+
+    assert result == {"subscriptions": 1, "refs_removed": 1, "reclaimed": 1}
+
+    # Oldest dropped: ref soft-removed, file + thumb gone, row reset.
+    assert _ref(db, "u1", v_old.id).removed_at is not None
+    assert not os.path.exists(old_media)
+    assert not os.path.exists(old_thumb)
+    db.refresh(v_old)
+    assert v_old.status == "CATALOGED"
+    assert v_old.file_path is None
+    assert v_old.file_size_bytes is None
+
+    # The newest two are untouched.
+    assert _ref(db, "u1", v_mid.id).removed_at is None
+    assert _ref(db, "u1", v_new.id).removed_at is None
+    assert os.path.exists(mid_media)
+    assert os.path.exists(new_media)
+    db.refresh(v_mid)
+    db.refresh(v_new)
+    assert v_mid.status == "COMPLETE"
+    assert v_new.status == "COMPLETE"
+    db.close()
+
+
+def test_keep_all_is_a_noop():
+    db = _make_db()
+    base = utcnow_naive()
+    videos = [_seed_downloaded_video(db, base - timedelta(days=i)) for i in range(3)]
+    for v in videos:
+        _seed_ref(db, "u1", v.id)
+    _seed_sub(db, "u1", KEEP_ALL, None)
+
+    media_paths = [_abs_media(v.file_path) for v in videos]
+    result = enforce_retention(db)
+
+    # KEEP_ALL subscriptions are filtered out entirely; nothing happens.
+    assert result == {"subscriptions": 0, "refs_removed": 0, "reclaimed": 0}
+    for v, path in zip(videos, media_paths):
+        assert _ref(db, "u1", v.id).removed_at is None
+        assert os.path.exists(path)
+        db.refresh(v)
+        assert v.status == "COMPLETE"
+    db.close()
+
+
+def test_shared_download_is_not_reclaimed_while_another_ref_is_active():
+    db = _make_db()
+    base = utcnow_naive()
+    v_old = _seed_downloaded_video(db, base - timedelta(days=2))
+    v_new = _seed_downloaded_video(db, base - timedelta(days=1))
+    # u1 keeps only the newest (KEEP_LAST_N=1), so v_old drops for u1; u2 still
+    # wants v_old and holds an active ref.
+    _seed_ref(db, "u1", v_old.id)
+    _seed_ref(db, "u1", v_new.id)
+    _seed_ref(db, "u2", v_old.id)
+    _seed_sub(db, "u1", KEEP_LAST_N, 1)
+
+    old_media = _abs_media(v_old.file_path)
+    result = enforce_retention(db)
+
+    assert result == {"subscriptions": 1, "refs_removed": 1, "reclaimed": 0}
+    # u1's ref dropped, u2's ref intact, and the shared file survives.
+    assert _ref(db, "u1", v_old.id).removed_at is not None
+    assert _ref(db, "u2", v_old.id).removed_at is None
+    assert os.path.exists(old_media)
+    db.refresh(v_old)
+    assert v_old.status == "COMPLETE"
+    assert v_old.file_path is not None
+    db.close()
+
+
+def test_only_downloaded_videos_count_toward_retention():
+    db = _make_db()
+    base = utcnow_naive()
+    v_dl_old = _seed_downloaded_video(db, base - timedelta(days=3))
+    v_dl_new = _seed_downloaded_video(db, base - timedelta(days=1))
+    v_cat = _seed_cataloged_video(db)  # never downloaded — no file
+    for v in (v_dl_old, v_dl_new, v_cat):
+        _seed_ref(db, "u1", v.id)
+    _seed_sub(db, "u1", KEEP_LAST_N, 1)
+
+    result = enforce_retention(db)
+
+    # Only the older downloaded video counts against N=1; the cataloged ref is
+    # left completely alone (we never touch videos the user hasn't downloaded).
+    assert result == {"subscriptions": 1, "refs_removed": 1, "reclaimed": 1}
+    assert _ref(db, "u1", v_dl_old.id).removed_at is not None
+    assert _ref(db, "u1", v_dl_new.id).removed_at is None
+    assert _ref(db, "u1", v_cat.id).removed_at is None
+    db.refresh(v_cat)
+    assert v_cat.status == "CATALOGED"
+    db.close()
+
+
+def test_keep_last_n_without_a_count_is_a_noop():
+    db = _make_db()
+    base = utcnow_naive()
+    v1 = _seed_downloaded_video(db, base - timedelta(days=2))
+    v2 = _seed_downloaded_video(db, base - timedelta(days=1))
+    _seed_ref(db, "u1", v1.id)
+    _seed_ref(db, "u1", v2.id)
+    _seed_sub(db, "u1", KEEP_LAST_N, None)  # misconfigured: no count
+
+    result = enforce_retention(db)
+
+    # A policy with no positive count can't be enforced — treat as no-op rather
+    # than deleting everything.
+    assert result == {"subscriptions": 1, "refs_removed": 0, "reclaimed": 0}
+    assert _ref(db, "u1", v1.id).removed_at is None
+    assert _ref(db, "u1", v2.id).removed_at is None
+    assert os.path.exists(_abs_media(v1.file_path))
+    assert os.path.exists(_abs_media(v2.file_path))
+    db.close()


### PR DESCRIPTION
Make `retention_policy`/`retention_count` real (roadmap LATER tier, #12) — they were accepted + persisted but never enforced. Additive — no schema change.

## Where / semantics
The fields live on `UserSubscription` (per-user, per-channel). The real wire values come from the clients: `KEEP_ALL`, `KEEP_LAST_N`, `KEEP_WATCHED` (the audit's "KEEP_LATEST_N" was a guess — matched the clients).

## Sweep (`app/services/retention.py` → `enforce_retention`)
- `KEEP_LAST_N`: for each subscription, keep the newest `retention_count` **downloaded** (COMPLETE) videos (by `coalesce(uploaded_at, created_at)` desc) and soft-remove the user's `UserVideoRef` for the rest. Missing/non-positive count → no-op (never interpreted as "delete all").
- Reclamation **reuses the orphan path** (`check_and_delete_orphan_sync`, a new sync twin of the async one sharing one `_reclaim_orphan_artifacts` helper) — files are deleted + the Video row reset to CATALOGED only when **no active ref remains**, so shared downloads stay ref-counted and safe. Only touches videos the user actually downloaded.
- `KEEP_ALL` / unknown → no-op. **`KEEP_WATCHED` is intentionally NOT enforced** (its literal reading would delete unwatched videos — destructive; dispatch is structured to add a defined behavior later).
- Wired into the beat as `enforce-retention` every `RETENTION_INTERVAL_HOURS` (default 6h).

## Verification (local)
- `pytest -q` → **195 passed** (+5: KEEP_LAST_N drops beyond N + reclaims; KEEP_ALL no-op; shared video with another active ref not reclaimed; only downloaded videos count; no-count no-op).
- `ruff` + `mypy` clean · no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY