### PR TITLE
feat(videos): batch preview pre-warming endpoint

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -24,6 +24,7 @@ from app.models.video import Video
 from app.schemas.ticket import AccessTicket
 from app.schemas.video import (
     DownloadRequest,
+    PrewarmRequest,
     VideoDetail,
     VideoOut,
     VideoProgress,
@@ -51,6 +52,10 @@ from app.utils.time import utcnow_naive
 
 router = APIRouter(prefix="/api/videos", tags=["videos"])
 logger = logging.getLogger(__name__)
+
+# Upper bound on how many previews one /prewarm call may enqueue, so a client
+# showing a long list can't kick off an unbounded number of preview downloads.
+PREWARM_MAX_PER_CALL = 16
 
 
 async def _ensure_active_ref(
@@ -244,6 +249,49 @@ async def get_active_downloads(
         )
         for v in videos
     ]
+
+
+@router.post("/prewarm")
+async def prewarm_previews(
+    body: PrewarmRequest,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Pre-generate 360p previews for videos the user is likely to play next (#87).
+
+    Clients call this with the ids they're showing (the focused tile, the
+    watch-later queue, the top of the feed) so a later tap lands on the
+    ready-preview fast path instead of the cold instant-stream path. Bounded and
+    idempotent: only not-downloaded videos without a preview are enqueued, capped
+    per call, and a preview already downloading/ready is left alone. Speculative,
+    so it records no ref (it just produces a shared preview file).
+    """
+    # Dedupe, then cap so a client can't enqueue an unbounded batch.
+    video_ids = list(dict.fromkeys(body.video_ids))[:PREWARM_MAX_PER_CALL]
+    if not video_ids:
+        return {"enqueued": []}
+
+    result = await db.execute(
+        select(Video).where(
+            Video.id.in_(video_ids),
+            Video.status != "COMPLETE",
+            Video.preview_status.is_(None),
+        )
+    )
+    eligible = result.scalars().all()
+
+    # Mark DOWNLOADING up front so a repeat prewarm (e.g. a feed refresh) skips a
+    # video already being prepared; the task sets it again and resets to NULL on
+    # failure, so a failed prewarm is retryable.
+    enqueued = [video.id for video in eligible]
+    for video in eligible:
+        video.preview_status = "DOWNLOADING"
+    if enqueued:
+        await db.commit()
+        for video_id in enqueued:
+            download_preview_task.delay(video_id, user.id)
+
+    return {"enqueued": enqueued}
 
 
 @router.get("/{video_id}", response_model=VideoDetail)

--- a/app/schemas/video.py
+++ b/app/schemas/video.py
@@ -38,6 +38,13 @@ class DownloadRequest(BaseModel):
     quality: Literal["720p", "1080p", "4k", "best"] | None = None
 
 
+class PrewarmRequest(BaseModel):
+    """Ids of videos the client expects the user to play soon, so the backend can
+    pre-generate their previews. Bounded server-side; extra ids are ignored."""
+
+    video_ids: list[str] = Field(default_factory=list)
+
+
 class VideoPagination(BaseModel):
     items: list[VideoOut]
     total: int

--- a/tests/test_prewarm.py
+++ b/tests/test_prewarm.py
@@ -1,0 +1,109 @@
+"""Predictive preview pre-warming: POST /api/videos/prewarm (#87)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from app.api.videos import PREWARM_MAX_PER_CALL
+from app.database import async_session_factory
+from app.models.video import Video
+from tests.helpers import seed_channel, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def preview_delay(monkeypatch):
+    """Stub the Celery preview enqueue so tests never touch the broker."""
+    mock = MagicMock()
+    monkeypatch.setattr("app.api.videos.download_preview_task.delay", mock)
+    return mock
+
+
+async def _preview_status(video_id: str) -> str | None:
+    async with async_session_factory() as db:
+        return (
+            await db.execute(select(Video.preview_status).where(Video.id == video_id))
+        ).scalar_one()
+
+
+async def test_prewarm_requires_auth(client):
+    resp = await client.post("/api/videos/prewarm", json={"video_ids": ["x"]})
+    assert resp.status_code == 401
+
+
+async def test_prewarm_enqueues_eligible(client, make_user, preview_delay):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cataloged = await seed_video(db, channel, status="CATALOGED")
+        # HQ downloading but no preview yet — a preview still helps (play now).
+        downloading = await seed_video(db, channel, status="DOWNLOADING")
+
+    resp = await client.post(
+        "/api/videos/prewarm",
+        json={"video_ids": [cataloged.id, downloading.id]},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert set(resp.json()["enqueued"]) == {cataloged.id, downloading.id}
+    assert preview_delay.call_count == 2
+    # Marked DOWNLOADING up front so a repeat call skips it.
+    assert await _preview_status(cataloged.id) == "DOWNLOADING"
+
+
+async def test_prewarm_skips_complete_and_already_previewed(
+    client, make_user, preview_delay
+):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        complete = await seed_video(db, channel, status="COMPLETE")
+        ready = await seed_video(
+            db, channel, status="CATALOGED", preview_status="READY"
+        )
+        in_progress = await seed_video(
+            db, channel, status="CATALOGED", preview_status="DOWNLOADING"
+        )
+        eligible = await seed_video(db, channel, status="CATALOGED")
+
+    resp = await client.post(
+        "/api/videos/prewarm",
+        json={
+            "video_ids": [complete.id, ready.id, in_progress.id, eligible.id],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["enqueued"] == [eligible.id]
+    preview_delay.assert_called_once_with(eligible.id, user["id"])
+
+
+async def test_prewarm_dedupes_and_caps(client, make_user, preview_delay):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        videos = [
+            await seed_video(db, channel, status="CATALOGED")
+            for _ in range(PREWARM_MAX_PER_CALL + 5)
+        ]
+
+    ids = [v.id for v in videos]
+    # Send every id twice; the endpoint dedupes, then caps.
+    resp = await client.post(
+        "/api/videos/prewarm", json={"video_ids": ids + ids}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert len(resp.json()["enqueued"]) == PREWARM_MAX_PER_CALL
+    assert preview_delay.call_count == PREWARM_MAX_PER_CALL
+
+
+async def test_prewarm_empty_list_is_noop(client, make_user, preview_delay):
+    user, headers = await make_user()
+    resp = await client.post(
+        "/api/videos/prewarm", json={"video_ids": []}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["enqueued"] == []
+    preview_delay.assert_not_called()


### PR DESCRIPTION
## What

Track 3 of the instant-playback initiative. Adds **`POST /api/videos/prewarm`** so clients can pre-generate 360p previews for the videos the user is most likely to play next — making those taps land on the **ready-preview fast path** (local file, sub-second) instead of the cold instant-stream path.

Clients call it with the ids they're showing: the focused tile (tvOS), the watch-later queue, the top of the home feed.

## Behavior

- Body `{video_ids: [...]}`. **Dedupes** and **caps** at `PREWARM_MAX_PER_CALL` (16) so a long list can't enqueue unbounded downloads.
- Only enqueues videos that are **not downloaded** (`status != COMPLETE`) and have **no preview yet** (`preview_status IS NULL`).
- Marks `preview_status = DOWNLOADING` up front, so a repeat call (e.g. a feed refresh) skips a video already being prepared; `download_preview_task` resets it to NULL on failure, so it stays retryable.
- **Speculative → records no `UserVideoRef`** (it just produces a shared preview file); it doesn't touch the library/cache model from #86.

## Tests

5 new in `test_prewarm.py`: eligible enqueue + optimistic DOWNLOADING, skips complete/already-previewing, dedupe + cap, empty no-op, auth. **Full suite: 289 passed.**

## Follow-ups

- Clients call `/prewarm` from the queue, home feed, and (tvOS) on focus.
- Track 4: HLS/CMAF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)