### PR TITLE
feat: push notifications via the push gateway (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,18 @@ TRUST_PROXY_HEADERS=false
 # that volume. Generate one with: python -c "import secrets;print(secrets.token_urlsafe(48))"
 STREAM_TICKET_SECRET=
 
+# Push notifications (public push gateway, push.julian.codes).
+# NullFeed relays APNs pushes through a shared gateway, so you need no Apple push
+# key of your own. On first use the backend auto-enrolls and persists the issued
+# key under CONFIG_PATH (a 0600 file). Leave the URL set to use the public relay;
+# set it BLANK to disable push entirely (register endpoints and new-episode sends
+# become no-ops). Point it at your own gateway to self-host.
+NULLFEED_PUSH_GATEWAY_URL=https://push.julian.codes
+# Pin an explicit tenant key instead of auto-enrolling (optional; never persisted).
+NULLFEED_PUSH_API_KEY=
+# Only needed when the gateway runs in "gated" enrollment mode (sent as X-Enroll-Token).
+NULLFEED_PUSH_ENROLL_TOKEN=
+
 # Redis URL (internal; override only if using external Redis)
 REDIS_URL=redis://localhost:6379/0
 

--- a/app/api/push.py
+++ b/app/api/push.py
@@ -1,0 +1,78 @@
+"""Device push-token endpoints (#33).
+
+A client registers its APNs device token here after the user grants push
+permission; the backend forwards it to the shared push gateway scoped to the
+current user (so a later new-episode notification can target ``user_ids``). On
+logout, or when the OS reports a token is stale, the client unregisters it.
+
+Both endpoints are session-authenticated and best-effort: the gateway call never
+raises into the response, and when push is disabled (no gateway configured) they
+no-op with ``{"enabled": false}`` rather than erroring, so a client can probe
+support and degrade gracefully.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.api.auth import get_current_user
+from app.models.user import User
+from app.services import push_gateway
+
+router = APIRouter(prefix="/api/push", tags=["push"])
+logger = logging.getLogger(__name__)
+
+
+class DeviceRegistration(BaseModel):
+    device_token: str
+    device_id: str | None = None
+    platform: str = "ios"
+
+
+class DeviceUnregistration(BaseModel):
+    device_token: str | None = None
+    device_id: str | None = None
+    platform: str = "ios"
+
+
+@router.post("/register")
+async def register_device(
+    body: DeviceRegistration,
+    user: User = Depends(get_current_user),
+) -> dict:
+    """Register this device's APNs token for the current user.
+
+    Forwards to the gateway ``POST /v1/devices`` with the caller's user id and
+    the fixed NullFeed topic. No-op (``{"enabled": false}``) when push is
+    disabled.
+    """
+    if not push_gateway.push_enabled():
+        return {"enabled": False}
+    registered = await push_gateway.register_device_async(
+        user.id,
+        body.device_token,
+        device_id=body.device_id,
+        platform=body.platform,
+    )
+    return {"enabled": True, "registered": registered}
+
+
+@router.delete("/register")
+async def unregister_device(
+    body: DeviceUnregistration,
+    user: User = Depends(get_current_user),
+) -> dict:
+    """Remove this device's token from the gateway (logout / stale token).
+
+    Identify the device by ``device_id`` or ``(platform, device_token)``. No-op
+    (``{"enabled": false}``) when push is disabled.
+    """
+    if not push_gateway.push_enabled():
+        return {"enabled": False}
+    unregistered = await push_gateway.unregister_device_async(
+        device_token=body.device_token,
+        device_id=body.device_id,
+        platform=body.platform,
+    )
+    return {"enabled": True, "unregistered": unregistered}

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,4 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
@@ -63,6 +64,25 @@ class Settings(BaseSettings):
     # this header; if clients can reach the app directly they could forge it to
     # evade the throttle. Off by default -> the real socket peer is used.
     trust_proxy_headers: bool = False
+
+    # Push notifications (public push gateway, push.julian.codes)
+    # NullFeed relays APNs pushes through a shared, multi-tenant gateway so a
+    # self-hoster needs no Apple push key of their own. On first use the backend
+    # auto-enrolls as a tenant and persists the issued key under config_path
+    # (0600 file, shared across workers on the same volume); set push_api_key to
+    # pin an explicit operator key instead (it is never persisted). Leave
+    # push_gateway_url blank to DISABLE push entirely — every push path
+    # (register/unregister endpoints, new-episode send) then becomes a no-op.
+    # push_enroll_token is only needed when the gateway runs in "gated"
+    # enrollment mode (sent as the X-Enroll-Token header on auto-enroll).
+    push_gateway_url: str = Field(
+        default="https://push.julian.codes",
+        validation_alias="NULLFEED_PUSH_GATEWAY_URL",
+    )
+    push_api_key: str = Field(default="", validation_alias="NULLFEED_PUSH_API_KEY")
+    push_enroll_token: str = Field(
+        default="", validation_alias="NULLFEED_PUSH_ENROLL_TOKEN"
+    )
 
     # File permissions
     puid: int = 1000

--- a/app/main.py
+++ b/app/main.py
@@ -18,6 +18,7 @@ from app.api import (
     discover,
     feed,
     health,
+    push,
     queue,
     videos,
     websocket,
@@ -121,6 +122,7 @@ app.include_router(feed.router)
 app.include_router(discover.router)
 app.include_router(websocket.router)
 app.include_router(youtube.router)
+app.include_router(push.router)
 
 
 # ---------------------------------------------------------------------------

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -17,6 +17,7 @@ from app.services.download_manager import (
     fetch_videos_metadata,
 )
 from app.services.progress_broadcaster import publish_new_episode
+from app.services.push_gateway import send_to_users
 from app.utils.time import utcnow_naive
 
 logger = logging.getLogger(__name__)
@@ -455,12 +456,18 @@ def _determine_auto_downloads(
 
 
 def _emit_new_episode_events(channel_id: str, videos: list[dict], db: Session) -> None:
-    """Broadcast a new_episode event to every subscriber of the channel.
+    """Notify every subscriber of a channel's genuinely new episodes.
 
-    Best-effort: a notification failure (e.g. Redis down) must never break a
-    poll, so the whole emit is wrapped and only logged.
+    For each (subscriber, new video) we publish the live WebSocket event (for an
+    open app) and, best-effort, send a push notification (for a closed one) so
+    the client can deep-link to the video. Everything is best-effort: a failure
+    (Redis down, push gateway unreachable/disabled) must never break a poll, so
+    the whole emit is wrapped and only logged, and ``send_to_users`` itself never
+    raises and no-ops when push is disabled.
     """
     try:
+        channel = db.get(Channel, channel_id)
+        channel_name = channel.name if channel is not None else None
         subscriber_ids = [
             row[0]
             for row in db.execute(
@@ -477,6 +484,15 @@ def _emit_new_episode_events(channel_id: str, videos: list[dict], db: Session) -
                     channel_id=channel_id,
                     title=video["title"],
                     youtube_video_id=video["youtube_video_id"],
+                )
+                # Push for a backgrounded/closed app. Target the user id (the
+                # gateway rejects raw tokens for tenant keys); data carries the
+                # video id so the client can deep-link to it.
+                send_to_users(
+                    [user_id],
+                    channel_name or "New episode",
+                    video["title"],
+                    {"type": "new_episode", "video_id": video["id"]},
                 )
     except Exception:
         logger.exception(

--- a/app/services/push_gateway.py
+++ b/app/services/push_gateway.py
@@ -1,0 +1,345 @@
+"""Best-effort integration with the public push gateway (push.julian.codes).
+
+NullFeed relays APNs notifications through a shared, multi-tenant gateway so a
+self-hoster needs no Apple push key of their own. This module speaks the
+gateway's ``/v1`` HTTP API (Bearer per-tenant key) to register device tokens and
+fan notifications out to a user's devices.
+
+Three design rules shape everything here:
+
+* **Best-effort.** Push is a nicety layered on top of the WebSocket live events,
+  never a dependency of the core flows. A disabled gateway, an unreachable
+  gateway, or a per-call error must NEVER raise into the poller or an endpoint:
+  the public helpers catch everything, log, and return a simple ``bool``.
+* **Zero-config auto-enrollment.** With no explicit key set, the backend
+  self-enrolls as a tenant on first use and persists the issued ``pgk_`` key
+  durably under ``settings.config_path`` (a 0600 file, claimed with the same
+  atomic hard-link dance as :mod:`app.utils.tickets`) so it survives restarts
+  and is shared by every worker on the same volume. An explicit
+  ``settings.push_api_key`` wins and is never persisted.
+* **Sync core, async edges.** The HTTP calls are plain synchronous ``httpx`` so
+  the Celery poller (a sync context) can call them directly; FastAPI endpoints
+  use the ``*_async`` wrappers, which run the sync call in a worker thread via
+  :func:`asyncio.to_thread` so the event loop is never blocked.
+
+The APNs topic / iOS bundle id is always :data:`PUSH_TOPIC`. Tenant keys may only
+target ``user_ids`` (the gateway rejects raw device tokens for tenant keys), so
+sends fan out by NullFeed user id.
+"""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from threading import Lock
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Fixed APNs topic (the iOS bundle id) for NullFeed's tenant on the gateway.
+PUSH_TOPIC = "codes.julian.nullfeed"
+
+# Tenant label sent to the gateway on auto-enroll.
+_ENROLL_NAME = "NullFeed"
+
+# Filename of the auto-enrolled tenant key persisted under settings.config_path.
+_API_KEY_FILENAME = "push_api_key"
+
+# Network timeout (seconds) for every gateway call.
+_TIMEOUT = 15.0
+
+# Cache the resolved (persisted / auto-enrolled) key so the hot send path does
+# not re-read the file on every call. An explicit settings key is never cached
+# here (it already lives in settings, so tests can override it freely). The lock
+# makes auto-enrollment single-flight within a process; the persisted file
+# converges all processes on one key.
+_cached_api_key: str | None = None
+_key_lock = Lock()
+
+
+class PushGatewayError(Exception):
+    """Raised by the low-level HTTP helpers on a transport error or non-2xx."""
+
+
+def push_enabled() -> bool:
+    """True when a gateway URL is configured; everything no-ops when False."""
+    return bool(settings.push_gateway_url)
+
+
+def _gateway_url() -> str:
+    return settings.push_gateway_url.rstrip("/")
+
+
+# --- low-level HTTP --------------------------------------------------------
+
+
+def _http(
+    method: str,
+    url: str,
+    *,
+    json: dict | None = None,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """Issue one gateway request, raising :class:`PushGatewayError` on failure."""
+    try:
+        resp = httpx.request(method, url, json=json, headers=headers, timeout=_TIMEOUT)
+    except httpx.HTTPError as exc:
+        raise PushGatewayError(f"{method} {url} transport error: {exc}") from exc
+    if resp.status_code // 100 != 2:
+        raise PushGatewayError(
+            f"{method} {url} returned {resp.status_code}: {resp.text[:200]}"
+        )
+    return resp
+
+
+# --- key resolution + persistence ------------------------------------------
+
+
+def _key_path() -> Path:
+    return Path(settings.config_path) / _API_KEY_FILENAME
+
+
+def _read_persisted_key() -> str | None:
+    try:
+        existing = _key_path().read_text().strip()
+        return existing or None
+    except FileNotFoundError:
+        return None
+
+
+def _persist_key(api_key: str) -> str:
+    """Persist the auto-enrolled key durably, atomically, shared across workers.
+
+    Mirrors :func:`app.utils.tickets._load_or_create_persisted_secret`: write a
+    private 0600 temp file then hard-link it into place (create-only, atomic).
+    Whoever wins the link keeps its key; everyone racing reads the winner's, so
+    all workers converge on a single key and the file is never half-written.
+    """
+    path = _key_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{os.urandom(4).hex()}.tmp")
+    tmp.write_text(api_key)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    try:
+        os.link(tmp, path)  # atomic create-only claim; raises if path exists
+        return api_key
+    except FileExistsError:
+        return path.read_text().strip()
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def enroll() -> str:
+    """Self-enroll NullFeed as a tenant and return the issued key (raises).
+
+    Unauthenticated; sends ``X-Enroll-Token`` when ``settings.push_enroll_token``
+    is set (required only for a gateway running in ``gated`` enrollment mode).
+    """
+    headers: dict[str, str] = {}
+    if settings.push_enroll_token:
+        headers["X-Enroll-Token"] = settings.push_enroll_token
+    resp = _http(
+        "POST",
+        f"{_gateway_url()}/v1/enroll",
+        json={"name": _ENROLL_NAME},
+        headers=headers or None,
+    )
+    api_key = resp.json().get("api_key")
+    if not api_key:
+        raise PushGatewayError("enroll: gateway returned an empty api_key")
+    return api_key
+
+
+def _resolve_api_key() -> str | None:
+    """Resolve the tenant key: explicit > persisted > self-enroll. Never raises.
+
+    Returns ``None`` when push is disabled or auto-enrollment fails (logged), so
+    callers cleanly no-op. An explicit ``settings.push_api_key`` wins and is
+    never persisted; otherwise a key persisted by a previous start/worker is
+    reused; otherwise we self-enroll once and persist the issued key.
+    """
+    if not push_enabled():
+        return None
+    if settings.push_api_key:
+        return settings.push_api_key
+
+    global _cached_api_key
+    if _cached_api_key is not None:
+        return _cached_api_key
+
+    persisted = _read_persisted_key()
+    if persisted:
+        _cached_api_key = persisted
+        return _cached_api_key
+
+    with _key_lock:
+        # Re-check under the lock: another thread may have enrolled meanwhile.
+        if _cached_api_key is not None:
+            return _cached_api_key
+        persisted = _read_persisted_key()
+        if persisted:
+            _cached_api_key = persisted
+            return _cached_api_key
+        try:
+            issued = enroll()
+        except PushGatewayError:
+            logger.warning("push: auto-enroll with gateway failed", exc_info=True)
+            return None
+        _cached_api_key = _persist_key(issued)
+        logger.info("push: auto-enrolled with gateway; key persisted")
+        return _cached_api_key
+
+
+def _authed_request(method: str, path: str, payload: dict) -> httpx.Response:
+    """Resolve the key and issue an authenticated gateway request (raises)."""
+    api_key = _resolve_api_key()
+    if api_key is None:
+        raise PushGatewayError("push not configured")
+    return _http(
+        method,
+        f"{_gateway_url()}{path}",
+        json=payload,
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+
+
+# --- public best-effort API (sync; safe for the Celery poller) -------------
+
+
+def register_device(
+    user_id: str,
+    device_token: str,
+    *,
+    device_id: str | None = None,
+    platform: str = "ios",
+) -> bool:
+    """Register/refresh a device token with the gateway (upsert). Best-effort.
+
+    Returns ``True`` on success, ``False`` when push is disabled or the gateway
+    call failed (logged, never raised).
+    """
+    if not push_enabled():
+        return False
+    payload: dict[str, object] = {
+        "user_id": user_id,
+        "platform": platform,
+        "token": device_token,
+        "topic": PUSH_TOPIC,
+    }
+    if device_id:
+        payload["device_id"] = device_id
+    try:
+        _authed_request("POST", "/v1/devices", payload)
+        return True
+    except PushGatewayError:
+        logger.warning("push: register device failed", exc_info=True)
+        return False
+
+
+def unregister_device(
+    *,
+    device_token: str | None = None,
+    device_id: str | None = None,
+    platform: str = "ios",
+) -> bool:
+    """Remove a device from the gateway by ``device_id`` or ``(platform, token)``.
+
+    Best-effort: returns ``False`` (no raise) when push is disabled, neither
+    identifier was given, or the gateway call failed.
+    """
+    if not push_enabled():
+        return False
+    payload: dict[str, object]
+    if device_id:
+        payload = {"device_id": device_id}
+    elif device_token:
+        payload = {"platform": platform, "token": device_token}
+    else:
+        return False
+    try:
+        _authed_request("DELETE", "/v1/devices", payload)
+        return True
+    except PushGatewayError:
+        logger.warning("push: unregister device failed", exc_info=True)
+        return False
+
+
+def send_to_users(
+    user_ids: list[str],
+    title: str,
+    body: str,
+    data: dict | None = None,
+) -> bool:
+    """Send a high-priority alert to the given users' devices. Best-effort.
+
+    Targets ``user_ids`` (tenant keys cannot target raw tokens). ``data`` rides
+    alongside the alert for client deep-linking. Returns ``True`` when the
+    gateway accepted the send, ``False`` when push is disabled, there are no
+    recipients, or the call failed (logged, never raised) — so a notification
+    failure can never break the caller (poller / endpoint).
+    """
+    if not push_enabled() or not user_ids:
+        return False
+    payload: dict[str, object] = {
+        "to": {"user_ids": user_ids},
+        "notification": {"title": title, "body": body},
+        "data": data or {},
+        "options": {"priority": "high"},
+        "apns": {"topic": PUSH_TOPIC},
+    }
+    try:
+        _authed_request("POST", "/v1/notifications", payload)
+        return True
+    except PushGatewayError:
+        logger.warning("push: send notification failed", exc_info=True)
+        return False
+
+
+# --- async wrappers (for FastAPI endpoints) --------------------------------
+
+
+async def register_device_async(
+    user_id: str,
+    device_token: str,
+    *,
+    device_id: str | None = None,
+    platform: str = "ios",
+) -> bool:
+    """Async wrapper over :func:`register_device` (runs off the event loop)."""
+    return await asyncio.to_thread(
+        register_device,
+        user_id,
+        device_token,
+        device_id=device_id,
+        platform=platform,
+    )
+
+
+async def unregister_device_async(
+    *,
+    device_token: str | None = None,
+    device_id: str | None = None,
+    platform: str = "ios",
+) -> bool:
+    """Async wrapper over :func:`unregister_device` (runs off the event loop)."""
+    return await asyncio.to_thread(
+        unregister_device,
+        device_token=device_token,
+        device_id=device_id,
+        platform=platform,
+    )
+
+
+def _reset_cache() -> None:
+    """Test hook: drop the in-process key cache (the file stays authoritative)."""
+    global _cached_api_key
+    _cached_api_key = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,9 @@ os.environ["MEDIA_PATH"] = os.path.join(_TMP_ROOT, "media")
 os.environ["DB_PATH"] = os.path.join(_TMP_ROOT, "db")
 os.environ["CONFIG_PATH"] = os.path.join(_TMP_ROOT, "config")
 os.environ["THUMBNAILS_PATH"] = os.path.join(_TMP_ROOT, "thumbnails")
+# Disable push by default so the suite never reaches the real gateway; the push
+# tests opt in by monkeypatching settings.push_gateway_url.
+os.environ["NULLFEED_PUSH_GATEWAY_URL"] = ""
 
 import pytest
 import pytest_asyncio
@@ -23,6 +26,7 @@ from httpx import ASGITransport, AsyncClient
 
 import app.api.auth as auth_api
 import app.api.websocket as websocket_api
+import app.services.push_gateway as push_gateway
 import app.services.youtube_import as youtube_import
 from app.database import engine
 from app.main import app
@@ -37,6 +41,7 @@ def _reset_in_memory_state():
     youtube_import._resolve_cache.clear()
     youtube_import._suggestions_cache.clear()
     websocket_api._connections.clear()
+    push_gateway._reset_cache()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_push_gateway.py
+++ b/tests/test_push_gateway.py
@@ -1,0 +1,424 @@
+"""Tests for the push gateway integration (#33).
+
+Everything mocks ``httpx`` at ``push_gateway.httpx.request`` — there is no real
+network. Covered: auto-enroll persists + reuses the key, the device-register
+forwards user id + token + topic, a new episode triggers a per-subscriber send
+with the right ``to.user_ids`` + ``data.video_id``, push DISABLED no-ops both the
+endpoints and the poller (no call-out), and a gateway error during a send never
+breaks the poll.
+"""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+import app.services.push_gateway as push_gateway
+from app.config import settings
+
+
+# --- test doubles ----------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``httpx.Response`` (status + optional JSON body)."""
+
+    def __init__(self, status_code: int = 200, json_data: dict | None = None):
+        self.status_code = status_code
+        self._json = {} if json_data is None else json_data
+        self.text = ""
+
+    def json(self) -> dict:
+        return self._json
+
+
+def _fake_request(record: list, handler):
+    """Build an ``httpx.request`` replacement that records and routes calls.
+
+    ``handler(method, url)`` returns a :class:`_FakeResponse`, or an ``Exception``
+    instance to be raised (to simulate a transport error / non-2xx).
+    """
+
+    def fake(method, url, *, json=None, headers=None, timeout=None):
+        record.append(
+            {"method": method, "url": url, "json": json, "headers": headers or {}}
+        )
+        result = handler(method, url)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    return fake
+
+
+def _no_network(*_args, **_kwargs):
+    raise AssertionError("unexpected push gateway network call")
+
+
+def _enable_push(monkeypatch, tmp_path, *, api_key: str = "pgk_explicit") -> None:
+    """Enable push with an explicit (non-persisted) key and an isolated config dir."""
+    monkeypatch.setattr(settings, "push_gateway_url", "https://gw.test")
+    monkeypatch.setattr(settings, "push_api_key", api_key)
+    monkeypatch.setattr(settings, "push_enroll_token", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+    push_gateway._reset_cache()
+
+
+def _poller_db(*user_ids: str, initial_poll_done: bool = True):
+    """In-memory poller DB with one channel + the given subscribers."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from app.models import Base
+    from app.models.channel import Channel
+    from app.models.subscription import UserSubscription
+    from app.utils.time import utcnow_naive
+
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    channel = Channel(
+        id="ch-1",
+        youtube_channel_id="@testchannel",
+        name="Test Channel",
+        slug="testchannel",
+        last_checked_at=utcnow_naive() if initial_poll_done else None,
+    )
+    db.add(channel)
+    for uid in user_ids:
+        db.add(UserSubscription(user_id=uid, channel_id=channel.id))
+    db.commit()
+    return db, channel
+
+
+# --- auto-enroll persistence ----------------------------------------------
+
+
+def test_auto_enroll_persists_and_reuses_key(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "push_gateway_url", "https://gw.test")
+    monkeypatch.setattr(settings, "push_api_key", "")  # force auto-enroll
+    monkeypatch.setattr(settings, "push_enroll_token", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+    push_gateway._reset_cache()
+
+    record: list = []
+
+    def handler(method, url):
+        if url.endswith("/v1/enroll"):
+            return _FakeResponse(201, {"api_key": "pgk_enrolled", "tenant_id": "t-1"})
+        return _FakeResponse(200, {"id": "d", "created": True})
+
+    monkeypatch.setattr(push_gateway.httpx, "request", _fake_request(record, handler))
+
+    key = push_gateway._resolve_api_key()
+    assert key == "pgk_enrolled"
+
+    # Persisted as a 0600 file under config_path.
+    key_file = tmp_path / "push_api_key"
+    assert key_file.read_text().strip() == "pgk_enrolled"
+    assert (key_file.stat().st_mode & 0o777) == 0o600
+
+    enroll_calls = [c for c in record if c["url"].endswith("/v1/enroll")]
+    assert len(enroll_calls) == 1
+    assert enroll_calls[0]["json"] == {"name": "NullFeed"}
+    assert "Authorization" not in enroll_calls[0]["headers"]  # enroll is unauth
+
+    # A fresh process (cache dropped) reuses the persisted key — no re-enroll.
+    push_gateway._reset_cache()
+    assert push_gateway._resolve_api_key() == "pgk_enrolled"
+    assert len([c for c in record if c["url"].endswith("/v1/enroll")]) == 1
+
+
+def test_auto_enroll_sends_enroll_token_when_gated(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "push_gateway_url", "https://gw.test")
+    monkeypatch.setattr(settings, "push_api_key", "")
+    monkeypatch.setattr(settings, "push_enroll_token", "secret-enroll")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+    push_gateway._reset_cache()
+
+    record: list = []
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        _fake_request(record, lambda m, u: _FakeResponse(201, {"api_key": "pgk_g"})),
+    )
+
+    assert push_gateway._resolve_api_key() == "pgk_g"
+    enroll_call = next(c for c in record if c["url"].endswith("/v1/enroll"))
+    assert enroll_call["headers"].get("X-Enroll-Token") == "secret-enroll"
+
+
+# --- device registration ---------------------------------------------------
+
+
+def test_register_forwards_user_token_topic(monkeypatch, tmp_path):
+    _enable_push(monkeypatch, tmp_path)
+    record: list = []
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        _fake_request(
+            record, lambda m, u: _FakeResponse(200, {"id": "d", "created": True})
+        ),
+    )
+
+    assert (
+        push_gateway.register_device("user-42", "apns-tok", device_id="dev-1") is True
+    )
+
+    assert len(record) == 1
+    call = record[0]
+    assert call["method"] == "POST"
+    assert call["url"].endswith("/v1/devices")
+    assert call["json"] == {
+        "user_id": "user-42",
+        "platform": "ios",
+        "token": "apns-tok",
+        "topic": "codes.julian.nullfeed",
+        "device_id": "dev-1",
+    }
+    assert call["headers"]["Authorization"] == "Bearer pgk_explicit"
+    # An explicit key is never persisted.
+    assert not (tmp_path / "push_api_key").exists()
+
+
+def test_unregister_by_device_id(monkeypatch, tmp_path):
+    _enable_push(monkeypatch, tmp_path)
+    record: list = []
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        _fake_request(record, lambda m, u: _FakeResponse(204)),
+    )
+
+    assert push_gateway.unregister_device(device_id="dev-1") is True
+    assert record[0]["method"] == "DELETE"
+    assert record[0]["url"].endswith("/v1/devices")
+    assert record[0]["json"] == {"device_id": "dev-1"}
+
+
+def test_unregister_without_identifier_is_noop(monkeypatch, tmp_path):
+    _enable_push(monkeypatch, tmp_path)
+    monkeypatch.setattr(push_gateway.httpx, "request", _no_network)
+    assert push_gateway.unregister_device() is False  # no network call
+
+
+# --- notification send -----------------------------------------------------
+
+
+def test_send_to_users_targets_user_ids_with_data(monkeypatch, tmp_path):
+    _enable_push(monkeypatch, tmp_path)
+    record: list = []
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        _fake_request(
+            record,
+            lambda m, u: _FakeResponse(200, {"sent": 1, "failed": 0, "results": []}),
+        ),
+    )
+
+    ok = push_gateway.send_to_users(
+        ["u1"], "Chan", "Vid Title", {"type": "new_episode", "video_id": "v1"}
+    )
+    assert ok is True
+
+    body = record[0]["json"]
+    assert record[0]["url"].endswith("/v1/notifications")
+    assert body["to"] == {"user_ids": ["u1"]}
+    assert body["notification"] == {"title": "Chan", "body": "Vid Title"}
+    assert body["data"] == {"type": "new_episode", "video_id": "v1"}
+    assert body["apns"] == {"topic": "codes.julian.nullfeed"}
+
+
+def test_send_error_is_swallowed(monkeypatch, tmp_path):
+    _enable_push(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        lambda *a, **k: (_ for _ in ()).throw(httpx.ConnectError("down")),
+    )
+    # Best-effort: a transport error returns False, never raises.
+    assert push_gateway.send_to_users(["u1"], "t", "b", {}) is False
+
+
+# --- push disabled ---------------------------------------------------------
+
+
+def test_disabled_functions_make_no_calls(monkeypatch):
+    monkeypatch.setattr(settings, "push_gateway_url", "")
+    push_gateway._reset_cache()
+    monkeypatch.setattr(push_gateway.httpx, "request", _no_network)
+
+    assert push_gateway.push_enabled() is False
+    assert push_gateway._resolve_api_key() is None
+    assert push_gateway.register_device("u1", "tok") is False
+    assert push_gateway.unregister_device(device_id="d") is False
+    assert push_gateway.send_to_users(["u1"], "t", "b", {}) is False
+
+
+# --- poller integration ----------------------------------------------------
+
+
+def test_new_episode_triggers_push_per_subscriber(monkeypatch, tmp_path):
+    from app.services import channel_poller
+
+    _enable_push(monkeypatch, tmp_path)
+    db, channel = _poller_db("u1", "u2", initial_poll_done=True)
+    feed = {"videos": [{"youtube_video_id": "vid00000001", "title": "New One"}]}
+    monkeypatch.setattr(channel_poller, "fetch_channel_videos", lambda _: feed)
+    monkeypatch.setattr(channel_poller, "publish_new_episode", MagicMock())
+
+    record: list = []
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        _fake_request(
+            record,
+            lambda m, u: _FakeResponse(200, {"sent": 1, "failed": 0, "results": []}),
+        ),
+    )
+
+    result = channel_poller.poll_single_channel(channel.id, db)
+    video_id = result["cataloged_ids"][0]
+
+    notifs = [c for c in record if c["url"].endswith("/v1/notifications")]
+    assert len(notifs) == 2  # one per subscriber x 1 new video
+    targets = set()
+    for c in notifs:
+        body = c["json"]
+        assert body["data"] == {"type": "new_episode", "video_id": video_id}
+        assert body["notification"]["title"] == "Test Channel"
+        assert body["notification"]["body"] == "New One"
+        (uid,) = body["to"]["user_ids"]
+        targets.add(uid)
+    assert targets == {"u1", "u2"}
+    db.close()
+
+
+def test_poller_does_not_call_out_when_push_disabled(monkeypatch):
+    from app.services import channel_poller
+
+    monkeypatch.setattr(settings, "push_gateway_url", "")
+    push_gateway._reset_cache()
+
+    db, channel = _poller_db("u1", initial_poll_done=True)
+    feed = {"videos": [{"youtube_video_id": "vid00000001", "title": "New One"}]}
+    monkeypatch.setattr(channel_poller, "fetch_channel_videos", lambda _: feed)
+    monkeypatch.setattr(channel_poller, "publish_new_episode", MagicMock())
+
+    calls: list = []
+
+    def counting(*a, **k):
+        calls.append(1)
+        return _FakeResponse(200, {})
+
+    monkeypatch.setattr(push_gateway.httpx, "request", counting)
+
+    result = channel_poller.poll_single_channel(channel.id, db)
+    assert len(result["cataloged_ids"]) == 1  # poll still catalogs
+    assert calls == []  # never reached the gateway
+    db.close()
+
+
+def test_gateway_error_during_send_does_not_break_poll(monkeypatch, tmp_path):
+    from app.services import channel_poller
+
+    _enable_push(monkeypatch, tmp_path)
+    db, channel = _poller_db("u1", initial_poll_done=True)
+    feed = {"videos": [{"youtube_video_id": "vid00000001", "title": "New One"}]}
+    monkeypatch.setattr(channel_poller, "fetch_channel_videos", lambda _: feed)
+    ws_mock = MagicMock()
+    monkeypatch.setattr(channel_poller, "publish_new_episode", ws_mock)
+
+    def boom(method, url, *, json=None, headers=None, timeout=None):
+        raise httpx.ConnectError("gateway down")
+
+    monkeypatch.setattr(push_gateway.httpx, "request", boom)
+
+    result = channel_poller.poll_single_channel(channel.id, db)
+    assert len(result["cataloged_ids"]) == 1  # poll succeeded despite push failure
+    ws_mock.assert_called_once()  # WS publish still happened
+    db.close()
+
+
+# --- endpoints -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_endpoint_forwards_user_and_topic(
+    client, make_user, monkeypatch, tmp_path
+):
+    _enable_push(monkeypatch, tmp_path)
+    record: list = []
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        _fake_request(
+            record, lambda m, u: _FakeResponse(200, {"id": "d1", "created": True})
+        ),
+    )
+
+    profile, headers = await make_user()
+    resp = await client.post(
+        "/api/push/register",
+        headers=headers,
+        json={"device_token": "apns-tok", "device_id": "dev-1"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"enabled": True, "registered": True}
+
+    devices = [c for c in record if c["url"].endswith("/v1/devices")]
+    assert len(devices) == 1
+    sent = devices[0]["json"]
+    assert sent["user_id"] == profile["id"]
+    assert sent["token"] == "apns-tok"
+    assert sent["device_id"] == "dev-1"
+    assert sent["topic"] == "codes.julian.nullfeed"
+    assert devices[0]["headers"]["Authorization"] == "Bearer pgk_explicit"
+
+
+@pytest.mark.asyncio
+async def test_unregister_endpoint_forwards(client, make_user, monkeypatch, tmp_path):
+    _enable_push(monkeypatch, tmp_path)
+    record: list = []
+    monkeypatch.setattr(
+        push_gateway.httpx,
+        "request",
+        _fake_request(record, lambda m, u: _FakeResponse(204)),
+    )
+
+    _, headers = await make_user()
+    resp = await client.request(
+        "DELETE", "/api/push/register", headers=headers, json={"device_id": "dev-1"}
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"enabled": True, "unregistered": True}
+
+    devices = [c for c in record if c["url"].endswith("/v1/devices")]
+    assert devices[0]["method"] == "DELETE"
+    assert devices[0]["json"] == {"device_id": "dev-1"}
+
+
+@pytest.mark.asyncio
+async def test_register_endpoint_requires_auth(client, monkeypatch, tmp_path):
+    _enable_push(monkeypatch, tmp_path)
+    monkeypatch.setattr(push_gateway.httpx, "request", _no_network)
+    resp = await client.post("/api/push/register", json={"device_token": "t"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_register_endpoint_disabled_returns_disabled(
+    client, make_user, monkeypatch
+):
+    monkeypatch.setattr(settings, "push_gateway_url", "")
+    push_gateway._reset_cache()
+    monkeypatch.setattr(push_gateway.httpx, "request", _no_network)
+
+    _, headers = await make_user()
+    resp = await client.post(
+        "/api/push/register", headers=headers, json={"device_token": "tok"}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"enabled": False}


### PR DESCRIPTION
New-episode push notifications (roadmap LATER tier, #4), integrated with the public push gateway (push.julian.codes) the same way Cantinarr does. Additive — no migration; disabled unless a gateway URL is configured (it defaults to the public relay).

## Config (`app/config.py`, `.env.example`)
`NULLFEED_PUSH_GATEWAY_URL` (default `https://push.julian.codes`), `NULLFEED_PUSH_API_KEY` (default ""), `NULLFEED_PUSH_ENROLL_TOKEN` (default ""). Blank URL ⇒ push fully disabled (every path no-ops).

## Gateway client (`app/services/push_gateway.py`)
- **Auto-enroll** on first use (`POST /v1/enroll`), persisting the issued `pgk_` key as a 0600 file under `config_path` via the same atomic hard-link claim as the ticket secret (survives restart, shared across workers). Explicit `NULLFEED_PUSH_API_KEY` wins and isn't persisted.
- `register_device` / `unregister_device` (`POST`/`DELETE /v1/devices`, topic `codes.julian.nullfeed`), `send_to_users` (`POST /v1/notifications`, `to.user_ids` only — tenant keys can't target raw tokens). Sync core (for the Celery poller) + async wrappers via `asyncio.to_thread` (for endpoints). **Best-effort throughout: disabled/unreachable/error is logged and swallowed, never raised into the poller or an endpoint.**

## Endpoints (`app/api/push.py`, X-User-Token auth)
`POST /api/push/register {device_token, device_id?, platform?="ios"}` → forwards to the gateway with `user.id`; `DELETE /api/push/register {device_id|device_token}`. Push disabled ⇒ `200 {"enabled": false}`.

## Send on new episode
`channel_poller._emit_new_episode_events` (sync Celery, after the back-catalog gate + WS publish) sends per subscriber×new video: `to.user_ids=[user_id]`, alert title=channel/body=video title, `data {"type":"new_episode","video_id"}` for deep-linking, priority high. A push error never breaks polling.

## Verification (local)
- `pytest -q` → **239 passed** (+15, httpx mocked: auto-enroll persists+reuses, register forwards user.id+token+topic, new_episode→send with right `to.user_ids`+`data.video_id`, disabled no-ops, gateway error doesn't break the poll).
- `ruff` + `mypy` clean · no migration.

**Clients next**: APNs registration → `POST /api/push/register`; tap on `data.video_id` → `/player/:id`. **Needs you (I'll handle with your access):** confirm the gateway's enrollment mode (auto-enroll assumes `open`; else an enroll token / explicit key) and the Apple Push capability on `codes.julian.nullfeed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY