### PR TITLE
fix(security): short-lived signed tickets for stream + WebSocket auth (#30)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,15 @@ PGID=1000
 # Leave false if clients can reach the app directly (they could forge it).
 TRUST_PROXY_HEADERS=false
 
+# HMAC secret for the short-lived tickets that authorize media streaming and the
+# WebSocket (so the session token no longer rides those URLs as ?token=).
+# It MUST be the same for every worker and survive restarts — set it explicitly
+# when running multiple workers/hosts, or to rotate all outstanding tickets.
+# If left blank the app generates a random secret on first use and persists it
+# under CONFIG_PATH, which is stable for a single-host Docker deployment sharing
+# that volume. Generate one with: python -c "import secrets;print(secrets.token_urlsafe(48))"
+STREAM_TICKET_SECRET=
+
 # Redis URL (internal; override only if using external Redis)
 REDIS_URL=redis://localhost:6379/0
 

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -24,6 +24,7 @@ from app.models.subscription import UserSubscription
 from app.models.user import User
 from app.models.user_queue import UserQueue
 from app.models.user_video_ref import UserVideoRef
+from app.schemas.ticket import AccessTicket
 from app.schemas.user import (
     UserCreate,
     UserProfile,
@@ -32,6 +33,7 @@ from app.schemas.user import (
     UserUpdate,
 )
 from app.services.storage import check_and_delete_orphan
+from app.utils.tickets import SCOPE_WS, mint_ticket
 from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -398,6 +400,17 @@ async def create_profile(
 @router.get("/me", response_model=UserProfile)
 async def get_me(user: User = Depends(get_current_user)) -> UserProfile:
     return UserProfile.model_validate(user)
+
+
+@router.post("/ws-ticket", response_model=AccessTicket)
+async def create_ws_ticket(user: User = Depends(get_current_user)) -> AccessTicket:
+    """Mint a short-lived, user-scoped ticket for the WebSocket handshake (#30).
+
+    Session-authenticated; the returned ticket is passed to ``/ws/{user_id}`` as
+    ``?ticket=`` so the long-lived session token never rides the handshake URL.
+    """
+    ticket, expires_in = mint_ticket(SCOPE_WS, user.id)
+    return AccessTicket(ticket=ticket, expires_in=expires_in)
 
 
 @router.post("/logout")

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -17,6 +17,7 @@ from app.models.channel import Channel
 from app.models.user import User
 from app.models.user_video_ref import UserVideoRef
 from app.models.video import Video
+from app.schemas.ticket import AccessTicket
 from app.schemas.video import (
     DownloadRequest,
     VideoDetail,
@@ -30,6 +31,7 @@ from app.services.storage import check_and_delete_orphan
 from app.tasks.download_tasks import download_preview_task, download_video_task
 from app.utils.pagination import decode_cursor, encode_cursor
 from app.utils.search import escape_like
+from app.utils.tickets import SCOPE_STREAM, TicketError, mint_ticket, verify_ticket
 from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/videos", tags=["videos"])
@@ -375,17 +377,60 @@ async def request_preview(
     return {"preview_status": "DOWNLOADING"}
 
 
+@router.post("/{video_id}/playback-ticket", response_model=AccessTicket)
+async def create_playback_ticket(
+    video_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> AccessTicket:
+    """Mint a short-lived, video+user-scoped ticket for ``/stream`` (#30).
+
+    Session-authenticated; the returned ticket is passed to the stream endpoints
+    as ``?ticket=`` instead of leaking the session token into the media URL.
+    """
+    exists = await db.scalar(select(Video.id).where(Video.id == video_id))
+    if not exists:
+        raise HTTPException(status_code=404, detail="Video not found")
+    ticket, expires_in = mint_ticket(SCOPE_STREAM, user.id, video_id=video_id)
+    return AccessTicket(ticket=ticket, expires_in=expires_in)
+
+
+async def _authorize_stream(
+    video_id: str,
+    ticket: str | None,
+    token: str | None,
+    x_user_token: str | None,
+    db: AsyncSession,
+) -> None:
+    """Authorize a media stream request, raising 401 if it cannot be.
+
+    A short-lived playback ticket (``?ticket=``) is checked first, then we fall
+    back to the legacy session token carried as ``?token=`` or the X-User-Token
+    header. The fallback is kept during the transition so existing clients keep
+    working; new clients mint a per-video ticket and never put the session token
+    in the URL (#30).
+    """
+    if ticket:
+        try:
+            verify_ticket(ticket, scope=SCOPE_STREAM, video_id=video_id)
+            return
+        except TicketError:
+            pass  # fall back to the session token below
+    auth_token = token or x_user_token
+    if not auth_token or not await validate_token(auth_token):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+
 @router.get("/{video_id}/preview-stream")
 async def stream_preview(
     video_id: str,
+    ticket: str | None = None,
     token: str | None = None,
     x_user_token: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
     range_header: str | None = Header(None, alias="Range"),
 ) -> Response:
-    auth_token = token or x_user_token
-    if not auth_token or not await validate_token(auth_token):
-        raise HTTPException(status_code=401, detail="Unauthorized")
+    await _authorize_stream(video_id, ticket, token, x_user_token, db)
 
     result = await db.execute(select(Video).where(Video.id == video_id))
     video = result.scalar_one_or_none()
@@ -407,15 +452,15 @@ async def stream_preview(
 @router.get("/{video_id}/stream")
 async def stream_video(
     video_id: str,
+    ticket: str | None = None,
     token: str | None = None,
     x_user_token: str | None = Header(None),
     db: AsyncSession = Depends(get_db),
     range_header: str | None = Header(None, alias="Range"),
 ) -> Response:
-    # Accept auth via query param (for <video> element) or header
-    auth_token = token or x_user_token
-    if not auth_token or not await validate_token(auth_token):
-        raise HTTPException(status_code=401, detail="Unauthorized")
+    # Accept auth via a short-lived playback ticket or the session token (query
+    # param for the <video> element, or X-User-Token header).
+    await _authorize_stream(video_id, ticket, token, x_user_token, db)
 
     result = await db.execute(select(Video).where(Video.id == video_id))
     video = result.scalar_one_or_none()

--- a/app/api/websocket.py
+++ b/app/api/websocket.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
 
 from app.api.auth import validate_token
+from app.utils.tickets import SCOPE_WS, TicketError, verify_ticket
 
 router = APIRouter(tags=["websocket"])
 logger = logging.getLogger(__name__)
@@ -17,14 +18,25 @@ _connections: dict[str, set[WebSocket]] = defaultdict(set)
 async def websocket_endpoint(
     websocket: WebSocket,
     user_id: str,
+    ticket: str | None = Query(None),
     token: str | None = Query(None),
 ) -> None:
     await websocket.accept()
 
-    # The token must resolve to a session belonging to this user.
-    token_user_id = await validate_token(token) if token else None
-    if token_user_id != user_id:
-        logger.info("WebSocket rejected (bad token): user=%s", user_id)
+    # Authorize this user via a short-lived ws ticket first, then fall back to
+    # the legacy session token (?token=). The ticket keeps the long-lived token
+    # out of the handshake URL; the fallback is kept during the transition (#30).
+    authorized = False
+    if ticket:
+        try:
+            verify_ticket(ticket, scope=SCOPE_WS, user_id=user_id)
+            authorized = True
+        except TicketError:
+            pass
+    if not authorized and token:
+        authorized = await validate_token(token) == user_id
+    if not authorized:
+        logger.info("WebSocket rejected (bad ticket/token): user=%s", user_id)
         await websocket.close(code=4401)
         return
 

--- a/app/config.py
+++ b/app/config.py
@@ -47,6 +47,17 @@ class Settings(BaseSettings):
     session_absolute_ttl_days: int = 30
     session_idle_ttl_days: int = 14
 
+    # Stream/WebSocket access tickets (#30)
+    # HMAC secret for signing the short-lived tickets that authorize media
+    # streaming and the WebSocket handshake (replacing the session token that
+    # used to ride those URLs as ?token=). It MUST be identical across every
+    # worker and survive restarts: a ticket minted by one worker is verified by
+    # any worker, so a per-process value would cause sporadic auth failures.
+    # Leave blank to have the app generate one once and persist it under
+    # config_path (stable for a single-host deployment sharing that volume); set
+    # it explicitly across multiple hosts, or to rotate all outstanding tickets.
+    stream_ticket_secret: str = ""
+
     # Trust X-Forwarded-For when deriving the client IP for PIN rate limiting.
     # Enable ONLY when running behind a single trusted reverse proxy that sets
     # this header; if clients can reach the app directly they could forge it to

--- a/app/schemas/ticket.py
+++ b/app/schemas/ticket.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class AccessTicket(BaseModel):
+    """A short-lived signed ticket for a media stream or the WebSocket (#30).
+
+    ``ticket`` is passed back as the ``?ticket=`` query param; ``expires_in`` is
+    the lifetime in seconds, after which the client must mint a fresh one.
+    """
+
+    ticket: str
+    expires_in: int

--- a/app/utils/tickets.py
+++ b/app/utils/tickets.py
@@ -1,0 +1,189 @@
+"""Short-lived, HMAC-signed access tickets for media streams and the WebSocket (#30).
+
+The long-lived session token used to ride media URLs (``/stream``,
+``/preview-stream``) and the WebSocket handshake as a ``?token=`` query param.
+Query strings leak into proxy/access logs, browser history, and shared links, so
+a single captured log line was a full session hijack.
+
+A ticket is a stateless capability minted from a session-authenticated request,
+scoped narrowly (one video for playback, the user for the socket) and valid for
+only a few minutes, so a leaked URL is worth almost nothing. Wire format::
+
+    base64url(payload).base64url(hmac_sha256(payload))
+
+where ``payload`` is compact JSON ``{"scope","user_id","video_id"?,"exp"}``.
+Verification is constant-time and rejects anything tampered, expired, or scoped
+to a different user/video.
+
+Signing secret: a single stable secret shared by every worker. It is read from
+``settings.stream_ticket_secret`` (env ``STREAM_TICKET_SECRET``) when set;
+otherwise the app generates one once and persists it under ``config_path`` so it
+survives restarts and is shared across workers on the same volume. A
+per-process random value is deliberately avoided — worker A's ticket would then
+fail verification on worker B.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import time
+from pathlib import Path
+
+from app.config import settings
+
+# Ticket scopes. A ticket only authorizes the endpoint family it was minted for;
+# replaying a ws-ticket on /stream (or vice versa) is rejected by the scope check.
+SCOPE_STREAM = "stream"
+SCOPE_WS = "ws"
+
+# Tickets are deliberately short-lived: long enough to start playback / open the
+# socket, short enough that a leaked URL expires before it is useful.
+TICKET_TTL_SECONDS = 300  # 5 minutes
+
+# Filename of the auto-generated secret persisted under settings.config_path.
+_SECRET_FILENAME = "stream_ticket_secret"
+
+# Cache for the persisted secret so we read/create the file at most once per
+# process. An explicitly configured secret is never cached here (it already
+# lives in settings), so tests can override it freely.
+_persisted_secret: str | None = None
+
+
+class TicketError(Exception):
+    """Raised when a ticket is malformed, tampered, expired, or mis-scoped."""
+
+
+def _b64encode(raw: bytes) -> str:
+    """URL-safe base64 without padding (so tickets stay clean in query strings)."""
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _b64decode(segment: str) -> bytes:
+    padding = "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
+
+
+def _load_or_create_persisted_secret() -> str:
+    """Read the persisted signing secret, generating it once if it is absent.
+
+    Concurrency-safe across workers booting together: the secret is written to a
+    private temp file and then hard-linked into place, which is atomic and fails
+    if the target already exists. Whoever wins the link returns its own secret;
+    everyone else reads the winner's. The target is therefore never observed
+    half-written, and all workers converge on a single value.
+    """
+    path = Path(settings.config_path) / _SECRET_FILENAME
+    try:
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    except FileNotFoundError:
+        pass
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    candidate = secrets.token_urlsafe(48)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    tmp.write_text(candidate)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    try:
+        os.link(tmp, path)  # atomic create-only claim; raises if path exists
+        return candidate
+    except FileExistsError:
+        return path.read_text().strip()
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _signing_secret() -> bytes:
+    configured = settings.stream_ticket_secret
+    if configured:
+        return configured.encode("utf-8")
+    global _persisted_secret
+    if _persisted_secret is None:
+        _persisted_secret = _load_or_create_persisted_secret()
+    return _persisted_secret.encode("utf-8")
+
+
+def _sign(payload_segment: str) -> str:
+    digest = hmac.new(
+        _signing_secret(), payload_segment.encode("ascii"), hashlib.sha256
+    ).digest()
+    return _b64encode(digest)
+
+
+def mint_ticket(
+    scope: str,
+    user_id: str,
+    *,
+    video_id: str | None = None,
+    ttl_seconds: int = TICKET_TTL_SECONDS,
+) -> tuple[str, int]:
+    """Mint a signed ticket. Returns ``(ticket, expires_in_seconds)``."""
+    payload: dict[str, object] = {
+        "scope": scope,
+        "user_id": user_id,
+        "exp": int(time.time()) + ttl_seconds,
+    }
+    if video_id is not None:
+        payload["video_id"] = video_id
+    segment = _b64encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    ticket = f"{segment}.{_sign(segment)}"
+    return ticket, ttl_seconds
+
+
+def verify_ticket(
+    ticket: str,
+    *,
+    scope: str,
+    user_id: str | None = None,
+    video_id: str | None = None,
+) -> str:
+    """Verify a ticket and return the ``user_id`` it was minted for.
+
+    Raises :class:`TicketError` if the ticket is malformed, tampered, expired, of
+    the wrong ``scope``, or (when the corresponding argument is given) bound to a
+    different ``user_id`` / ``video_id``. The signature is checked first, in
+    constant time, before any field of the payload is trusted.
+    """
+    if not ticket or ticket.count(".") != 1:
+        raise TicketError("malformed ticket")
+
+    segment, signature = ticket.split(".", 1)
+    if not hmac.compare_digest(signature, _sign(segment)):
+        raise TicketError("bad signature")
+
+    try:
+        payload = json.loads(_b64decode(segment))
+    except (ValueError, TypeError) as exc:
+        raise TicketError("undecodable payload") from exc
+    if not isinstance(payload, dict):
+        raise TicketError("bad payload")
+
+    if payload.get("scope") != scope:
+        raise TicketError("wrong scope")
+
+    exp = payload.get("exp")
+    if not isinstance(exp, int) or isinstance(exp, bool) or time.time() >= exp:
+        raise TicketError("expired")
+
+    token_user_id = payload.get("user_id")
+    if not isinstance(token_user_id, str) or not token_user_id:
+        raise TicketError("missing user")
+    if user_id is not None and token_user_id != user_id:
+        raise TicketError("wrong user")
+
+    if video_id is not None and payload.get("video_id") != video_id:
+        raise TicketError("wrong video")
+
+    return token_user_id

--- a/tests/test_stream_tickets.py
+++ b/tests/test_stream_tickets.py
@@ -1,0 +1,297 @@
+"""Short-lived signed stream/WS tickets and ticket-or-token acceptance (#30).
+
+Covers the ticket helper crypto, the mint endpoints, and that ``/stream``,
+``/preview-stream`` and the WebSocket accept a valid ticket while still honoring
+the legacy ``?token=`` session param during the transition.
+"""
+
+import os
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+import app.api.websocket as websocket_api
+from app.config import settings
+from app.database import async_session_factory
+from app.utils.tickets import (
+    SCOPE_STREAM,
+    SCOPE_WS,
+    TicketError,
+    mint_ticket,
+    verify_ticket,
+)
+from tests.helpers import seed_channel, seed_video
+
+CONTENT = b"0123456789" * 10  # 100 bytes
+
+
+# --- ticket helper (pure crypto) -------------------------------------------
+
+
+def test_mint_verify_roundtrip_stream():
+    ticket, expires_in = mint_ticket(SCOPE_STREAM, "user-1", video_id="vid-1")
+    assert expires_in > 0
+    assert verify_ticket(ticket, scope=SCOPE_STREAM, video_id="vid-1") == "user-1"
+
+
+def test_mint_verify_roundtrip_ws():
+    ticket, _ = mint_ticket(SCOPE_WS, "user-1")
+    assert verify_ticket(ticket, scope=SCOPE_WS, user_id="user-1") == "user-1"
+
+
+def test_verify_rejects_wrong_scope():
+    ticket, _ = mint_ticket(SCOPE_WS, "user-1")
+    with pytest.raises(TicketError):
+        verify_ticket(ticket, scope=SCOPE_STREAM, video_id="vid-1")
+
+
+def test_verify_rejects_expired():
+    ticket, _ = mint_ticket(SCOPE_STREAM, "user-1", video_id="vid-1", ttl_seconds=-1)
+    with pytest.raises(TicketError):
+        verify_ticket(ticket, scope=SCOPE_STREAM, video_id="vid-1")
+
+
+def test_verify_rejects_wrong_video():
+    ticket, _ = mint_ticket(SCOPE_STREAM, "user-1", video_id="vid-1")
+    with pytest.raises(TicketError):
+        verify_ticket(ticket, scope=SCOPE_STREAM, video_id="vid-2")
+
+
+def test_verify_rejects_wrong_user():
+    ticket, _ = mint_ticket(SCOPE_WS, "user-1")
+    with pytest.raises(TicketError):
+        verify_ticket(ticket, scope=SCOPE_WS, user_id="user-2")
+
+
+def test_verify_rejects_tampered_signature():
+    ticket, _ = mint_ticket(SCOPE_STREAM, "user-1", video_id="vid-1")
+    tampered = ticket[:-1] + ("A" if ticket[-1] != "A" else "B")
+    with pytest.raises(TicketError):
+        verify_ticket(tampered, scope=SCOPE_STREAM, video_id="vid-1")
+
+
+def test_verify_rejects_tampered_payload():
+    segment, signature = mint_ticket(SCOPE_STREAM, "u", video_id="vid-1")[0].split(".")
+    forged_segment = mint_ticket(SCOPE_STREAM, "u", video_id="vid-EVIL")[0].split(".")[
+        0
+    ]
+    with pytest.raises(TicketError):
+        verify_ticket(f"{forged_segment}.{signature}", scope=SCOPE_STREAM)
+
+
+@pytest.mark.parametrize("bad", ["", "no-dot", "a.b.c", "....", "only."])
+def test_verify_rejects_malformed(bad):
+    with pytest.raises(TicketError):
+        verify_ticket(bad, scope=SCOPE_STREAM)
+
+
+def test_secret_change_invalidates_tickets(monkeypatch):
+    monkeypatch.setattr(settings, "stream_ticket_secret", "secret-A")
+    ticket, _ = mint_ticket(SCOPE_WS, "user-1")
+    assert verify_ticket(ticket, scope=SCOPE_WS) == "user-1"
+    monkeypatch.setattr(settings, "stream_ticket_secret", "secret-B")
+    with pytest.raises(TicketError):
+        verify_ticket(ticket, scope=SCOPE_WS)
+
+
+# --- mint endpoints ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_playback_ticket_requires_session(client):
+    resp = await client.post(f"/api/videos/{uuid.uuid4()}/playback-ticket")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_playback_ticket_unknown_video_404(client, make_user):
+    _, headers = await make_user()
+    resp = await client.post(
+        f"/api/videos/{uuid.uuid4()}/playback-ticket", headers=headers
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_ws_ticket_requires_session(client):
+    resp = await client.post("/api/auth/ws-ticket")
+    assert resp.status_code == 401
+
+
+# --- /stream and /preview-stream accept ticket OR token ---------------------
+
+
+async def _seed_complete_video(rel_path: str, *, preview: bool = False):
+    full_path = os.path.join(settings.media_path, rel_path)
+    os.makedirs(os.path.dirname(full_path), exist_ok=True)
+    with open(full_path, "wb") as f:
+        f.write(CONTENT)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        if preview:
+            video = await seed_video(
+                db,
+                channel,
+                preview_status="READY",
+                preview_file_path=rel_path,
+            )
+        else:
+            video = await seed_video(db, channel, status="COMPLETE", file_path=rel_path)
+    return video
+
+
+@pytest.mark.asyncio
+async def test_mint_then_stream_with_ticket(client, make_user):
+    _, headers = await make_user()
+    video = await _seed_complete_video(f"chan/{uuid.uuid4().hex}.mp4")
+
+    mint = await client.post(f"/api/videos/{video.id}/playback-ticket", headers=headers)
+    assert mint.status_code == 200, mint.text
+    body = mint.json()
+    assert body["expires_in"] > 0
+    ticket = body["ticket"]
+
+    # The ticket alone authorizes the stream; no session token in the URL.
+    resp = await client.get(f"/api/videos/{video.id}/stream?ticket={ticket}")
+    assert resp.status_code == 200
+    assert resp.content == CONTENT
+
+    # Range requests still work over a ticket.
+    resp = await client.get(
+        f"/api/videos/{video.id}/stream?ticket={ticket}",
+        headers={"Range": "bytes=10-19"},
+    )
+    assert resp.status_code == 206
+    assert resp.content == CONTENT[10:20]
+
+
+@pytest.mark.asyncio
+async def test_stream_token_still_works(client, make_user):
+    _, headers = await make_user()
+    token = headers["X-User-Token"]
+    video = await _seed_complete_video(f"chan/{uuid.uuid4().hex}.mp4")
+
+    resp = await client.get(f"/api/videos/{video.id}/stream?token={token}")
+    assert resp.status_code == 200
+    assert resp.content == CONTENT
+
+
+@pytest.mark.asyncio
+async def test_stream_expired_ticket_rejected(client, make_user):
+    user, _ = await make_user()
+    video = await _seed_complete_video(f"chan/{uuid.uuid4().hex}.mp4")
+    ticket, _ = mint_ticket(SCOPE_STREAM, user["id"], video_id=video.id, ttl_seconds=-1)
+
+    resp = await client.get(f"/api/videos/{video.id}/stream?ticket={ticket}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_ticket_for_other_video_rejected(client, make_user):
+    user, _ = await make_user()
+    video = await _seed_complete_video(f"chan/{uuid.uuid4().hex}.mp4")
+    # A valid ticket, but minted for a different video id.
+    ticket, _ = mint_ticket(SCOPE_STREAM, user["id"], video_id="some-other-video")
+
+    resp = await client.get(f"/api/videos/{video.id}/stream?ticket={ticket}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_tampered_ticket_rejected(client, make_user):
+    user, _ = await make_user()
+    video = await _seed_complete_video(f"chan/{uuid.uuid4().hex}.mp4")
+    ticket, _ = mint_ticket(SCOPE_STREAM, user["id"], video_id=video.id)
+    tampered = ticket[:-1] + ("A" if ticket[-1] != "A" else "B")
+
+    resp = await client.get(f"/api/videos/{video.id}/stream?ticket={tampered}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_stream_ticket_falls_back_to_token_when_invalid(client, make_user):
+    """A present-but-invalid ticket must not block a valid session token."""
+    _, headers = await make_user()
+    token = headers["X-User-Token"]
+    video = await _seed_complete_video(f"chan/{uuid.uuid4().hex}.mp4")
+
+    resp = await client.get(
+        f"/api/videos/{video.id}/stream?ticket=garbage&token={token}"
+    )
+    assert resp.status_code == 200
+    assert resp.content == CONTENT
+
+
+@pytest.mark.asyncio
+async def test_preview_stream_with_ticket(client, make_user):
+    _, headers = await make_user()
+    video = await _seed_complete_video(
+        f"chan/{uuid.uuid4().hex}.preview.mp4", preview=True
+    )
+    ticket, _ = mint_ticket(SCOPE_STREAM, "ignored", video_id=video.id)
+
+    resp = await client.get(f"/api/videos/{video.id}/preview-stream?ticket={ticket}")
+    assert resp.status_code == 200
+    assert resp.content == CONTENT
+
+
+# --- WebSocket accepts ticket OR token --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_accepts_valid_ticket():
+    # Pass token=None explicitly: a direct call would otherwise see the Query()
+    # default object (the ASGI layer resolves an absent param to None for us).
+    ticket, _ = mint_ticket(SCOPE_WS, "u1")
+    ws = AsyncMock()
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+    await websocket_api.websocket_endpoint(ws, user_id="u1", ticket=ticket, token=None)
+    ws.accept.assert_awaited_once()
+    ws.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ws_ticket_for_other_user_closes_4401():
+    ticket, _ = mint_ticket(SCOPE_WS, "u2")
+    ws = AsyncMock()
+    await websocket_api.websocket_endpoint(ws, user_id="u1", ticket=ticket, token=None)
+    ws.close.assert_awaited_once_with(code=4401)
+
+
+@pytest.mark.asyncio
+async def test_ws_bad_ticket_closes_4401():
+    ws = AsyncMock()
+    await websocket_api.websocket_endpoint(
+        ws, user_id="u1", ticket="garbage", token=None
+    )
+    ws.close.assert_awaited_once_with(code=4401)
+
+
+@pytest.mark.asyncio
+async def test_ws_token_still_works(monkeypatch):
+    async def fake_validate(_token):
+        return "u1"
+
+    monkeypatch.setattr(websocket_api, "validate_token", fake_validate)
+    ws = AsyncMock()
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+    await websocket_api.websocket_endpoint(
+        ws, user_id="u1", ticket=None, token="good-token"
+    )
+    ws.close.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ws_invalid_ticket_falls_back_to_token(monkeypatch):
+    async def fake_validate(_token):
+        return "u1"
+
+    monkeypatch.setattr(websocket_api, "validate_token", fake_validate)
+    ws = AsyncMock()
+    ws.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
+    await websocket_api.websocket_endpoint(
+        ws, user_id="u1", ticket="garbage", token="good-token"
+    )
+    ws.close.assert_not_awaited()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -10,8 +10,10 @@ from app.main import app
 
 @pytest.mark.asyncio
 async def test_ws_absent_token_closes_4401():
+    # ticket/token are passed explicitly: a direct call bypasses FastAPI's Query
+    # resolution, so an omitted param would arrive as the Query() default object.
     ws = AsyncMock()
-    await websocket_api.websocket_endpoint(ws, user_id="u1", token=None)
+    await websocket_api.websocket_endpoint(ws, user_id="u1", ticket=None, token=None)
     ws.accept.assert_awaited_once()
     ws.close.assert_awaited_once_with(code=4401)
 
@@ -23,7 +25,9 @@ async def test_ws_unresolvable_token_closes_4401(monkeypatch):
 
     monkeypatch.setattr(websocket_api, "validate_token", fake_validate)
     ws = AsyncMock()
-    await websocket_api.websocket_endpoint(ws, user_id="u1", token="garbage")
+    await websocket_api.websocket_endpoint(
+        ws, user_id="u1", ticket=None, token="garbage"
+    )
     ws.close.assert_awaited_once_with(code=4401)
 
 
@@ -34,7 +38,9 @@ async def test_ws_token_for_other_user_closes_4401(monkeypatch):
 
     monkeypatch.setattr(websocket_api, "validate_token", fake_validate)
     ws = AsyncMock()
-    await websocket_api.websocket_endpoint(ws, user_id="u1", token="valid-but-other")
+    await websocket_api.websocket_endpoint(
+        ws, user_id="u1", ticket=None, token="valid-but-other"
+    )
     ws.close.assert_awaited_once_with(code=4401)
 
 


### PR DESCRIPTION
Move the long-lived session token out of `/stream`, `/preview-stream`, and the WebSocket handshake URL query strings (where it leaks to proxy/access logs, history, and shared links) into short-lived HMAC-signed tickets (roadmap LATER tier, #10 / issue #30). **Additive / backward-compatible** — the old `?token=` keeps working during transition; clients switch in a follow-up. No migration.

## Tickets (`app/utils/tickets.py`)
- Wire format `base64url(payload).base64url(hmac_sha256(payload))`; compact payload `{scope, user_id, video_id?, exp}`. **Signature verified first, constant-time** (`hmac.compare_digest`) before any field is trusted; rejects tampered/expired/wrong-scope/wrong-user/wrong-video (with a `bool`-vs-`int` exp guard). TTL 5 min. Scopes `stream` (video+user) and `ws` (user) — a ws ticket can't be replayed on `/stream`.
- **Signing secret**: stable + shared — `STREAM_TICKET_SECRET` env if set, else a secret generated once and persisted under `config_path` via an **atomic hard-link claim** (concurrency-safe across workers, 0600). Never per-process-random, so worker A's ticket verifies on worker B.

## Endpoints
- Mint (session-auth): `POST /api/videos/{id}/playback-ticket` → stream ticket; `POST /api/auth/ws-ticket` → ws ticket. Both return `{ticket, expires_in}`.
- `/stream` + `/preview-stream`: check `?ticket=` (verify scope+video) first, else fall back to `?token=`/`X-User-Token`.
- WS: check `?ticket=` (verify scope+user) first, else fall back to `?token=`.

## Verification (local)
- `pytest -q` → **224 passed** (+ `test_stream_tickets.py`: mint→stream works, expired/tampered/wrong-video/wrong-user rejected, WS accepts a valid ws-ticket and still 4401s a bad one, and **`?token=` still works** on stream + WS).
- `ruff` clean · no migration.

Follow-up: switch the Flutter + tvOS stream/WS URL builders to fetch a ticket. The old query token still works until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY