### PR TITLE
feat(videos): instant-start playback via progressive source proxy

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -25,6 +25,11 @@ from app.schemas.video import (
     VideoProgress,
     VideoSearchPage,
 )
+from app.services.instant_stream import (
+    InstantStreamError,
+    resolve_progressive_url,
+    stream_proxy,
+)
 from app.services.media_server import build_media_response
 from app.services.progress_broadcaster import publish_progress_updated
 from app.services.storage import check_and_delete_orphan
@@ -485,6 +490,51 @@ async def stream_video(
         raise HTTPException(status_code=404, detail="Video file missing from disk")
 
     return build_media_response(file_path, range_header)
+
+
+@router.get("/{video_id}/instant-stream")
+async def instant_stream(
+    video_id: str,
+    ticket: str | None = None,
+    token: str | None = None,
+    x_user_token: str | None = Header(None),
+    db: AsyncSession = Depends(get_db),
+    range_header: str | None = Header(None, alias="Range"),
+) -> Response:
+    """Stream something playable *right now* for a not-yet-downloaded video (#85).
+
+    Removes the cold-press wait: instead of generating and waiting on a whole
+    preview file, the backend resolves a progressive source URL and proxies it,
+    so playback starts as the first bytes arrive (~1-2s). The HQ download and
+    the seamless in-player swap are unchanged and handled separately.
+
+    If a full HQ file already exists we serve that directly — strictly better,
+    and it avoids a needless upstream round-trip; otherwise we proxy the source.
+    """
+    await _authorize_stream(video_id, ticket, token, x_user_token, db)
+
+    result = await db.execute(select(Video).where(Video.id == video_id))
+    video = result.scalar_one_or_none()
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    # Defensive fast path: a client may hit this for a video that already
+    # finished downloading; serve the local file rather than proxying the source.
+    if video.status == "COMPLETE" and video.file_path:
+        file_path = video.file_path
+        if not os.path.isabs(file_path):
+            file_path = os.path.join(settings.media_path, file_path)
+        if os.path.exists(file_path):
+            return build_media_response(file_path, range_header)
+
+    try:
+        url = await asyncio.to_thread(resolve_progressive_url, video.youtube_video_id)
+        return await stream_proxy(url, range_header)
+    except InstantStreamError as exc:
+        logger.warning("instant-stream resolve/proxy failed for %s: %s", video_id, exc)
+        raise HTTPException(
+            status_code=502, detail="Could not start instant stream"
+        ) from exc
 
 
 @router.put("/{video_id}/progress")

--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -1,0 +1,196 @@
+"""Instant-start playback by reverse-proxying a progressive source stream.
+
+A cold press on a video nobody has downloaded used to wait for the backend to
+download a whole 360p preview file before the first frame. This module removes
+that wait: it resolves a *progressive* (single-file, muxed audio+video) source
+URL with yt-dlp and streams those bytes straight through the backend to the
+client, forwarding Range requests. Playback starts as soon as the first bytes
+arrive (~1-2s, dominated by the yt-dlp resolve), with no file written to disk.
+
+Why proxy instead of redirecting the client to the source URL: the signed
+source URLs are bound to the *server's* IP, so a 302 to the device gets 403s.
+Fetching server-side keeps the URL valid; the backend is a byte pass-through
+(bandwidth, no transcode).
+
+The HQ download + seamless in-player swap is unchanged and orthogonal: this
+just makes the instant tier instant. Resolved URLs are cached briefly (they
+carry a multi-hour ``expire``), so repeat presses skip the resolve entirely.
+"""
+
+import logging
+import subprocess
+import threading
+import time
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+# Progressive (muxed) selectors only — a single file AVPlayer / video_player can
+# play without a merge step. Prefer H.264 + AAC for native decode, then any
+# progressive mp4, then itag 18 (the canonical 360p muxed format), then any
+# format that carries both audio and video.
+_PROGRESSIVE_FORMAT = (
+    "best[vcodec^=avc1][acodec^=mp4a]"
+    "/best[ext=mp4][acodec!=none][vcodec!=none]"
+    "/18"
+    "/best[acodec!=none][vcodec!=none]"
+)
+
+# yt-dlp resolve timeout. Resolve is a metadata/extraction round-trip, not a
+# download, so it should be quick; keep it tight so a wedged extract surfaces as
+# a 502 fast instead of hanging the player on a spinner.
+_RESOLVE_TIMEOUT_SECONDS = 30
+
+# Fallback cache TTL when the source URL has no parseable ``expire``. Source
+# URLs typically last ~6h; we re-resolve well before that.
+_DEFAULT_TTL_SECONDS = 3600
+
+# Re-resolve this many seconds before the URL's own expiry so we never hand a
+# client a URL that dies mid-stream.
+_EXPIRY_SAFETY_SECONDS = 300
+
+_UPSTREAM_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+# Response headers worth forwarding from the source so the client gets correct
+# length/range/type metadata for seeking.
+_FORWARDED_HEADERS = ("content-length", "content-range", "content-type")
+
+# video_id -> (url, expiry_epoch). Per-process; each worker resolves once and
+# reuses. Cleared between tests via conftest's reset fixture.
+_resolve_cache: dict[str, tuple[str, float]] = {}
+_cache_lock = threading.Lock()
+
+
+class InstantStreamError(Exception):
+    """Raised when a progressive source URL cannot be resolved."""
+
+
+def _ytdlp_get_url(youtube_video_id: str) -> str:
+    """Resolve a direct progressive media URL with ``yt-dlp -g`` (blocking).
+
+    Runs in a worker thread (see :func:`resolve_progressive_url`). Raises
+    :class:`InstantStreamError` on any failure so the caller can map it to 502.
+    """
+    url = f"https://www.youtube.com/watch?v={youtube_video_id}"
+    cmd = [
+        "yt-dlp",
+        "--format",
+        _PROGRESSIVE_FORMAT,
+        "--get-url",
+        "--no-playlist",
+        "--no-warnings",
+        url,
+    ]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=_RESOLVE_TIMEOUT_SECONDS
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise InstantStreamError(f"Resolve timed out for {youtube_video_id}") from exc
+
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "").strip().splitlines()[-1:]
+        detail = tail[0] if tail else "unknown error"
+        raise InstantStreamError(
+            f"Resolve failed for {youtube_video_id}: {detail[:300]}"
+        )
+
+    # -g prints one URL per selected stream; a progressive format yields exactly
+    # one. Take the first non-empty line defensively.
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if line:
+            return line
+    raise InstantStreamError(f"Resolve returned no URL for {youtube_video_id}")
+
+
+def _compute_expiry(url: str, now: float) -> float:
+    """Cache-until epoch for a resolved URL, honouring its own ``expire`` param."""
+    cap = now + _DEFAULT_TTL_SECONDS
+    try:
+        expire = parse_qs(urlparse(url).query).get("expire", [None])[0]
+        if expire is not None:
+            return min(cap, float(expire) - _EXPIRY_SAFETY_SECONDS)
+    except (ValueError, TypeError):
+        pass
+    return cap
+
+
+def resolve_progressive_url(youtube_video_id: str) -> str:
+    """Return a cached or freshly resolved progressive source URL (blocking).
+
+    Call via ``asyncio.to_thread`` from async code — it spawns yt-dlp. Raises
+    :class:`InstantStreamError` if resolution fails.
+    """
+    now = time.time()
+    with _cache_lock:
+        cached = _resolve_cache.get(youtube_video_id)
+        if cached is not None and cached[1] > now:
+            return cached[0]
+
+    url = _ytdlp_get_url(youtube_video_id)
+
+    with _cache_lock:
+        _resolve_cache[youtube_video_id] = (url, _compute_expiry(url, now))
+    return url
+
+
+def _make_client() -> httpx.AsyncClient:
+    """Build the AsyncClient used to fetch the source.
+
+    Factored out so tests can inject an ``httpx.MockTransport``. Read timeout is
+    disabled (a stream stays open for the whole playback), while connect/write
+    stay bounded so a dead source fails fast.
+    """
+    timeout = httpx.Timeout(connect=10.0, read=None, write=10.0, pool=10.0)
+    return httpx.AsyncClient(follow_redirects=True, timeout=timeout)
+
+
+async def stream_proxy(url: str, range_header: str | None) -> StreamingResponse:
+    """Reverse-proxy ``url`` to the client, forwarding Range and mirroring status.
+
+    The source's status (200/206), Content-Length, Content-Range and
+    Content-Type are passed through so the client's player can seek normally.
+    The client and upstream response are closed when the body is fully streamed
+    (or the client disconnects and the generator is torn down).
+    """
+    req_headers = {"User-Agent": _UPSTREAM_USER_AGENT}
+    if range_header:
+        req_headers["Range"] = range_header
+
+    client = _make_client()
+    try:
+        request = client.build_request("GET", url, headers=req_headers)
+        upstream = await client.send(request, stream=True)
+    except httpx.HTTPError as exc:
+        await client.aclose()
+        raise InstantStreamError(f"Upstream fetch failed: {exc}") from exc
+
+    out_headers = {
+        key: upstream.headers[key]
+        for key in _FORWARDED_HEADERS
+        if key in upstream.headers
+    }
+    out_headers["Accept-Ranges"] = "bytes"
+    media_type = upstream.headers.get("content-type", "video/mp4")
+
+    async def body():
+        try:
+            async for chunk in upstream.aiter_raw():
+                yield chunk
+        finally:
+            await upstream.aclose()
+            await client.aclose()
+
+    return StreamingResponse(
+        body(),
+        status_code=upstream.status_code,
+        headers=out_headers,
+        media_type=media_type,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from httpx import ASGITransport, AsyncClient
 
 import app.api.auth as auth_api
 import app.api.websocket as websocket_api
+import app.services.instant_stream as instant_stream
 import app.services.push_gateway as push_gateway
 import app.services.youtube_import as youtube_import
 import app.utils.websub as websub_util
@@ -41,6 +42,7 @@ def _reset_in_memory_state():
     auth_api._pin_throttle.clear()
     youtube_import._resolve_cache.clear()
     youtube_import._suggestions_cache.clear()
+    instant_stream._resolve_cache.clear()
     websocket_api._connections.clear()
     push_gateway._reset_cache()
     websub_util._reset_cache()

--- a/tests/test_instant_stream.py
+++ b/tests/test_instant_stream.py
@@ -1,0 +1,173 @@
+"""Instant-start playback: progressive-URL resolve cache + reverse proxy (#85)."""
+
+import os
+
+import httpx
+import pytest
+
+import app.api.videos as videos_api
+import app.services.instant_stream as instant_stream
+from app.config import settings
+from app.database import async_session_factory
+from app.services.instant_stream import InstantStreamError
+from tests.helpers import seed_channel, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+def _mock_client_factory(body: bytes):
+    """An httpx.AsyncClient whose MockTransport serves ``body`` with Range support.
+
+    The body is returned as an async byte stream (not buffered ``content=``) so
+    the response is a genuine stream — exactly what the proxy's ``aiter_raw``
+    consumes against a real transport.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        rng = request.headers.get("range")
+        if rng and rng.startswith("bytes="):
+            spec = rng[len("bytes=") :].split(",")[0]
+            start_s, _, end_s = spec.partition("-")
+            start = int(start_s)
+            end = int(end_s) if end_s else len(body) - 1
+            chunk = body[start : end + 1]
+
+            async def range_stream():
+                yield chunk
+
+            return httpx.Response(
+                206,
+                headers={
+                    "Content-Range": f"bytes {start}-{end}/{len(body)}",
+                    "Content-Length": str(len(chunk)),
+                    "Content-Type": "video/mp4",
+                },
+                content=range_stream(),
+            )
+
+        async def full_stream():
+            yield body
+
+        return httpx.Response(
+            200,
+            headers={"Content-Length": str(len(body)), "Content-Type": "video/mp4"},
+            content=full_stream(),
+        )
+
+    return lambda: httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# --- resolve cache --------------------------------------------------------
+
+
+async def test_resolve_caches_url(monkeypatch):
+    calls = []
+
+    def fake_get(vid: str) -> str:
+        calls.append(vid)
+        return "https://upstream.test/v.mp4?expire=9999999999"
+
+    monkeypatch.setattr(instant_stream, "_ytdlp_get_url", fake_get)
+
+    first = instant_stream.resolve_progressive_url("vid-1")
+    second = instant_stream.resolve_progressive_url("vid-1")
+
+    assert first == second
+    assert calls == ["vid-1"]  # resolved once, second call hit the cache
+
+
+async def test_resolve_failure_raises(monkeypatch):
+    def boom(vid: str) -> str:
+        raise InstantStreamError("nope")
+
+    monkeypatch.setattr(instant_stream, "_ytdlp_get_url", boom)
+    with pytest.raises(InstantStreamError):
+        instant_stream.resolve_progressive_url("vid-2")
+
+
+# --- endpoint -------------------------------------------------------------
+
+
+async def test_instant_stream_requires_auth(client):
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream")
+    assert resp.status_code == 401
+
+
+async def test_instant_stream_unknown_video_404(client, make_user):
+    _, headers = await make_user()
+    resp = await client.get(
+        "/api/videos/does-not-exist/instant-stream", headers=headers
+    )
+    assert resp.status_code == 404
+
+
+async def test_instant_stream_proxies_source(client, make_user, monkeypatch):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    body = b"".join(bytes([i % 256]) for i in range(1000))
+    monkeypatch.setattr(
+        videos_api, "resolve_progressive_url", lambda vid: "https://upstream.test/v.mp4"
+    )
+    monkeypatch.setattr(instant_stream, "_make_client", _mock_client_factory(body))
+
+    # Full stream.
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
+    assert resp.status_code == 200
+    assert resp.content == body
+
+    # Range request is forwarded and the 206 + Content-Range pass through.
+    resp = await client.get(
+        f"/api/videos/{video.id}/instant-stream",
+        headers={**headers, "Range": "bytes=0-99"},
+    )
+    assert resp.status_code == 206
+    assert resp.headers["Content-Range"] == "bytes 0-99/1000"
+    assert resp.content == body[:100]
+
+
+async def test_instant_stream_resolve_failure_502(client, make_user, monkeypatch):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    def boom(vid: str) -> str:
+        raise InstantStreamError("resolve failed")
+
+    monkeypatch.setattr(videos_api, "resolve_progressive_url", boom)
+
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
+    assert resp.status_code == 502
+
+
+async def test_instant_stream_serves_complete_file_without_resolving(
+    client, make_user, monkeypatch
+):
+    """A COMPLETE video is served from disk; the source is never resolved."""
+    user, headers = await make_user()
+
+    os.makedirs(settings.media_path, exist_ok=True)
+    rel_path = "instant_complete.mp4"
+    body = b"local-hq-bytes"
+    with open(os.path.join(settings.media_path, rel_path), "wb") as f:
+        f.write(body)
+
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE", file_path=rel_path)
+
+    def fail(vid: str) -> str:
+        raise AssertionError("resolve must not be called for a COMPLETE video")
+
+    monkeypatch.setattr(videos_api, "resolve_progressive_url", fail)
+
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
+    assert resp.status_code == 200
+    assert resp.content == body


### PR DESCRIPTION
## What

Cold-pressing a not-yet-downloaded video used to **wait for the backend to download a whole 360p preview file** before the first frame. This adds instant-start playback.

New endpoint **`GET /api/videos/{id}/instant-stream`**:
1. Resolves a **progressive** (single-file, muxed audio+video) source URL with `yt-dlp -g`.
2. **Reverse-proxies** those bytes to the client with HTTP Range pass-through.

Playback starts as the first bytes arrive (~1–2s, dominated by the resolve), with **nothing written to disk**.

## Why proxy instead of redirect

Signed source URLs are bound to the **server's** IP — a 302 to the device would 403. Fetching server-side keeps the URL valid; the backend is a pure byte pass-through (bandwidth, **no transcode**).

## Details

- `app/services/instant_stream.py`: `yt-dlp -g` resolve with a short TTL cache (honours the URL's own `expire` param) + an httpx streaming reverse proxy that mirrors upstream status / `Content-Range` / `Content-Length` / `Content-Type`.
- The endpoint serves a **COMPLETE local file directly** when present (strictly better, avoids a needless upstream round-trip); otherwise it proxies the source.
- The HQ download and the **seamless in-player quality swap are unchanged** — this only makes the instant tier instant.

## Tests

`tests/test_instant_stream.py` covers: resolve cache (resolves once), auth 401, unknown-video 404, full + Range proxy round-trip (via `httpx.MockTransport`), resolve-failure → 502, and the COMPLETE-local-file fast path. Full suite: **271 passed**.

## Follow-ups (same feature set)

- Flutter + tvOS switch their cold-press path from "request preview & wait" to this endpoint.
- Cache-vs-library model (play caches HQ as an evictable cache ref, not a library download).
- Predictive preview pre-warming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)