### PR TITLE
feat(refs): model downloads as a cache, not a collection

### DIFF
--- a/alembic/versions/013_user_video_refs_kind.py
+++ b/alembic/versions/013_user_video_refs_kind.py
@@ -1,0 +1,34 @@
+"""Distinguish library vs cache refs: user_video_refs.kind
+
+Revision ID: 013_user_video_refs_kind
+Revises: 012_channel_websub_expires_at
+Create Date: 2026-06-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "013_user_video_refs_kind"
+down_revision: Union[str, None] = "012_channel_websub_expires_at"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Existing refs were all created by explicit intent (download/subscription),
+    # so they backfill as LIBRARY. New play-cache refs are written as CACHE.
+    op.add_column(
+        "user_video_refs",
+        sa.Column(
+            "kind",
+            sa.String(length=20),
+            nullable=False,
+            server_default="LIBRARY",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_video_refs", "kind")

--- a/app/api/feed.py
+++ b/app/api/feed.py
@@ -7,7 +7,7 @@ from app.database import get_db
 from app.models.channel import Channel
 from app.models.subscription import UserSubscription
 from app.models.user import User
-from app.models.user_video_ref import UserVideoRef
+from app.models.user_video_ref import REF_KIND_LIBRARY, UserVideoRef
 from app.models.video import Video
 from app.schemas.channel import ChannelOut
 from app.schemas.feed import FeedItem, HomeFeed
@@ -110,6 +110,7 @@ async def _new_episodes_items(
         .where(
             UserVideoRef.user_id == user.id,
             UserVideoRef.removed_at.is_(None),
+            UserVideoRef.kind == REF_KIND_LIBRARY,
             UserVideoRef.is_watched == False,  # noqa: E712
             Video.channel_id.in_(subscribed_ids),
             Video.status == "COMPLETE",
@@ -150,6 +151,7 @@ async def _recently_added_items(
         .where(
             UserVideoRef.user_id == user.id,
             UserVideoRef.removed_at.is_(None),
+            UserVideoRef.kind == REF_KIND_LIBRARY,
             Video.status == "COMPLETE",
         )
         .order_by(

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -15,7 +15,11 @@ from app.config import settings
 from app.database import get_db
 from app.models.channel import Channel
 from app.models.user import User
-from app.models.user_video_ref import UserVideoRef
+from app.models.user_video_ref import (
+    REF_KIND_CACHE,
+    REF_KIND_LIBRARY,
+    UserVideoRef,
+)
 from app.models.video import Video
 from app.schemas.ticket import AccessTicket
 from app.schemas.video import (
@@ -44,22 +48,41 @@ router = APIRouter(prefix="/api/videos", tags=["videos"])
 logger = logging.getLogger(__name__)
 
 
-async def _ensure_active_ref(db: AsyncSession, user_id: str, video_id: str) -> None:
+async def _ensure_active_ref(
+    db: AsyncSession,
+    user_id: str,
+    video_id: str,
+    kind: str = REF_KIND_LIBRARY,
+) -> None:
     """Register (or reactivate) the caller's claim on a video.
 
     The set of active (``removed_at IS NULL``) UserVideoRefs is the download's
     reference count, so any endpoint that expresses "I want this video" must
     leave the caller holding an active ref. Idempotent: creates the ref if
-    missing, clears ``removed_at`` if it was soft-deleted, and leaves an
-    already-active ref untouched.
+    missing and clears ``removed_at`` if it was soft-deleted.
+
+    ``kind`` records *why* the user holds it. A LIBRARY claim (explicit download)
+    **promotes** an existing CACHE ref to LIBRARY, so a video you cold-watched
+    and then chose to download joins your collection. A CACHE claim (implicit,
+    from playing) never *downgrades* an existing LIBRARY ref — it only sets the
+    kind when creating the row.
     """
     now = utcnow_naive()
+    set_: dict = {"removed_at": None}
+    if kind == REF_KIND_LIBRARY:
+        set_["kind"] = REF_KIND_LIBRARY
     stmt = (
         sqlite_insert(UserVideoRef)
-        .values(user_id=user_id, video_id=video_id, added_at=now, removed_at=None)
+        .values(
+            user_id=user_id,
+            video_id=video_id,
+            added_at=now,
+            removed_at=None,
+            kind=kind,
+        )
         .on_conflict_do_update(
             index_elements=["user_id", "video_id"],
-            set_={"removed_at": None},
+            set_=set_,
         )
     )
     await db.execute(stmt)
@@ -85,9 +108,12 @@ async def search_videos(
     """
     sort_key = func.coalesce(Video.uploaded_at, Video.created_at)
 
+    # The library grid is the user's *collection* — LIBRARY refs only. Videos
+    # held merely as a play cache never appear here.
     filters = [
         UserVideoRef.user_id == user.id,
         UserVideoRef.removed_at.is_(None),
+        UserVideoRef.kind == REF_KIND_LIBRARY,
     ]
     if q and q.strip():
         pattern = f"%{escape_like(q.strip())}%"
@@ -182,6 +208,10 @@ async def get_active_downloads(
         .where(
             UserVideoRef.user_id == user.id,
             UserVideoRef.removed_at.is_(None),
+            # Cache downloads are silent — the Downloads tab tracks the user's
+            # collection (LIBRARY) only; a cold-press's background HQ fetch shows
+            # up in the player (preview->HQ swap), not here.
+            UserVideoRef.kind == REF_KIND_LIBRARY,
             or_(
                 Video.status.in_(["PENDING", "DOWNLOADING"]),
                 # Include recently completed videos for the "done" transition
@@ -288,6 +318,41 @@ async def trigger_download(
     download_video_task.delay(video_id, user.id, quality=quality)
 
     return {"detail": "Download enqueued", "video_id": video_id}
+
+
+@router.post("/{video_id}/cache")
+async def cache_video(
+    video_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Cache a video the user is about to watch (#86).
+
+    Called when a client starts instant playback of a not-yet-downloaded video:
+    it records an evictable CACHE claim and, if nothing is downloading it yet,
+    enqueues the HQ download so the player can swap preview -> HQ. Idempotent and
+    best-effort — unlike ``/download`` it never 409s, because caching is implicit
+    (the user pressed play, not "download"). A CACHE claim never downgrades an
+    existing LIBRARY ref, and the download is hidden from the Downloads tab.
+    """
+    result = await db.execute(select(Video).where(Video.id == video_id))
+    video = result.scalar_one_or_none()
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    await _ensure_active_ref(db, user.id, video_id, kind=REF_KIND_CACHE)
+
+    # Already downloaded or in flight (incl. a teardown settling): the player
+    # gets HQ from the existing file/download, so there is nothing to enqueue.
+    if video.status in ("PENDING", "DOWNLOADING", "COMPLETE", "CANCELLING"):
+        return {"status": video.status, "video_id": video_id}
+
+    # CATALOGED or FAILED: kick off the HQ download that backs the cache.
+    video.status = "PENDING"
+    await db.commit()
+    download_video_task.delay(video_id, user.id)
+
+    return {"status": "PENDING", "video_id": video_id}
 
 
 @router.post("/{video_id}/cancel")
@@ -518,6 +583,11 @@ async def update_progress(
         added_at=now,
         removed_at=None,
         last_watched_at=now,
+        # Watching a video the user hasn't downloaded creates an evictable CACHE
+        # ref, never a library entry — playing must not silently build a
+        # collection. The conflict path below leaves ``kind`` untouched, so an
+        # existing LIBRARY ref is never downgraded by watching it.
+        kind=REF_KIND_CACHE,
     )
     # UPSERT: update progress and reactivate soft-deleted refs in one statement.
     stmt = stmt.on_conflict_do_update(

--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,16 @@ class Settings(BaseSettings):
     # Reclaiming disk is not urgent, so a few hours' latency is plenty.
     retention_interval_hours: int = 6
 
+    # Play cache (downloads-as-cache, #86)
+    # A cold press on a not-yet-downloaded video records an evictable CACHE ref
+    # (distinct from the user's library) and may back it with an HQ download. The
+    # cache reaper keeps the most-recently-watched cache_retention_count videos
+    # per user — watch-later-queued videos are pinned and never evicted — and
+    # reclaims the rest. Runs every cache_retention_interval_hours. A negative
+    # count disables eviction; 0 keeps no cache.
+    cache_retention_count: int = 200
+    cache_retention_interval_hours: int = 6
+
     # Auth sessions
     # A session is rejected once it is older than the absolute TTL (since
     # creation) or has been idle longer than the idle TTL (since last activity).

--- a/app/models/user_video_ref.py
+++ b/app/models/user_video_ref.py
@@ -6,6 +6,11 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.models import Base
 from app.utils.time import utcnow_naive
 
+# Ref "kind": how the user came to hold this video, which decides whether it
+# counts as part of their library or is just an evictable play cache.
+REF_KIND_LIBRARY = "LIBRARY"  # explicit intent: download, subscription, watch
+REF_KIND_CACHE = "CACHE"  # implicit: created by playing a not-downloaded video
+
 
 class UserVideoRef(Base):
     __tablename__ = "user_video_refs"
@@ -24,6 +29,16 @@ class UserVideoRef(Base):
     added_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive)
     removed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_watched_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # See REF_KIND_*. LIBRARY refs are the user's collection (shown in the
+    # library/Downloads, governed by per-subscription retention); CACHE refs are
+    # created by playing a not-yet-downloaded video and are evicted by the cache
+    # reaper (LRU), so playing never silently builds a collection.
+    kind: Mapped[str] = mapped_column(
+        String(20),
+        default=REF_KIND_LIBRARY,
+        server_default=REF_KIND_LIBRARY,
+        nullable=False,
+    )
 
     user = relationship("User", back_populates="video_refs")
     video = relationship("Video", back_populates="user_refs")

--- a/app/services/cache_retention.py
+++ b/app/services/cache_retention.py
@@ -1,0 +1,128 @@
+"""Evict the play cache (CACHE-kind UserVideoRefs) by LRU.
+
+Playing a not-yet-downloaded video records a CACHE ref and may back it with an
+HQ download (see ``POST /api/videos/{id}/cache``). Those refs are a cache, not a
+collection, so this periodic sweep bounds how many a user accumulates: it keeps
+the most-recently-watched ``cache_retention_count`` per user and soft-removes the
+rest, then reuses the shared orphan cleanup
+(:func:`app.services.storage.check_and_delete_orphan_sync`) to reclaim files no
+remaining active ref still wants.
+
+Two things are never evicted here: LIBRARY refs (the collection — governed by
+per-subscription retention instead) and any cache video the user has put in their
+watch-later queue ("want to watch later" is intent to keep, so queued videos are
+pinned and don't count toward the budget).
+
+Like the other reapers it does no Celery I/O so it stays unit-testable; the
+scheduling lives in the task wrapper.
+"""
+
+import logging
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session as DBSession
+
+from app.config import settings
+from app.models.user_queue import UserQueue
+from app.models.user_video_ref import REF_KIND_CACHE, UserVideoRef
+from app.services.storage import check_and_delete_orphan_sync
+from app.utils.time import utcnow_naive
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_refs_to_drop(db: DBSession, user_id: str, keep: int) -> list[UserVideoRef]:
+    """Return the user's CACHE refs to soft-remove: those beyond the newest
+    ``keep``, excluding any video pinned by the watch-later queue.
+
+    A negative ``keep`` disables eviction (returns nothing); ``keep == 0`` drops
+    every non-pinned cache ref.
+    """
+    if keep < 0:
+        return []
+
+    refs = (
+        db.execute(
+            select(UserVideoRef)
+            .where(
+                UserVideoRef.user_id == user_id,
+                UserVideoRef.removed_at.is_(None),
+                UserVideoRef.kind == REF_KIND_CACHE,
+            )
+            # Most-recently-watched first; never-watched cache (last_watched_at
+            # NULL) sorts last, with added_at as a stable tiebreaker.
+            .order_by(
+                UserVideoRef.last_watched_at.desc().nullslast(),
+                UserVideoRef.added_at.desc(),
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    queued = set(
+        db.execute(select(UserQueue.video_id).where(UserQueue.user_id == user_id))
+        .scalars()
+        .all()
+    )
+
+    # Pinned (queued) videos are never dropped and don't consume the budget.
+    non_queued = [ref for ref in refs if ref.video_id not in queued]
+    return non_queued[keep:]
+
+
+def enforce_cache_retention(db: DBSession, now: datetime | None = None) -> dict:
+    """Evict stale play-cache refs across all users. Returns a summary dict.
+
+    Soft-removes each user's CACHE refs beyond the newest
+    ``settings.cache_retention_count`` (committed in one batch), then runs the
+    orphan cleanup on the affected videos so files no other active ref still
+    wants are reclaimed and their rows reset to ``CATALOGED``.
+    """
+    now = now or utcnow_naive()
+    keep = settings.cache_retention_count
+
+    user_ids = (
+        db.execute(
+            select(UserVideoRef.user_id)
+            .where(
+                UserVideoRef.removed_at.is_(None),
+                UserVideoRef.kind == REF_KIND_CACHE,
+            )
+            .distinct()
+        )
+        .scalars()
+        .all()
+    )
+
+    affected_video_ids: set[str] = set()
+    refs_removed = 0
+    for user_id in user_ids:
+        for ref in _cache_refs_to_drop(db, user_id, keep):
+            ref.removed_at = now
+            affected_video_ids.add(ref.video_id)
+            refs_removed += 1
+
+    if refs_removed:
+        db.commit()
+
+    reclaimed = 0
+    for video_id in affected_video_ids:
+        if check_and_delete_orphan_sync(video_id, db):
+            reclaimed += 1
+
+    if refs_removed:
+        logger.info(
+            "Cache sweep: %d user(s) with cache, %d ref(s) soft-removed, "
+            "%d file(s) reclaimed",
+            len(user_ids),
+            refs_removed,
+            reclaimed,
+        )
+
+    return {
+        "users": len(user_ids),
+        "refs_removed": refs_removed,
+        "reclaimed": reclaimed,
+    }

--- a/app/services/retention.py
+++ b/app/services/retention.py
@@ -26,7 +26,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.subscription import UserSubscription
-from app.models.user_video_ref import UserVideoRef
+from app.models.user_video_ref import REF_KIND_LIBRARY, UserVideoRef
 from app.models.video import Video
 from app.services.storage import check_and_delete_orphan_sync
 from app.utils.time import utcnow_naive
@@ -70,6 +70,9 @@ def _refs_to_drop_for_subscription(
                     Video.status == "COMPLETE",
                     UserVideoRef.user_id == sub.user_id,
                     UserVideoRef.removed_at.is_(None),
+                    # Subscription retention governs the collection only; cache
+                    # refs are evicted separately by the cache reaper.
+                    UserVideoRef.kind == REF_KIND_LIBRARY,
                 )
                 .order_by(
                     func.coalesce(Video.uploaded_at, Video.created_at).desc(),

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -59,6 +59,13 @@ celery_app.conf.beat_schedule = {
         "task": "app.tasks.download_tasks.enforce_retention_task",
         "schedule": settings.retention_interval_hours * 3600,
     },
+    # Evict the play cache: keep each user's most-recently-watched cache videos
+    # (queued ones pinned) and reclaim the rest. Same cadence/cost profile as the
+    # retention sweep — indexed per-user queries, a few hours' latency is fine.
+    "enforce-video-cache": {
+        "task": "app.tasks.download_tasks.enforce_video_cache_task",
+        "schedule": settings.cache_retention_interval_hours * 3600,
+    },
 }
 
 # WebSub (PubSubHubbub) subscription upkeep — only scheduled when a public

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -27,6 +27,7 @@ from app.services.download_manager import (
     download_preview,
     download_video,
 )
+from app.services.cache_retention import enforce_cache_retention
 from app.services.download_reaper import reap_stuck_downloads
 from app.services.retention import enforce_retention
 from app.services.session_reaper import reap_expired_sessions
@@ -529,6 +530,29 @@ def enforce_retention_task(self) -> dict:
         return {"status": "ok", **result}
     except Exception:
         logger.exception("Error in enforce_retention_task")
+        return {"status": "error"}
+    finally:
+        db.close()
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.enforce_video_cache_task",
+    bind=True,
+    max_retries=0,
+)
+def enforce_video_cache_task(self) -> dict:
+    """Periodic task: evict stale play-cache refs (LRU) per user.
+
+    Soft-removes each user's CACHE refs beyond the most-recently-watched budget
+    (watch-later-queued videos pinned), then reuses the orphan cleanup to reclaim
+    any file no remaining active ref still wants.
+    """
+    db = _get_sync_db()
+    try:
+        result = enforce_cache_retention(db)
+        return {"status": "ok", **result}
+    except Exception:
+        logger.exception("Error in enforce_video_cache_task")
         return {"status": "error"}
     finally:
         db.close()

--- a/tests/test_cache_refs.py
+++ b/tests/test_cache_refs.py
@@ -1,0 +1,182 @@
+"""Library-vs-cache ref kind: playing caches, downloading promotes, listings
+filter (downloads-as-cache, #86)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.database import async_session_factory
+from app.models.user_video_ref import (
+    REF_KIND_CACHE,
+    REF_KIND_LIBRARY,
+    UserVideoRef,
+)
+from app.models.video import Video
+from tests.helpers import seed_channel, seed_ref, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def download_delay(monkeypatch):
+    """Stub Celery enqueue so tests never touch the Redis broker."""
+    mock = MagicMock()
+    monkeypatch.setattr("app.api.videos.download_video_task.delay", mock)
+    return mock
+
+
+async def _get_ref(user_id: str, video_id: str) -> UserVideoRef:
+    async with async_session_factory() as db:
+        return (
+            await db.execute(
+                select(UserVideoRef).where(
+                    UserVideoRef.user_id == user_id,
+                    UserVideoRef.video_id == video_id,
+                )
+            )
+        ).scalar_one()
+
+
+async def test_progress_creates_cache_ref(client, make_user):
+    """Watching a not-downloaded video records a CACHE ref, not a library one."""
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    resp = await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": 12},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    ref = await _get_ref(user["id"], video.id)
+    assert ref.kind == REF_KIND_CACHE
+    assert ref.removed_at is None
+
+
+async def test_progress_does_not_downgrade_library_ref(client, make_user):
+    """Watching a library video leaves it LIBRARY (conflict path keeps kind)."""
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE")
+        await seed_ref(db, user["id"], video.id, kind=REF_KIND_LIBRARY)
+
+    resp = await client.put(
+        f"/api/videos/{video.id}/progress",
+        json={"position_seconds": 5},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    ref = await _get_ref(user["id"], video.id)
+    assert ref.kind == REF_KIND_LIBRARY
+
+
+async def test_cache_endpoint_creates_cache_ref_and_enqueues(
+    client, make_user, download_delay
+):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    resp = await client.post(f"/api/videos/{video.id}/cache", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "PENDING"
+    download_delay.assert_called_once_with(video.id, user["id"])
+
+    ref = await _get_ref(user["id"], video.id)
+    assert ref.kind == REF_KIND_CACHE
+
+    async with async_session_factory() as db:
+        v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()
+        assert v.status == "PENDING"
+
+
+async def test_cache_endpoint_complete_video_does_not_enqueue(
+    client, make_user, download_delay
+):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="COMPLETE")
+
+    resp = await client.post(f"/api/videos/{video.id}/cache", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "COMPLETE"
+    download_delay.assert_not_called()
+    # It still records the cache claim so the ref-count keeps the file alive.
+    ref = await _get_ref(user["id"], video.id)
+    assert ref.kind == REF_KIND_CACHE
+
+
+async def test_download_promotes_cache_ref_to_library(
+    client, make_user, download_delay
+):
+    """A cold-watched (CACHE) video that the user then downloads joins library."""
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+        await seed_ref(db, user["id"], video.id, kind=REF_KIND_CACHE)
+
+    resp = await client.post(f"/api/videos/{video.id}/download", headers=headers)
+    assert resp.status_code == 200
+    download_delay.assert_called_once()
+    ref = await _get_ref(user["id"], video.id)
+    assert ref.kind == REF_KIND_LIBRARY
+
+
+async def test_library_grid_excludes_cache_refs(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        lib = await seed_video(db, channel, status="COMPLETE", title="Lib")
+        cached = await seed_video(db, channel, status="COMPLETE", title="Cached")
+        await seed_ref(db, user["id"], lib.id, kind=REF_KIND_LIBRARY)
+        await seed_ref(db, user["id"], cached.id, kind=REF_KIND_CACHE)
+
+    resp = await client.get("/api/videos", headers=headers)
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()["items"]}
+    assert lib.id in ids
+    assert cached.id not in ids
+
+
+async def test_downloads_list_excludes_cache(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        lib = await seed_video(db, channel, status="DOWNLOADING")
+        cached = await seed_video(db, channel, status="DOWNLOADING")
+        await seed_ref(db, user["id"], lib.id, kind=REF_KIND_LIBRARY)
+        await seed_ref(db, user["id"], cached.id, kind=REF_KIND_CACHE)
+
+    resp = await client.get("/api/videos/downloads", headers=headers)
+    assert resp.status_code == 200
+    ids = {item["id"] for item in resp.json()}
+    assert lib.id in ids
+    assert cached.id not in ids
+
+
+async def test_continue_watching_includes_cache(client, make_user):
+    """A mid-watch cache video still shows in Continue Watching."""
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cached = await seed_video(db, channel, status="COMPLETE")
+        await seed_ref(
+            db,
+            user["id"],
+            cached.id,
+            kind=REF_KIND_CACHE,
+            watch_position_seconds=30,
+            is_watched=False,
+        )
+
+    resp = await client.get("/api/feed/continue-watching", headers=headers)
+    assert resp.status_code == 200
+    ids = {item["video"]["id"] for item in resp.json()}
+    assert cached.id in ids

--- a/tests/test_cache_retention.py
+++ b/tests/test_cache_retention.py
@@ -1,0 +1,178 @@
+"""Tests for play-cache eviction (downloads-as-cache, #86).
+
+Exercise the synchronous sweep directly (the way the Celery task does) against
+an in-memory SQLite session plus real files under the temp media paths conftest
+configures, mirroring tests/test_retention.py.
+"""
+
+import os
+import uuid
+from datetime import datetime, timedelta
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.config import settings
+from app.models import Base
+from app.models.user_queue import UserQueue
+from app.models.user_video_ref import (
+    REF_KIND_CACHE,
+    REF_KIND_LIBRARY,
+    UserVideoRef,
+)
+from app.models.video import Video
+from app.services.cache_retention import enforce_cache_retention
+from app.utils.time import utcnow_naive
+
+CHANNEL_ID = "chan-1"
+
+
+def _make_db():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _write(path: str, data: bytes = b"data") -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "wb") as f:
+        f.write(data)
+
+
+def _abs_media(rel_path: str) -> str:
+    return os.path.join(settings.media_path, rel_path)
+
+
+def _seed_downloaded_video(db) -> Video:
+    vid_id = str(uuid.uuid4())
+    yt_id = f"yt{uuid.uuid4().hex[:9]}"
+    rel_path = f"{CHANNEL_ID}/{vid_id}.mp4"
+    _write(_abs_media(rel_path))
+    _write(os.path.join(settings.thumbnails_path, f"{yt_id}.jpg"), b"thumb")
+    video = Video(
+        id=vid_id,
+        youtube_video_id=yt_id,
+        channel_id=CHANNEL_ID,
+        title="V",
+        status="COMPLETE",
+        file_path=rel_path,
+        file_size_bytes=4,
+    )
+    db.add(video)
+    db.commit()
+    return video
+
+
+def _seed_ref(
+    db, user_id: str, video_id: str, kind: str, last_watched_at: datetime | None = None
+) -> None:
+    db.add(
+        UserVideoRef(
+            user_id=user_id,
+            video_id=video_id,
+            kind=kind,
+            last_watched_at=last_watched_at,
+        )
+    )
+    db.commit()
+
+
+def _ref(db, user_id: str, video_id: str) -> UserVideoRef:
+    return db.execute(
+        select(UserVideoRef).where(
+            UserVideoRef.user_id == user_id,
+            UserVideoRef.video_id == video_id,
+        )
+    ).scalar_one()
+
+
+def test_keeps_newest_cache_and_reclaims_the_rest(monkeypatch):
+    monkeypatch.setattr(settings, "cache_retention_count", 1)
+    db = _make_db()
+    base = utcnow_naive()
+    v_old = _seed_downloaded_video(db)
+    v_new = _seed_downloaded_video(db)
+    _seed_ref(db, "u1", v_old.id, REF_KIND_CACHE, base - timedelta(days=2))
+    _seed_ref(db, "u1", v_new.id, REF_KIND_CACHE, base - timedelta(days=1))
+
+    old_media = _abs_media(v_old.file_path)
+    new_media = _abs_media(v_new.file_path)
+
+    result = enforce_cache_retention(db)
+
+    assert result == {"users": 1, "refs_removed": 1, "reclaimed": 1}
+    # Least-recently-watched cache evicted; newest kept.
+    assert _ref(db, "u1", v_old.id).removed_at is not None
+    assert _ref(db, "u1", v_new.id).removed_at is None
+    assert not os.path.exists(old_media)
+    assert os.path.exists(new_media)
+    db.refresh(v_old)
+    assert v_old.status == "CATALOGED"
+    db.close()
+
+
+def test_library_refs_are_never_evicted(monkeypatch):
+    monkeypatch.setattr(settings, "cache_retention_count", 0)  # drop all cache
+    db = _make_db()
+    v_lib = _seed_downloaded_video(db)
+    v_cache = _seed_downloaded_video(db)
+    _seed_ref(db, "u1", v_lib.id, REF_KIND_LIBRARY)
+    _seed_ref(db, "u1", v_cache.id, REF_KIND_CACHE)
+
+    result = enforce_cache_retention(db)
+
+    assert result["refs_removed"] == 1
+    assert _ref(db, "u1", v_lib.id).removed_at is None  # library untouched
+    assert _ref(db, "u1", v_cache.id).removed_at is not None  # cache evicted
+    assert os.path.exists(_abs_media(v_lib.file_path))
+    db.close()
+
+
+def test_queued_cache_is_pinned(monkeypatch):
+    monkeypatch.setattr(settings, "cache_retention_count", 0)  # would drop all
+    db = _make_db()
+    v_queued = _seed_downloaded_video(db)
+    v_other = _seed_downloaded_video(db)
+    _seed_ref(db, "u1", v_queued.id, REF_KIND_CACHE)
+    _seed_ref(db, "u1", v_other.id, REF_KIND_CACHE)
+    db.add(UserQueue(user_id="u1", video_id=v_queued.id))
+    db.commit()
+
+    enforce_cache_retention(db)
+
+    # "Want to watch later" pins the queued cache video; the other is evicted.
+    assert _ref(db, "u1", v_queued.id).removed_at is None
+    assert _ref(db, "u1", v_other.id).removed_at is not None
+    assert os.path.exists(_abs_media(v_queued.file_path))
+    db.close()
+
+
+def test_negative_count_disables_eviction(monkeypatch):
+    monkeypatch.setattr(settings, "cache_retention_count", -1)
+    db = _make_db()
+    v = _seed_downloaded_video(db)
+    _seed_ref(db, "u1", v.id, REF_KIND_CACHE)
+
+    result = enforce_cache_retention(db)
+
+    assert result["refs_removed"] == 0
+    assert _ref(db, "u1", v.id).removed_at is None
+    db.close()
+
+
+def test_shared_cache_not_reclaimed_while_another_ref_active(monkeypatch):
+    monkeypatch.setattr(settings, "cache_retention_count", 0)
+    db = _make_db()
+    v = _seed_downloaded_video(db)
+    # u1 holds it as cache (evicted); u2 holds it in their library (keeps file).
+    _seed_ref(db, "u1", v.id, REF_KIND_CACHE)
+    _seed_ref(db, "u2", v.id, REF_KIND_LIBRARY)
+
+    result = enforce_cache_retention(db)
+
+    assert result["refs_removed"] == 1
+    assert result["reclaimed"] == 0
+    assert _ref(db, "u1", v.id).removed_at is not None
+    assert _ref(db, "u2", v.id).removed_at is None
+    assert os.path.exists(_abs_media(v.file_path))  # shared file survives
+    db.close()


### PR DESCRIPTION
## What

Playing a not-yet-downloaded video used to create the same durable `UserVideoRef` as an explicit download — so **watching silently built up the user's library**. This adds a `kind` (LIBRARY vs CACHE) so the two are distinct, making "downloads = cache, only follows / watch-later / explicit saves build the library" true.

Track 2 of the instant-playback initiative (backend #85 was track 1).

## Behavior

| Action | Ref kind |
|--------|----------|
| Play / progress / `POST /{id}/cache` | **CACHE** (evictable, hidden from library) |
| Explicit `/download`, subscription auto-download | **LIBRARY** |
| Download a cold-watched video | CACHE → **promoted to LIBRARY** |
| Watch a library video | stays LIBRARY (never downgraded) |

**Listing surfaces:**
- LIBRARY-only: library grid (`GET /api/videos`), `/downloads`, feed `new-episodes` + `recently-added`.
- Both kinds: `continue-watching` (you can resume a cached video), recommendation scoring (still a taste signal).

## Pieces

- **`POST /api/videos/{id}/cache`** — idempotent, never-409 enqueue clients call when starting instant playback; records a CACHE claim and kicks off the HQ download so the player's preview→HQ swap works, without the download appearing in the Downloads tab.
- **Cache reaper** (`cache_retention.py` + `enforce_video_cache_task`, scheduled every `cache_retention_interval_hours`): evicts each user's CACHE refs by LRU beyond `cache_retention_count`, **pins watch-later-queued videos**, then reuses the shared orphan cleanup (shared files survive while any active ref remains). Per-subscription retention now scopes to LIBRARY so the two systems don't fight.
- **Migration 013** adds `kind` with `server_default='LIBRARY'`, backfilling existing refs as library.

## Tests

13 new across `test_cache_refs.py` (kind classification on play/cache/download, listing filters, promotion, continue-watching includes cache) and `test_cache_retention.py` (LRU eviction, library never evicted, queued pinned, negative disables, shared-file safety). **Full suite: 277 passed.** Migration head `013`, ruff clean.

## Follow-ups

- Clients: call `POST /{id}/cache` on cold-press so the instant stream also caches HQ + swaps (stacked on the track-1 client PRs).
- Track 3: predictive preview pre-warming. Track 4: HLS/CMAF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)