### PR TITLE
feat: YouTube WebSub subscriber (config-gated, RSS stays fallback) (#7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,23 @@ NULLFEED_PUSH_API_KEY=
 # Only needed when the gateway runs in "gated" enrollment mode (sent as X-Enroll-Token).
 NULLFEED_PUSH_ENROLL_TOKEN=
 
+# WebSub / PubSubHubbub subscriber (optional; near-real-time new uploads).
+# When set, NullFeed asks YouTube's hub to PUSH new-upload notifications to this
+# public callback so new videos appear almost immediately instead of waiting for
+# the next adaptive RSS poll. It is a pure accelerator: RSS + adaptive polling
+# stays the always-on fallback, so a missed/late push is still caught by polling.
+# Leave the callback URL BLANK to disable WebSub entirely (the callback 404s and
+# the subscribe task no-ops). To enable, set it to a PUBLIC https URL that is
+# reachable from the internet and routes to /api/websub/callback, e.g.
+# https://nullfeed.example.com/api/websub/callback
+# The HMAC secret used with the hub is generated once and persisted under
+# CONFIG_PATH (a 0600 file), so no secret needs to be configured here.
+NULLFEED_WEBSUB_CALLBACK_URL=
+# Hub endpoint (Google's public hub by default; override only to self-host one).
+NULLFEED_WEBSUB_HUB_URL=https://pubsubhubbub.appspot.com/subscribe
+# Subscription lease to request and renew before, in seconds (default 5 days).
+NULLFEED_WEBSUB_LEASE_SECONDS=432000
+
 # Redis URL (internal; override only if using external Redis)
 REDIS_URL=redis://localhost:6379/0
 

--- a/alembic/versions/012_channel_websub_expires_at.py
+++ b/alembic/versions/012_channel_websub_expires_at.py
@@ -1,0 +1,30 @@
+"""Track WebSub lease expiry: channels.websub_expires_at
+
+Revision ID: 012_channel_websub_expires_at
+Revises: 011_videos_channel_uploaded_index
+Create Date: 2026-06-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "012_channel_websub_expires_at"
+down_revision: Union[str, None] = "011_videos_channel_uploaded_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable: NULL means no active WebSub (PubSubHubbub) subscription — either
+    # the feature is disabled or the channel was never subscribed — so existing
+    # rows backfill to NULL and the subscribe beat task picks them up as due.
+    op.add_column(
+        "channels",
+        sa.Column("websub_expires_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channels", "websub_expires_at")

--- a/app/api/websub.py
+++ b/app/api/websub.py
@@ -1,0 +1,124 @@
+"""Public WebSub (PubSubHubbub) callback for near-real-time new uploads.
+
+YouTube's hub calls these endpoints directly, so — unlike every other NullFeed
+route — they are UNAUTHENTICATED. Trust comes instead from the protocol:
+
+  * ``GET /api/websub/callback`` is the hub's subscription-verification probe. We
+    echo ``hub.challenge`` (text/plain 200) only for a ``hub.topic`` that maps to
+    a channel we actually track; anything else 404s, so we can't be coerced into
+    confirming subscriptions we never requested.
+  * ``POST /api/websub/callback`` is a content-distribution push. Its body is
+    authenticated by recomputing the ``X-Hub-Signature`` HMAC with our shared
+    secret; an absent/forged signature 404s WITHOUT revealing why. A verified
+    push is parsed for ``yt:videoId``s and the genuinely-new ones are cataloged
+    off the request path via the same poller code (Celery), so the response stays
+    fast and duplicate pushes are idempotent.
+
+The whole router is gated on ``websub_enabled()``: when no callback URL is
+configured the feature is off and both endpoints 404, leaving the RSS/adaptive
+poller as the sole (unchanged) discovery path.
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import PlainTextResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.services.websub import channel_id_for_topic, parse_push, websub_enabled
+from app.tasks.download_tasks import ingest_websub_push_task
+from app.utils.websub import verify_signature
+
+router = APIRouter(prefix="/api/websub", tags=["websub"])
+logger = logging.getLogger(__name__)
+
+
+async def _tracked_channel_id(uc_id: str, db: AsyncSession) -> str | None:
+    """Return our internal id for a tracked (subscribed) UC channel, else None.
+
+    "Tracked" means a Channel row with this canonical UC id that has at least one
+    subscriber — exactly the set the subscribe beat task subscribes — so the
+    callback only ever acts on subscriptions we requested.
+    """
+    result = await db.execute(
+        select(Channel.id)
+        .join(UserSubscription, UserSubscription.channel_id == Channel.id)
+        .where(Channel.youtube_channel_id == uc_id)
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+@router.get("/callback")
+async def verify_subscription(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Hub verification probe: echo ``hub.challenge`` for a tracked topic.
+
+    Returns the challenge as text/plain 200 when ``hub.mode`` is subscribe or
+    unsubscribe and ``hub.topic`` resolves to a channel we track; 404 otherwise
+    (including when WebSub is disabled), which tells the hub the (un)subscription
+    was not confirmed.
+    """
+    if not websub_enabled():
+        raise HTTPException(status_code=404, detail="WebSub not enabled")
+
+    params = request.query_params
+    mode = params.get("hub.mode")
+    challenge = params.get("hub.challenge")
+    uc_id = channel_id_for_topic(params.get("hub.topic"))
+
+    if (
+        mode in ("subscribe", "unsubscribe")
+        and challenge
+        and uc_id
+        and await _tracked_channel_id(uc_id, db) is not None
+    ):
+        return PlainTextResponse(challenge)
+
+    raise HTTPException(status_code=404, detail="Unknown subscription")
+
+
+@router.post("/callback")
+async def receive_push(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Authenticated content push: catalog genuinely-new uploads off the request path.
+
+    Verifies ``X-Hub-Signature`` against the raw body, then parses the Atom push
+    for video ids and dispatches a Celery job to catalog the new ones (yt-dlp can
+    be slow, so it must not block this response). Always returns quickly: 204 once
+    accepted; 404 for a bad/absent signature (without revealing why) or when the
+    feature is disabled.
+    """
+    if not websub_enabled():
+        raise HTTPException(status_code=404, detail="WebSub not enabled")
+
+    raw = await request.body()
+    if not verify_signature(raw, request.headers.get("X-Hub-Signature")):
+        # Do not reveal whether the topic is tracked or why verification failed;
+        # an unauthenticated body must never reach the catalog path.
+        raise HTTPException(status_code=404, detail="Invalid signature")
+
+    parsed = parse_push(raw)
+    uc_id = parsed["channel_id"]
+    video_ids = parsed["video_ids"]
+    if not uc_id or not video_ids:
+        # Nothing actionable (e.g. a deletion tombstone or an empty body).
+        return Response(status_code=204)
+
+    channel_id = await _tracked_channel_id(uc_id, db)
+    if channel_id is None:
+        # Signed, but for a channel we no longer track; accept and ignore.
+        return Response(status_code=204)
+
+    # Hand off to Celery: idempotent cataloging of only the genuinely-new ids
+    # happens there, so this handler stays fast for the hub.
+    ingest_websub_push_task.delay(channel_id, video_ids)
+    return Response(status_code=204)

--- a/app/config.py
+++ b/app/config.py
@@ -84,6 +84,32 @@ class Settings(BaseSettings):
         default="", validation_alias="NULLFEED_PUSH_ENROLL_TOKEN"
     )
 
+    # WebSub / PubSubHubbub subscriber (near-real-time new uploads)
+    # When enabled, NullFeed subscribes each tracked UC channel to YouTube's
+    # WebSub hub so the hub PUSHES new-upload notifications to our public
+    # callback, instead of waiting for the next adaptive RSS poll. It is a pure
+    # accelerator layered on top of polling: RSS + adaptive polling stays the
+    # always-on fallback, and everything here no-ops when disabled.
+    #
+    # websub_callback_url is the PUBLIC https URL the hub will call back; it must
+    # be reachable from the internet and resolve to GET/POST /api/websub/callback
+    # (e.g. https://nullfeed.example.com/api/websub/callback). Leave it BLANK to
+    # disable WebSub entirely — the callback router 404s and the subscribe beat
+    # task no-ops, leaving polling untouched. websub_hub_url is Google's public
+    # hub; websub_lease_seconds is the subscription lease we request and renew
+    # before (default 5 days).
+    websub_callback_url: str = Field(
+        default="", validation_alias="NULLFEED_WEBSUB_CALLBACK_URL"
+    )
+    websub_hub_url: str = Field(
+        default="https://pubsubhubbub.appspot.com/subscribe",
+        validation_alias="NULLFEED_WEBSUB_HUB_URL",
+    )
+    websub_lease_seconds: int = Field(
+        default=432000,  # 5 days
+        validation_alias="NULLFEED_WEBSUB_LEASE_SECONDS",
+    )
+
     # File permissions
     puid: int = 1000
     pgid: int = 1000

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.api import (
     queue,
     videos,
     websocket,
+    websub,
     youtube,
 )
 from app.config import settings
@@ -123,6 +124,7 @@ app.include_router(discover.router)
 app.include_router(websocket.router)
 app.include_router(youtube.router)
 app.include_router(push.router)
+app.include_router(websub.router)
 
 
 # ---------------------------------------------------------------------------

--- a/app/models/channel.py
+++ b/app/models/channel.py
@@ -42,6 +42,12 @@ class Channel(Base):
     poll_interval_minutes: Mapped[int] = mapped_column(
         Integer, nullable=False, default=15
     )
+    # WebSub (PubSubHubbub) lease expiry, when the optional near-real-time
+    # subscriber is enabled. NULL means no active hub subscription (never
+    # subscribed, or the feature is off); the subscribe beat task renews each
+    # channel before this passes. Independent of the poll cadence above, which
+    # remains the always-on fallback.
+    websub_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     videos = relationship("Video", back_populates="channel", lazy="select")
     subscriptions = relationship(

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -155,10 +155,44 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
             db.commit()
             return {"cataloged_ids": [], "auto_download_ids": []}
 
+    # The routine poll updates last_checked_at and the adaptive cadence as part
+    # of the catalog commit; the initial poll only catalogs (no prior schedule).
+    return _catalog_videos(
+        channel,
+        yt_videos,
+        db,
+        had_initial_poll=had_initial_poll,
+        update_schedule=True,
+    )
+
+
+def _catalog_videos(
+    channel: Channel,
+    yt_videos: list[dict],
+    db: Session,
+    *,
+    had_initial_poll: bool,
+    update_schedule: bool,
+) -> dict:
+    """Insert genuinely-new videos from a metadata batch and fan out the rest.
+
+    Shared by the routine poll and the WebSub push handler. ``yt_videos`` is a
+    list of yt-dlp metadata dicts (newest-first). New videos are inserted
+    CATALOGED, subscriber refs are ensured, FUTURE_ONLY auto-download candidates
+    flip to PENDING, and — only when ``had_initial_poll`` (so back-catalog
+    ingestion stays silent) — a new_episode event + push is emitted per
+    subscriber/new video.
+
+    When ``update_schedule`` is set (the poller) ``last_checked_at`` and the
+    adaptive cadence are folded into the same commit; the WebSub path passes
+    ``False`` so the poll schedule (the RSS fallback) is left entirely untouched.
+    Returns ``{"cataloged_ids", "auto_download_ids"}``.
+    """
+    channel_id = channel.id
     cataloged_ids: list[str] = []
     new_video_ids: list[str] = []
     new_videos_for_events: list[dict] = []
-    # Every video this poll touched (new rows plus already-cataloged ones seen
+    # Every video this batch touched (new rows plus already-cataloged ones seen
     # in the feed); a single batched ref-ensure runs over them after the loop.
     video_ids_for_refs: list[str] = []
 
@@ -181,7 +215,7 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
     # yt-dlp returns the channel feed newest-first. Cataloged videos have no
     # upload date until downloaded, and listings fall back to created_at — so
     # stamp each new row with a synthetic timestamp that decreases down the
-    # feed, preserving the feed order within this poll batch.
+    # feed, preserving the feed order within this batch.
     poll_started_at = utcnow_naive()
 
     for index, yt_vid in enumerate(yt_videos):
@@ -232,7 +266,7 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
         )
         logger.info("New video cataloged: %s (%s)", yt_video_id, video.title)
 
-    # One batched ref-ensure over every video this poll touched, instead of the
+    # One batched ref-ensure over every video this batch touched, instead of the
     # per-video, per-subscriber N+1 the old per-video helper issued.
     _ensure_user_refs_bulk(video_ids_for_refs, channel_id, db)
 
@@ -243,10 +277,11 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
             new_video_ids, channel_id, db, had_initial_poll
         )
 
-    channel.last_checked_at = utcnow_naive()
-    # New rows -> the channel looks active, shorten toward the floor; an empty
-    # poll -> looks dormant, lengthen toward the cap.
-    _reschedule_channel(channel, found_new=bool(cataloged_ids))
+    if update_schedule:
+        channel.last_checked_at = utcnow_naive()
+        # New rows -> the channel looks active, shorten toward the floor; an
+        # empty poll -> looks dormant, lengthen toward the cap.
+        _reschedule_channel(channel, found_new=bool(cataloged_ids))
     db.commit()
 
     # Notify subscribers about genuinely new episodes — never the back catalog
@@ -255,6 +290,68 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
         _emit_new_episode_events(channel_id, new_videos_for_events, db)
 
     return {"cataloged_ids": cataloged_ids, "auto_download_ids": auto_download_ids}
+
+
+def ingest_pushed_videos(
+    channel_id: str, youtube_video_ids: list[str], db: Session
+) -> dict:
+    """Catalog WebSub-pushed video IDs for a channel via the normal poll path.
+
+    The near-real-time counterpart to :func:`poll_single_channel`: instead of
+    polling the Atom feed, YouTube's hub pushed the new video ids to our
+    callback. We catalog the genuinely-new ones — skipping any already known, so
+    the duplicate pushes the hub commonly sends are idempotent — exactly as the
+    RSS discovery path does via :func:`_catalog_videos`, emitting new_episode
+    events + pushes. The adaptive poll schedule is deliberately left untouched so
+    the RSS poller remains the unchanged fallback.
+
+    Returns ``{"cataloged_ids", "auto_download_ids"}`` like the poller.
+    """
+    empty: dict = {"cataloged_ids": [], "auto_download_ids": []}
+
+    channel = db.get(Channel, channel_id)
+    if channel is None:
+        logger.warning("WebSub ingest: channel %s not found", channel_id)
+        return empty
+
+    # A channel that has never been polled has no back-catalog baseline; defer to
+    # the poller for the initial ingest rather than treating a push as a flood of
+    # "new" episodes (and spamming notifications for the back catalog).
+    if channel.last_checked_at is None:
+        logger.info(
+            "WebSub ingest: channel %s has no initial poll yet; deferring to poller",
+            channel_id,
+        )
+        return empty
+
+    # Idempotency: keep only ids we have never cataloged, deduped and order-
+    # preserving. A duplicate push thus resolves to an empty set and does no
+    # yt-dlp work. _catalog_videos re-checks under the same transaction too, so
+    # this is also safe under concurrent pushes.
+    candidate_ids = [vid for vid in dict.fromkeys(youtube_video_ids) if vid]
+    if not candidate_ids:
+        return empty
+    known = set(
+        db.execute(
+            select(Video.youtube_video_id).where(
+                Video.youtube_video_id.in_(candidate_ids)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    new_ids = [vid for vid in candidate_ids if vid not in known]
+    if not new_ids:
+        return empty
+
+    logger.info("WebSub push: %d new video(s) for channel %s", len(new_ids), channel_id)
+    yt_videos = fetch_videos_metadata(new_ids)
+    if not yt_videos:
+        return empty
+
+    return _catalog_videos(
+        channel, yt_videos, db, had_initial_poll=True, update_schedule=False
+    )
 
 
 def _discover_routine(channel: Channel, db: Session) -> list[dict] | None:

--- a/app/services/websub.py
+++ b/app/services/websub.py
@@ -1,0 +1,199 @@
+"""YouTube WebSub (PubSubHubbub) subscribe lifecycle + push parsing.
+
+A pure accelerator on top of the RSS/adaptive poller: when ``websub_callback_url``
+is configured, NullFeed asks YouTube's hub to PUSH new-upload notifications to its
+public callback so discovery is near-real-time instead of waiting for the next
+adaptive poll. Everything here no-ops when WebSub is disabled, and the poller
+remains the unchanged always-on fallback (a missed/late push is still caught by
+the next RSS poll).
+
+This module owns the sync (Celery-side) pieces:
+
+  * :func:`subscribe_channel` POSTs a ``hub.mode=subscribe`` form to the hub;
+  * :func:`sync_subscriptions` is the beat task body that (re)subscribes every
+    tracked UC channel whose lease is missing or near expiry;
+  * :func:`parse_push` / :func:`channel_id_for_topic` parse the Atom push body
+    and topic URL for the callback router.
+
+The HTTP calls are plain synchronous ``httpx`` so the Celery beat can call them
+directly, mirroring :mod:`app.services.push_gateway`.
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import timedelta
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.services.download_manager import YOUTUBE_RSS_FEED_URL
+from app.utils.time import utcnow_naive
+from app.utils.websub import websub_secret
+
+logger = logging.getLogger(__name__)
+
+# Atom + YouTube namespaces in a push body (same feed schema as the RSS poll).
+# ElementTree matches tags by their {namespace}localname form.
+_ATOM_NS = "{http://www.w3.org/2005/Atom}"
+_YT_NS = "{http://www.youtube.com/xml/schemas/2015}"
+
+# Renew a subscription once it is within this fraction of its lease from expiry,
+# so a renewal (and the hub's async re-verification) has comfortable headroom
+# before the current lease lapses. With the default 5-day lease this renews in
+# the final day.
+_RENEW_BEFORE_FRACTION = 0.2
+
+# httpx timeout (seconds) for a hub request.
+_TIMEOUT = 15.0
+
+
+def websub_enabled() -> bool:
+    """True when a public callback URL is configured; everything no-ops if not."""
+    return bool(settings.websub_callback_url)
+
+
+def topic_url(youtube_channel_id: str) -> str:
+    """The WebSub topic (the channel's Atom feed URL) for a canonical UC id."""
+    return f"{YOUTUBE_RSS_FEED_URL}?channel_id={youtube_channel_id}"
+
+
+def channel_id_for_topic(topic: str | None) -> str | None:
+    """Extract the ``channel_id`` query param from a topic URL (or None)."""
+    if not topic:
+        return None
+    try:
+        values = parse_qs(urlparse(topic).query).get("channel_id")
+    except ValueError:
+        return None
+    return values[0] if values else None
+
+
+def parse_push(raw_body: bytes) -> dict:
+    """Parse a WebSub Atom push into ``{"channel_id", "video_ids"}``.
+
+    Returns the feed's canonical UC ``channel_id`` (from the first entry's
+    ``yt:channelId``, falling back to a feed-level one) and the newest-first list
+    of ``yt:videoId``s. Deletion tombstones carry no ``yt:videoId`` and are
+    ignored — we only catalog new uploads. A body that doesn't parse yields empty
+    values so the caller treats the push as a no-op rather than erroring.
+
+    The body is YouTube-originated and HMAC-verified by the caller before this
+    runs, so stdlib ElementTree is used directly (no untrusted-XML concerns).
+    """
+    try:
+        root = ET.fromstring(raw_body)
+    except ET.ParseError:
+        return {"channel_id": None, "video_ids": []}
+
+    channel_id: str | None = None
+    feed_channel_el = root.find(f"{_YT_NS}channelId")
+    if feed_channel_el is not None and feed_channel_el.text:
+        channel_id = feed_channel_el.text.strip() or None
+
+    video_ids: list[str] = []
+    for entry in root.findall(f"{_ATOM_NS}entry"):
+        vid_el = entry.find(f"{_YT_NS}videoId")
+        video_id = (vid_el.text or "").strip() if vid_el is not None else ""
+        if video_id:
+            video_ids.append(video_id)
+        if channel_id is None:
+            chan_el = entry.find(f"{_YT_NS}channelId")
+            if chan_el is not None and chan_el.text:
+                channel_id = chan_el.text.strip() or None
+
+    return {"channel_id": channel_id, "video_ids": video_ids}
+
+
+def subscribe_channel(channel: Channel, *, mode: str = "subscribe") -> bool:
+    """POST a subscribe/unsubscribe request for one channel to the hub.
+
+    Sends the form the hub expects (``hub.callback``/``hub.topic``/``hub.mode``/
+    ``hub.verify=async``/``hub.secret``/``hub.lease_seconds``). With async verify
+    the hub replies 202 and then calls our GET callback to confirm. Best-effort:
+    returns ``False`` (logged, never raised) when WebSub is disabled or the hub
+    request fails, so a single channel's failure can't abort the beat batch.
+    """
+    if not websub_enabled():
+        return False
+    payload = {
+        "hub.callback": settings.websub_callback_url,
+        "hub.topic": topic_url(channel.youtube_channel_id),
+        "hub.mode": mode,
+        "hub.verify": "async",
+        "hub.secret": websub_secret(),
+        "hub.lease_seconds": str(settings.websub_lease_seconds),
+    }
+    try:
+        resp = httpx.post(settings.websub_hub_url, data=payload, timeout=_TIMEOUT)
+    except httpx.HTTPError:
+        logger.warning(
+            "WebSub %s request failed for channel %s", mode, channel.id, exc_info=True
+        )
+        return False
+    if resp.status_code // 100 != 2:
+        logger.warning(
+            "WebSub %s for channel %s returned HTTP %s",
+            mode,
+            channel.id,
+            resp.status_code,
+        )
+        return False
+    return True
+
+
+def sync_subscriptions(db: Session) -> dict:
+    """(Re)subscribe every tracked UC channel whose lease is missing/near expiry.
+
+    The beat task body. No-ops entirely when WebSub is disabled. Otherwise it
+    selects channels that (a) have at least one subscriber, (b) carry a canonical
+    UC id (the only ids the Atom feed/topic is addressable by), and (c) have no
+    recorded lease or one expiring within the renewal window, then subscribes
+    each. On a successful POST the channel's ``websub_expires_at`` is stamped
+    optimistically to ``now + lease``; on failure it is left as-is so the channel
+    stays due and is retried on the next beat. Never touches the adaptive poll
+    schedule, so the RSS fallback is unaffected.
+    """
+    if not websub_enabled():
+        return {"status": "disabled", "subscribed": 0}
+
+    now = utcnow_naive()
+    renew_margin = timedelta(
+        seconds=int(settings.websub_lease_seconds * _RENEW_BEFORE_FRACTION)
+    )
+    due_cutoff = now + renew_margin
+
+    channels = (
+        db.execute(
+            select(Channel)
+            .join(UserSubscription, UserSubscription.channel_id == Channel.id)
+            .where(Channel.youtube_channel_id.like("UC%"))
+            .where(
+                (Channel.websub_expires_at.is_(None))
+                | (Channel.websub_expires_at <= due_cutoff)
+            )
+            .distinct()
+        )
+        .scalars()
+        .all()
+    )
+
+    subscribed = 0
+    lease = timedelta(seconds=settings.websub_lease_seconds)
+    for channel in channels:
+        if subscribe_channel(channel, mode="subscribe"):
+            # Optimistic: the hub confirms asynchronously via our GET callback.
+            # The next beat renews before this lapses; a failed/declined verify
+            # just means the next RSS poll still catches the upload.
+            channel.websub_expires_at = utcnow_naive() + lease
+            subscribed += 1
+    db.commit()
+
+    logger.info(
+        "WebSub sync: %d channel(s) due, %d (re)subscribed", len(channels), subscribed
+    )
+    return {"status": "ok", "due": len(channels), "subscribed": subscribed}

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -60,3 +60,15 @@ celery_app.conf.beat_schedule = {
         "schedule": settings.retention_interval_hours * 3600,
     },
 }
+
+# WebSub (PubSubHubbub) subscription upkeep — only scheduled when a public
+# callback URL is configured, so the feature is entirely absent when disabled.
+# Renews each tracked channel's hub lease before it lapses; every 6h gives
+# several renewal attempts inside the default 5-day lease's renewal window, and
+# is cheap (one indexed query that hits the network only for channels actually
+# due). Discovery keeps working via RSS polling regardless.
+if settings.websub_callback_url:
+    celery_app.conf.beat_schedule["sync-websub-subscriptions"] = {
+        "task": "app.tasks.download_tasks.sync_websub_subscriptions_task",
+        "schedule": 6 * 3600,
+    }

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -16,6 +16,7 @@ from app.models.subscription import UserSubscription
 from app.models.video import Video
 from app.services.channel_poller import (
     _backoff_failed_channel,
+    ingest_pushed_videos,
     list_channel_ids_to_poll,
     poll_single_channel,
     refresh_stale_channel_metadata,
@@ -29,6 +30,7 @@ from app.services.download_manager import (
 from app.services.download_reaper import reap_stuck_downloads
 from app.services.retention import enforce_retention
 from app.services.session_reaper import reap_expired_sessions
+from app.services.websub import sync_subscriptions
 from app.utils.time import utcnow_naive
 from app.services.progress_broadcaster import (
     publish_download_complete,
@@ -123,6 +125,60 @@ def poll_channel_task(self, channel_id: str) -> dict:
         logger.exception("Error polling channel %s", channel_id)
         db.rollback()
         _backoff_failed_channel(channel_id, db)
+        return {"status": "error"}
+    finally:
+        db.close()
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.ingest_websub_push_task",
+    bind=True,
+    max_retries=0,
+)
+def ingest_websub_push_task(self, channel_id: str, youtube_video_ids: list) -> dict:
+    """Catalog WebSub-pushed video ids off the callback request path.
+
+    The callback verifies the push signature and dispatches this job so the
+    (possibly slow) yt-dlp metadata fetch never blocks the hub's HTTP request.
+    Runs on its own DB session, catalogs only genuinely-new ids (idempotent for
+    the duplicate pushes the hub commonly sends), and enqueues any auto-download
+    candidates exactly as a normal poll would.
+    """
+    db = _get_sync_db()
+    try:
+        result = ingest_pushed_videos(channel_id, youtube_video_ids, db)
+        for video_id in result["auto_download_ids"]:
+            download_video_task.delay(video_id)
+        return {
+            "status": "ok",
+            "cataloged": len(result["cataloged_ids"]),
+            "auto_downloads": len(result["auto_download_ids"]),
+        }
+    except Exception:
+        logger.exception("Error ingesting WebSub push for channel %s", channel_id)
+        db.rollback()
+        return {"status": "error"}
+    finally:
+        db.close()
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.sync_websub_subscriptions_task",
+    bind=True,
+    max_retries=0,
+)
+def sync_websub_subscriptions_task(self) -> dict:
+    """Periodic task: (re)subscribe tracked UC channels to the WebSub hub.
+
+    No-ops when WebSub is disabled (blank callback URL). Otherwise subscribes
+    each tracked channel whose lease is missing or near expiry, renewing before
+    it lapses. Independent of polling, which stays the always-on fallback.
+    """
+    db = _get_sync_db()
+    try:
+        return sync_subscriptions(db)
+    except Exception:
+        logger.exception("Error syncing WebSub subscriptions")
         return {"status": "error"}
     finally:
         db.close()

--- a/app/utils/websub.py
+++ b/app/utils/websub.py
@@ -1,0 +1,107 @@
+"""Durable HMAC secret + push-signature verification for the WebSub subscriber.
+
+WebSub (PubSubHubbub) lets YouTube's hub PUSH new-upload notifications to a
+public callback instead of NullFeed polling each channel's Atom feed. Two places
+share one secret:
+
+  * a subscribe request sends it as ``hub.secret`` so the hub will sign pushes;
+  * every push carries an ``X-Hub-Signature`` HMAC of the raw body keyed by that
+    same secret, which we recompute to authenticate the push before acting on it.
+
+The secret MUST be identical across every worker and survive restarts: a push
+delivered to (and verified by) one worker may have been subscribed by another, so
+a per-process random value would make pushes fail verification on the worker that
+didn't mint the subscription. Exactly like :mod:`app.utils.tickets`, it is read
+from a file persisted under ``settings.config_path``, generated once via an
+atomic create-only hard-link so racing workers converge on a single value.
+"""
+
+import hashlib
+import hmac
+import os
+import secrets
+from pathlib import Path
+
+from app.config import settings
+
+# Filename of the persisted secret under settings.config_path.
+_SECRET_FILENAME = "websub_secret"
+
+# X-Hub-Signature digests we accept, keyed by the algorithm prefix the hub uses
+# (e.g. ``sha1=<hex>`` / ``sha256=<hex>``). Google's pubsubhubbub sends sha1.
+_SUPPORTED_ALGOS = {"sha1": hashlib.sha1, "sha256": hashlib.sha256}
+
+# Cache so the file is read/created at most once per process; the file remains
+# authoritative across workers.
+_persisted_secret: str | None = None
+
+
+def _load_or_create_persisted_secret() -> str:
+    """Read the persisted secret, generating it once if absent.
+
+    Concurrency-safe across workers booting together: a private temp file is
+    written then hard-linked into place, which is atomic and fails if the target
+    already exists. Whoever wins the link returns its own secret; everyone else
+    reads the winner's, so all workers converge on a single value and the target
+    is never observed half-written. Mirrors
+    :func:`app.utils.tickets._load_or_create_persisted_secret`.
+    """
+    path = Path(settings.config_path) / _SECRET_FILENAME
+    try:
+        existing = path.read_text().strip()
+        if existing:
+            return existing
+    except FileNotFoundError:
+        pass
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    candidate = secrets.token_urlsafe(48)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{secrets.token_hex(4)}.tmp")
+    tmp.write_text(candidate)
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    try:
+        os.link(tmp, path)  # atomic create-only claim; raises if path exists
+        return candidate
+    except FileExistsError:
+        return path.read_text().strip()
+    finally:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def websub_secret() -> str:
+    """Return the shared WebSub secret, creating + persisting it on first use."""
+    global _persisted_secret
+    if _persisted_secret is None:
+        _persisted_secret = _load_or_create_persisted_secret()
+    return _persisted_secret
+
+
+def verify_signature(raw_body: bytes, header_value: str | None) -> bool:
+    """Constant-time check of an ``X-Hub-Signature`` against the raw push body.
+
+    The header is ``<algo>=<hexdigest>`` (e.g. ``sha1=...``). Returns ``False``
+    for a missing/malformed header or an unsupported algorithm — so an unsigned
+    or tampered push is rejected — and verifies the HMAC in constant time
+    otherwise. The body must be the EXACT bytes the hub sent (re-encoding it
+    would change the digest), so callers pass ``await request.body()`` verbatim.
+    """
+    if not header_value or "=" not in header_value:
+        return False
+    algo_name, _, sent_hex = header_value.partition("=")
+    algo = _SUPPORTED_ALGOS.get(algo_name.strip().lower())
+    if algo is None or not sent_hex.strip():
+        return False
+    expected = hmac.new(websub_secret().encode("utf-8"), raw_body, algo).hexdigest()
+    return hmac.compare_digest(expected, sent_hex.strip())
+
+
+def _reset_cache() -> None:
+    """Test hook: drop the in-process secret cache (the file stays authoritative)."""
+    global _persisted_secret
+    _persisted_secret = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ import app.api.auth as auth_api
 import app.api.websocket as websocket_api
 import app.services.push_gateway as push_gateway
 import app.services.youtube_import as youtube_import
+import app.utils.websub as websub_util
 from app.database import engine
 from app.main import app
 from app.models import Base
@@ -42,6 +43,7 @@ def _reset_in_memory_state():
     youtube_import._suggestions_cache.clear()
     websocket_api._connections.clear()
     push_gateway._reset_cache()
+    websub_util._reset_cache()
 
 
 @pytest_asyncio.fixture

--- a/tests/test_websub.py
+++ b/tests/test_websub.py
@@ -1,0 +1,632 @@
+"""Tests for the YouTube WebSub (PubSubHubbub) subscriber.
+
+Covered, all without network (httpx mocked) and with WebSub off by default:
+
+* parsing: ``parse_push`` extracts video ids + channel id; ``channel_id_for_topic``.
+* push ingest (``ingest_pushed_videos``, in-memory sqlite): catalogs genuinely-new
+  videos via the normal poll path, is idempotent for duplicate pushes, defers a
+  channel with no initial poll, and never touches the adaptive poll schedule.
+* subscribe lifecycle (``sync_subscriptions`` / ``subscribe_channel``): posts the
+  right hub params for due UC channels only, stamps the lease, and no-ops when
+  disabled.
+* callback router: GET echoes ``hub.challenge`` for a tracked topic (else 404),
+  POST verifies the HMAC (valid -> dispatch + 204, bad/absent -> 404), and the
+  whole router 404s when WebSub is disabled.
+"""
+
+import hashlib
+import hmac
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+import app.services.websub as websub_service
+import app.utils.websub as websub_util
+from app.config import settings
+from app.database import async_session_factory
+from app.models import Base
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.models.video import Video
+from app.services import channel_poller
+from app.services.websub import (
+    channel_id_for_topic,
+    parse_push,
+    subscribe_channel,
+    sync_subscriptions,
+    topic_url,
+)
+from app.utils.time import utcnow_naive
+from app.utils.websub import verify_signature, websub_secret
+from tests.helpers import seed_channel, seed_subscription
+
+_UC_ID = "UCpushchannel00000000000"
+
+# A realistic YouTube WebSub push: one new upload, channel id carried per-entry
+# (as YouTube actually sends it) rather than at the feed level.
+PUSH_BODY = f"""<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns="http://www.w3.org/2005/Atom">
+  <link rel="hub" href="https://pubsubhubbub.appspot.com"/>
+  <link rel="self"
+    href="https://www.youtube.com/xml/feeds/videos.xml?channel_id={_UC_ID}"/>
+  <title>YouTube video feed</title>
+  <updated>2026-06-28T19:05:24+00:00</updated>
+  <entry>
+    <id>yt:video:PUSHVIDEO001</id>
+    <yt:videoId>PUSHVIDEO001</yt:videoId>
+    <yt:channelId>{_UC_ID}</yt:channelId>
+    <title>Pushed Upload</title>
+    <link rel="alternate" href="https://www.youtube.com/watch?v=PUSHVIDEO001"/>
+    <author><name>Push Channel</name></author>
+    <published>2026-06-28T19:00:00+00:00</published>
+    <updated>2026-06-28T19:05:00+00:00</updated>
+  </entry>
+</feed>
+""".encode()
+
+
+# --- pure parsing helpers --------------------------------------------------
+
+
+def test_parse_push_extracts_channel_and_video_ids():
+    parsed = parse_push(PUSH_BODY)
+    assert parsed["channel_id"] == _UC_ID
+    assert parsed["video_ids"] == ["PUSHVIDEO001"]
+
+
+def test_parse_push_prefers_feed_level_channel_id():
+    body = f"""<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns="http://www.w3.org/2005/Atom">
+  <yt:channelId>{_UC_ID}</yt:channelId>
+  <entry>
+    <yt:videoId>AAA00000001</yt:videoId>
+    <title>One</title>
+  </entry>
+  <entry>
+    <yt:videoId>BBB00000002</yt:videoId>
+    <title>Two</title>
+  </entry>
+</feed>
+""".encode()
+    parsed = parse_push(body)
+    assert parsed["channel_id"] == _UC_ID
+    assert parsed["video_ids"] == ["AAA00000001", "BBB00000002"]
+
+
+def test_parse_push_ignores_deletion_tombstone():
+    # A deletion notification carries no <yt:videoId>; nothing to catalog.
+    body = b"""<?xml version='1.0' encoding='UTF-8'?>
+<feed xmlns:at="http://purl.org/atompub/tombstones/1.0"
+      xmlns:yt="http://www.youtube.com/xml/schemas/2015"
+      xmlns="http://www.w3.org/2005/Atom">
+  <at:deleted-entry ref="yt:video:GONE0000001" when="2026-06-28T19:00:00+00:00">
+    <link href="https://www.youtube.com/watch?v=GONE0000001"/>
+  </at:deleted-entry>
+</feed>
+"""
+    parsed = parse_push(body)
+    assert parsed["video_ids"] == []
+
+
+def test_parse_push_unparseable_body_is_empty():
+    parsed = parse_push(b"<<not xml>>")
+    assert parsed == {"channel_id": None, "video_ids": []}
+
+
+def test_channel_id_for_topic_roundtrip_and_garbage():
+    assert channel_id_for_topic(topic_url(_UC_ID)) == _UC_ID
+    assert channel_id_for_topic("https://example.com/feed") is None
+    assert channel_id_for_topic(None) is None
+
+
+def test_verify_signature_sha1_and_sha256(monkeypatch):
+    monkeypatch.setattr(websub_util, "websub_secret", lambda: "secret-xyz")
+    body = b"hello-body"
+    sha1 = "sha1=" + hmac.new(b"secret-xyz", body, hashlib.sha1).hexdigest()
+    sha256 = "sha256=" + hmac.new(b"secret-xyz", body, hashlib.sha256).hexdigest()
+    assert verify_signature(body, sha1) is True
+    assert verify_signature(body, sha256) is True
+    # Wrong secret, tampered body, missing/garbage headers all reject.
+    assert verify_signature(b"tampered", sha1) is False
+    assert verify_signature(body, "sha1=deadbeef") is False
+    assert verify_signature(body, "md5=" + "0" * 32) is False
+    assert verify_signature(body, None) is False
+    assert verify_signature(body, "garbage") is False
+
+
+# --- push ingest (in-memory sqlite) ----------------------------------------
+
+
+def _mem_db_with_channel(*user_ids, initial_poll_done=True, **channel_overrides):
+    """In-memory poller DB with one UC channel + subscribers (FKs off)."""
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine)()
+    channel = Channel(
+        id="ch-1",
+        youtube_channel_id=_UC_ID,
+        name="Push Channel",
+        slug="push-channel",
+        last_checked_at=utcnow_naive() if initial_poll_done else None,
+    )
+    for key, value in channel_overrides.items():
+        setattr(channel, key, value)
+    db.add(channel)
+    for uid in user_ids:
+        db.add(UserSubscription(user_id=uid, channel_id=channel.id))
+    db.commit()
+    return db, channel
+
+
+def test_ingest_catalogs_new_video_and_emits(monkeypatch):
+    db, channel = _mem_db_with_channel("u1")
+    meta_calls = []
+
+    def fake_meta(ids):
+        meta_calls.append(list(ids))
+        return [
+            {"youtube_video_id": v, "title": f"T-{v}", "duration_seconds": 0}
+            for v in ids
+        ]
+
+    monkeypatch.setattr(channel_poller, "fetch_videos_metadata", fake_meta)
+    publish_mock = MagicMock()
+    monkeypatch.setattr(channel_poller, "publish_new_episode", publish_mock)
+    monkeypatch.setattr(channel_poller, "send_to_users", MagicMock())
+
+    result = channel_poller.ingest_pushed_videos("ch-1", ["PUSHVIDEO001"], db)
+
+    assert len(result["cataloged_ids"]) == 1
+    assert meta_calls == [["PUSHVIDEO001"]]
+    rows = db.execute(select(Video.youtube_video_id)).scalars().all()
+    assert rows == ["PUSHVIDEO001"]
+    # new_episode emitted for the (1 subscriber x 1 new video).
+    assert publish_mock.call_count == 1
+    db.close()
+
+
+def test_ingest_is_idempotent_for_duplicate_push(monkeypatch):
+    db, channel = _mem_db_with_channel("u1")
+
+    def fake_meta(ids):
+        return [{"youtube_video_id": v, "title": v, "duration_seconds": 0} for v in ids]
+
+    meta_mock = MagicMock(side_effect=fake_meta)
+    monkeypatch.setattr(channel_poller, "fetch_videos_metadata", meta_mock)
+    publish_mock = MagicMock()
+    monkeypatch.setattr(channel_poller, "publish_new_episode", publish_mock)
+    monkeypatch.setattr(channel_poller, "send_to_users", MagicMock())
+
+    first = channel_poller.ingest_pushed_videos("ch-1", ["PUSHVIDEO001"], db)
+    second = channel_poller.ingest_pushed_videos("ch-1", ["PUSHVIDEO001"], db)
+
+    assert len(first["cataloged_ids"]) == 1
+    assert second["cataloged_ids"] == []
+    # The already-known id does no yt-dlp work the second time, and emits nothing.
+    assert meta_mock.call_count == 1
+    assert publish_mock.call_count == 1
+    rows = (
+        db.execute(select(Video).where(Video.youtube_video_id == "PUSHVIDEO001"))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    db.close()
+
+
+def test_ingest_defers_when_no_initial_poll(monkeypatch):
+    db, channel = _mem_db_with_channel("u1", initial_poll_done=False)
+    meta_mock = MagicMock()
+    monkeypatch.setattr(channel_poller, "fetch_videos_metadata", meta_mock)
+
+    result = channel_poller.ingest_pushed_videos("ch-1", ["PUSHVIDEO001"], db)
+
+    assert result == {"cataloged_ids": [], "auto_download_ids": []}
+    meta_mock.assert_not_called()
+    assert db.execute(select(Video)).scalars().all() == []
+    db.close()
+
+
+def test_ingest_unknown_channel_is_noop(monkeypatch):
+    db, channel = _mem_db_with_channel("u1")
+    meta_mock = MagicMock()
+    monkeypatch.setattr(channel_poller, "fetch_videos_metadata", meta_mock)
+
+    result = channel_poller.ingest_pushed_videos("does-not-exist", ["X"], db)
+
+    assert result == {"cataloged_ids": [], "auto_download_ids": []}
+    meta_mock.assert_not_called()
+    db.close()
+
+
+def test_ingest_leaves_poll_schedule_untouched(monkeypatch):
+    """WebSub is additive: it must not move the RSS poller's adaptive cadence."""
+    next_poll = utcnow_naive() + timedelta(minutes=99)
+    last_checked = utcnow_naive() - timedelta(hours=3)
+    db, channel = _mem_db_with_channel(
+        "u1",
+        next_poll_at=next_poll,
+        poll_interval_minutes=120,
+        last_checked_at=last_checked,
+    )
+
+    monkeypatch.setattr(
+        channel_poller,
+        "fetch_videos_metadata",
+        lambda ids: [
+            {"youtube_video_id": v, "title": v, "duration_seconds": 0} for v in ids
+        ],
+    )
+    monkeypatch.setattr(channel_poller, "publish_new_episode", MagicMock())
+    monkeypatch.setattr(channel_poller, "send_to_users", MagicMock())
+
+    channel_poller.ingest_pushed_videos("ch-1", ["PUSHVIDEO001"], db)
+
+    db.refresh(channel)
+    assert channel.next_poll_at == next_poll
+    assert channel.poll_interval_minutes == 120
+    assert channel.last_checked_at == last_checked
+    db.close()
+
+
+# --- subscribe lifecycle ----------------------------------------------------
+
+
+@pytest.fixture
+def enabled_websub(monkeypatch):
+    """Configure a callback URL so WebSub is enabled for the test."""
+    monkeypatch.setattr(
+        settings, "websub_callback_url", "https://nf.example.com/api/websub/callback"
+    )
+    return settings.websub_callback_url
+
+
+def _sub_mem_db():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)
+
+
+def test_subscribe_channel_posts_expected_hub_params(monkeypatch, enabled_websub):
+    # subscribe_channel binds websub_secret in its own module namespace.
+    monkeypatch.setattr(websub_service, "websub_secret", lambda: "the-secret")
+    captured = {}
+
+    class _Resp:
+        status_code = 202
+
+    def fake_post(url, data=None, timeout=None):
+        captured["url"] = url
+        captured["data"] = data
+        return _Resp()
+
+    monkeypatch.setattr(websub_service.httpx, "post", fake_post)
+
+    channel = Channel(id="c1", youtube_channel_id=_UC_ID, name="n", slug="s")
+    assert subscribe_channel(channel) is True
+    assert captured["url"] == settings.websub_hub_url
+    assert captured["data"]["hub.callback"] == enabled_websub
+    assert captured["data"]["hub.topic"] == topic_url(_UC_ID)
+    assert captured["data"]["hub.mode"] == "subscribe"
+    assert captured["data"]["hub.verify"] == "async"
+    assert captured["data"]["hub.secret"] == "the-secret"
+    assert captured["data"]["hub.lease_seconds"] == str(settings.websub_lease_seconds)
+
+
+def test_subscribe_channel_disabled_is_noop(monkeypatch):
+    monkeypatch.setattr(settings, "websub_callback_url", "")
+    post_mock = MagicMock()
+    monkeypatch.setattr(websub_service.httpx, "post", post_mock)
+    channel = Channel(id="c1", youtube_channel_id=_UC_ID, name="n", slug="s")
+    assert subscribe_channel(channel) is False
+    post_mock.assert_not_called()
+
+
+def test_subscribe_channel_non_2xx_returns_false(monkeypatch, enabled_websub):
+    class _Resp:
+        status_code = 500
+
+    monkeypatch.setattr(websub_service.httpx, "post", lambda *a, **k: _Resp())
+    channel = Channel(id="c1", youtube_channel_id=_UC_ID, name="n", slug="s")
+    assert subscribe_channel(channel) is False
+
+
+def test_sync_subscriptions_disabled_no_ops(monkeypatch):
+    monkeypatch.setattr(settings, "websub_callback_url", "")
+    post_mock = MagicMock()
+    monkeypatch.setattr(websub_service.httpx, "post", post_mock)
+    db = _sub_mem_db()()
+    db.add(Channel(id="c1", youtube_channel_id=_UC_ID, name="n", slug="s"))
+    db.add(UserSubscription(user_id="u1", channel_id="c1"))
+    db.commit()
+
+    result = sync_subscriptions(db)
+
+    assert result == {"status": "disabled", "subscribed": 0}
+    post_mock.assert_not_called()
+    db.close()
+
+
+def test_sync_subscriptions_subscribes_only_due_uc_channels(
+    monkeypatch, enabled_websub
+):
+    posted_topics = []
+
+    class _Resp:
+        status_code = 202
+
+    def fake_post(url, data=None, timeout=None):
+        posted_topics.append(data["hub.topic"])
+        return _Resp()
+
+    monkeypatch.setattr(websub_service.httpx, "post", fake_post)
+
+    session_local = _sub_mem_db()
+    db = session_local()
+    now = utcnow_naive()
+    # Due: never subscribed (NULL lease).
+    db.add(
+        Channel(
+            id="due-null",
+            youtube_channel_id="UCdue0000000000000000a",
+            name="a",
+            slug="a",
+        )
+    )
+    db.add(UserSubscription(user_id="u1", channel_id="due-null"))
+    # Due: lease near expiry (inside the renewal window).
+    db.add(
+        Channel(
+            id="due-soon",
+            youtube_channel_id="UCdue0000000000000000b",
+            name="b",
+            slug="b",
+            websub_expires_at=now + timedelta(hours=1),
+        )
+    )
+    db.add(UserSubscription(user_id="u1", channel_id="due-soon"))
+    # Not due: lease comfortably in the future.
+    db.add(
+        Channel(
+            id="fresh",
+            youtube_channel_id="UCfresh000000000000000c",
+            name="c",
+            slug="c",
+            websub_expires_at=now + timedelta(days=4),
+        )
+    )
+    db.add(UserSubscription(user_id="u1", channel_id="fresh"))
+    # Skipped: non-UC id (feed not addressable).
+    db.add(Channel(id="handle", youtube_channel_id="@handle", name="d", slug="d"))
+    db.add(UserSubscription(user_id="u1", channel_id="handle"))
+    # Skipped: UC but no subscriber (not tracked).
+    db.add(
+        Channel(
+            id="nosub", youtube_channel_id="UCnosub00000000000000e", name="e", slug="e"
+        )
+    )
+    db.commit()
+
+    result = sync_subscriptions(db)
+
+    assert result["status"] == "ok"
+    assert result["subscribed"] == 2
+    assert set(posted_topics) == {
+        topic_url("UCdue0000000000000000a"),
+        topic_url("UCdue0000000000000000b"),
+    }
+    # The two due channels got an optimistic lease stamp; others are unchanged.
+    db2 = session_local()
+    by_id = {c.id: c for c in db2.execute(select(Channel)).scalars().all()}
+    assert by_id["due-null"].websub_expires_at is not None
+    assert by_id["due-soon"].websub_expires_at > now + timedelta(days=1)
+    assert by_id["fresh"].websub_expires_at == now + timedelta(days=4)
+    assert by_id["handle"].websub_expires_at is None
+    db2.close()
+    db.close()
+
+
+def test_sync_subscriptions_failed_post_leaves_lease_due(monkeypatch, enabled_websub):
+    """A hub failure must not stamp a lease, so the channel retries next beat."""
+
+    class _Resp:
+        status_code = 503
+
+    monkeypatch.setattr(websub_service.httpx, "post", lambda *a, **k: _Resp())
+    session_local = _sub_mem_db()
+    db = session_local()
+    db.add(Channel(id="c1", youtube_channel_id=_UC_ID, name="n", slug="s"))
+    db.add(UserSubscription(user_id="u1", channel_id="c1"))
+    db.commit()
+
+    result = sync_subscriptions(db)
+
+    assert result["subscribed"] == 0
+    db2 = session_local()
+    ch = db2.get(Channel, "c1")
+    assert ch.websub_expires_at is None
+    db2.close()
+    db.close()
+
+
+# --- callback router (async client) ----------------------------------------
+
+
+def _sign(body: bytes) -> str:
+    return "sha1=" + hmac.new(websub_secret().encode(), body, hashlib.sha1).hexdigest()
+
+
+@pytest.mark.asyncio
+async def test_callback_get_echoes_challenge_for_tracked_topic(
+    client, make_user, monkeypatch
+):
+    monkeypatch.setattr(
+        settings, "websub_callback_url", "https://nf.example.com/api/websub/callback"
+    )
+    user, _ = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, youtube_channel_id=_UC_ID)
+        await seed_subscription(db, user["id"], channel.id)
+
+    resp = await client.get(
+        "/api/websub/callback",
+        params={
+            "hub.mode": "subscribe",
+            "hub.topic": topic_url(_UC_ID),
+            "hub.challenge": "challenge-token-123",
+            "hub.lease_seconds": "432000",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert resp.text == "challenge-token-123"
+    assert resp.headers["content-type"].startswith("text/plain")
+
+
+@pytest.mark.asyncio
+async def test_callback_get_404_for_untracked_topic(client, make_user, monkeypatch):
+    monkeypatch.setattr(
+        settings, "websub_callback_url", "https://nf.example.com/api/websub/callback"
+    )
+    await make_user()
+    resp = await client.get(
+        "/api/websub/callback",
+        params={
+            "hub.mode": "subscribe",
+            "hub.topic": topic_url("UCnottracked0000000000"),
+            "hub.challenge": "x",
+        },
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_callback_get_404_when_disabled(client, make_user, monkeypatch):
+    monkeypatch.setattr(settings, "websub_callback_url", "")
+    user, _ = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, youtube_channel_id=_UC_ID)
+        await seed_subscription(db, user["id"], channel.id)
+
+    resp = await client.get(
+        "/api/websub/callback",
+        params={
+            "hub.mode": "subscribe",
+            "hub.topic": topic_url(_UC_ID),
+            "hub.challenge": "x",
+        },
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_callback_post_valid_signature_dispatches_ingest(
+    client, make_user, monkeypatch
+):
+    monkeypatch.setattr(
+        settings, "websub_callback_url", "https://nf.example.com/api/websub/callback"
+    )
+    user, _ = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, youtube_channel_id=_UC_ID)
+        await seed_subscription(db, user["id"], channel.id)
+        channel_id = channel.id
+
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.websub.ingest_websub_push_task.delay", delay_mock)
+
+    resp = await client.post(
+        "/api/websub/callback",
+        content=PUSH_BODY,
+        headers={"X-Hub-Signature": _sign(PUSH_BODY)},
+    )
+
+    assert resp.status_code == 204
+    delay_mock.assert_called_once_with(channel_id, ["PUSHVIDEO001"])
+
+
+@pytest.mark.asyncio
+async def test_callback_post_bad_signature_rejected(client, make_user, monkeypatch):
+    monkeypatch.setattr(
+        settings, "websub_callback_url", "https://nf.example.com/api/websub/callback"
+    )
+    user, _ = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db, youtube_channel_id=_UC_ID)
+        await seed_subscription(db, user["id"], channel.id)
+
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.websub.ingest_websub_push_task.delay", delay_mock)
+
+    resp = await client.post(
+        "/api/websub/callback",
+        content=PUSH_BODY,
+        headers={"X-Hub-Signature": "sha1=deadbeef"},
+    )
+
+    assert resp.status_code == 404
+    delay_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_callback_post_missing_signature_rejected(client, make_user, monkeypatch):
+    monkeypatch.setattr(
+        settings, "websub_callback_url", "https://nf.example.com/api/websub/callback"
+    )
+    await make_user()
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.websub.ingest_websub_push_task.delay", delay_mock)
+
+    resp = await client.post("/api/websub/callback", content=PUSH_BODY)
+
+    assert resp.status_code == 404
+    delay_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_callback_post_untracked_channel_accepts_without_dispatch(
+    client, make_user, monkeypatch
+):
+    """A signed push for a channel we don't track is accepted (204) but ignored."""
+    monkeypatch.setattr(
+        settings, "websub_callback_url", "https://nf.example.com/api/websub/callback"
+    )
+    await make_user()  # no channel/subscription seeded
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.websub.ingest_websub_push_task.delay", delay_mock)
+
+    resp = await client.post(
+        "/api/websub/callback",
+        content=PUSH_BODY,
+        headers={"X-Hub-Signature": _sign(PUSH_BODY)},
+    )
+
+    assert resp.status_code == 204
+    delay_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_callback_post_404_when_disabled(client, make_user, monkeypatch):
+    monkeypatch.setattr(settings, "websub_callback_url", "")
+    await make_user()
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.websub.ingest_websub_push_task.delay", delay_mock)
+
+    resp = await client.post(
+        "/api/websub/callback",
+        content=PUSH_BODY,
+        headers={"X-Hub-Signature": _sign(PUSH_BODY)},
+    )
+
+    assert resp.status_code == 404
+    delay_mock.assert_not_called()


### PR DESCRIPTION
Near-real-time new-upload discovery via YouTube WebSub/PubSubHubbub (roadmap LATER tier, #7 / issue #14). **Config-gated + additive**: fully disabled unless `NULLFEED_WEBSUB_CALLBACK_URL` is set; the existing RSS + adaptive polling stays the fallback (and the safety net for missed/late/duplicate pushes or NAT'd hosts).

## Config (default OFF)
`NULLFEED_WEBSUB_CALLBACK_URL` ("" = disabled), `websub_hub_url` (pubsubhubbub.appspot.com), `websub_lease_seconds` (5d). HMAC secret auto-generated + persisted under `config_path` (atomic hard-link, like the ticket secret) — used as `hub.secret` and to verify pushes.

## Callback (`app/api/websub.py`, unauthenticated)
- `GET /api/websub/callback` — echoes `hub.challenge` (text/plain 200) only for a `hub.topic` mapping to a tracked channel; else 404. 404s when disabled.
- `POST /api/websub/callback` — recomputes the `X-Hub-Signature` HMAC over the raw body (sha1/sha256, constant-time); bad/absent → 404 (no reveal); valid → parse Atom, dispatch a Celery ingest, return 204 fast.

## Ingest (reuses the poller, no schedule side-effects)
Extracted `channel_poller._catalog_videos`; `ingest_pushed_videos` filters to genuinely-new ids (idempotent), fetches metadata only for those, catalogs via the shared path (emits `new_episode` + push), with **`update_schedule=False`** so RSS `last_checked_at`/`next_poll_at`/validators are never touched.

## Subscribe / renew
`channels.websub_expires_at` (migration 012). A beat task subscribes tracked UC channels (`hub.mode=subscribe`, `verify=async`, secret, lease) and renews in the last 20% of the lease; failures leave the lease unstamped to retry. Beat entry only registered when a callback URL is set; task no-ops when disabled.

## Verification (local)
- `pytest -q` → **264 passed** (+25: parse, topic→channel, sig sha1/sha256, ingest catalog+idempotency+schedule-untouched, subscribe params/lease/disabled, callback GET/POST/disabled). `alembic` up/down clean · `ruff` + `mypy` clean.

To operate: set `NULLFEED_WEBSUB_CALLBACK_URL` to a public https URL routing to `/api/websub/callback` (e.g. via a Cloudflare Tunnel) + run beat/worker. Disabled until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXMKM1rDWn8wNh93MMUtxY