### PR TITLE
fix(security): video-scale TTL for stream tickets (WS stays 5m)

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -31,7 +31,13 @@ from app.services.storage import check_and_delete_orphan
 from app.tasks.download_tasks import download_preview_task, download_video_task
 from app.utils.pagination import decode_cursor, encode_cursor
 from app.utils.search import escape_like
-from app.utils.tickets import SCOPE_STREAM, TicketError, mint_ticket, verify_ticket
+from app.utils.tickets import (
+    SCOPE_STREAM,
+    STREAM_TICKET_TTL_SECONDS,
+    TicketError,
+    mint_ticket,
+    verify_ticket,
+)
 from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/videos", tags=["videos"])
@@ -391,7 +397,9 @@ async def create_playback_ticket(
     exists = await db.scalar(select(Video.id).where(Video.id == video_id))
     if not exists:
         raise HTTPException(status_code=404, detail="Video not found")
-    ticket, expires_in = mint_ticket(SCOPE_STREAM, user.id, video_id=video_id)
+    ticket, expires_in = mint_ticket(
+        SCOPE_STREAM, user.id, video_id=video_id, ttl_seconds=STREAM_TICKET_TTL_SECONDS
+    )
     return AccessTicket(ticket=ticket, expires_in=expires_in)
 
 

--- a/app/utils/tickets.py
+++ b/app/utils/tickets.py
@@ -39,9 +39,18 @@ from app.config import settings
 SCOPE_STREAM = "stream"
 SCOPE_WS = "ws"
 
-# Tickets are deliberately short-lived: long enough to start playback / open the
-# socket, short enough that a leaked URL expires before it is useful.
+# WS tickets are deliberately short-lived: long enough to open the socket, short
+# enough that a leaked handshake URL expires before it is useful. (The socket is
+# authorized once, at connect.)
 TICKET_TTL_SECONDS = 300  # 5 minutes
+
+# Stream tickets must outlive a whole playback session: media is fetched via many
+# HTTP Range requests over the video's duration (plus pauses), and each request
+# re-verifies the ticket — a 5-minute TTL would break any video longer than that.
+# A stream ticket is narrowly scoped to ONE video for ONE user (read-only), so a
+# multi-hour TTL keeps the blast radius of a leaked URL tiny while letting long
+# videos play through.
+STREAM_TICKET_TTL_SECONDS = 12 * 3600  # 12 hours
 
 # Filename of the auto-generated secret persisted under settings.config_path.
 _SECRET_FILENAME = "stream_ticket_secret"


### PR DESCRIPTION
Follow-up to #79. A `/stream` playback ticket is re-verified on **every HTTP Range request**, which span the whole playback session (a long video + pauses). The 5-minute ticket TTL would break any video longer than ~5 min once clients switch off the long-lived `?token=`. Since a stream ticket is scoped to **one video for one user (read-only)**, a 12h TTL keeps the leaked-URL blast radius tiny while letting long videos play through. WebSocket tickets keep the 5-min TTL (authorized once at connect).

- `STREAM_TICKET_TTL_SECONDS = 12h`; `create_playback_ticket` mints with it.
- `pytest -q` → **239 passed**; `ruff` clean. No migration.

Unblocks the Flutter/tvOS stream-ticket switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY