### PR TITLE
feat(videos): detect sponsor/ad segments for client-side skipping

### DIFF
--- a/alembic/versions/014_video_ad_segments.py
+++ b/alembic/versions/014_video_ad_segments.py
@@ -1,0 +1,28 @@
+"""Sponsor/ad segments for client-side skipping: videos.ad_segments(_status)
+
+Revision ID: 014_video_ad_segments
+Revises: 013_user_video_refs_kind
+Create Date: 2026-06-28
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "014_video_ad_segments"
+down_revision: Union[str, None] = "013_user_video_refs_kind"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("videos", sa.Column("ad_segments", sa.JSON(), nullable=True))
+    op.add_column(
+        "videos", sa.Column("ad_segments_status", sa.String(length=20), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("videos", "ad_segments_status")
+    op.drop_column("videos", "ad_segments")

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -38,7 +38,11 @@ from app.services.instant_stream import (
 from app.services.media_server import build_media_response
 from app.services.progress_broadcaster import publish_progress_updated
 from app.services.storage import check_and_delete_orphan
-from app.tasks.download_tasks import download_preview_task, download_video_task
+from app.tasks.download_tasks import (
+    detect_ad_segments_task,
+    download_preview_task,
+    download_video_task,
+)
 from app.utils.pagination import decode_cursor, encode_cursor
 from app.utils.search import escape_like
 from app.utils.tickets import (
@@ -478,6 +482,37 @@ async def cancel_download(
     await db.commit()
 
     return {"detail": "Download cancelled", "video_id": video_id, "stopped": True}
+
+
+@router.get("/{video_id}/ad-segments")
+async def get_ad_segments(
+    video_id: str,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Return detected sponsor/ad segments for client-side skipping (#88).
+
+    Lazily triggers detection (SponsorBlock first, AI-from-transcript fallback)
+    on first request and returns PENDING; once ready, returns the cached segments
+    (a possibly-empty list of ``{start, end, category}`` in seconds). Clients seek
+    past these during playback.
+    """
+    result = await db.execute(select(Video).where(Video.id == video_id))
+    video = result.scalar_one_or_none()
+    if not video:
+        raise HTTPException(status_code=404, detail="Video not found")
+
+    if video.ad_segments_status == "READY":
+        return {"status": "READY", "segments": video.ad_segments or []}
+    if video.ad_segments_status == "PENDING":
+        return {"status": "PENDING", "segments": []}
+
+    # Not yet checked — mark PENDING up front (so concurrent requests don't
+    # double-enqueue) and kick off detection.
+    video.ad_segments_status = "PENDING"
+    await db.commit()
+    detect_ad_segments_task.delay(video_id)
+    return {"status": "PENDING", "segments": []}
 
 
 @router.post("/{video_id}/preview")

--- a/app/models/video.py
+++ b/app/models/video.py
@@ -35,6 +35,12 @@ class Video(Base):
     metadata_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     preview_file_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     preview_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Detected sponsor/ad segments for client-side skipping (#88). JSON list of
+    # {start, end, category} in seconds. ad_segments_status: NULL = not checked,
+    # "PENDING" = detection enqueued, "READY" = checked (list may be empty when
+    # no ads were found).
+    ad_segments: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    ad_segments_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
     downloaded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     # Liveness signal for an in-flight download: set when the row enters
     # DOWNLOADING and refreshed by the worker as yt-dlp produces output. The

--- a/app/services/ad_segments.py
+++ b/app/services/ad_segments.py
@@ -53,7 +53,9 @@ def fetch_sponsorblock_segments(youtube_video_id: str) -> list[dict] | None:
     caller can distinguish "no data" from "couldn't check" and fall back to AI in
     both cases without treating an error as a definitive "no ads".
     """
-    params = [("videoID", youtube_video_id)]
+    params: list[tuple[str, str | int | float | bool | None]] = [
+        ("videoID", youtube_video_id)
+    ]
     params += [("category", category) for category in SPONSORBLOCK_CATEGORIES]
     try:
         resp = httpx.get(SPONSORBLOCK_API_URL, params=params, timeout=_REQUEST_TIMEOUT)

--- a/app/services/ad_segments.py
+++ b/app/services/ad_segments.py
@@ -1,0 +1,164 @@
+"""Detect sponsor/ad segments in a video for client-side skipping (#88).
+
+Two sources, tried in order:
+
+1. **SponsorBlock** — the free community API. Accurate and instant for popular
+   videos, and the only cost is one HTTP GET.
+2. **AI fallback** — only when SponsorBlock has no data *and* an Anthropic key
+   is configured: read the video's transcript and ask Claude to mark sponsor
+   reads. Covers the long tail SponsorBlock hasn't catalogued.
+
+Segments are ``{start, end, category}`` in seconds; clients seek past them during
+playback. This module is pure (no DB); the Celery task stores the result.
+"""
+
+import json
+import logging
+
+import httpx
+
+from app.config import settings
+from app.services.download_manager import fetch_transcript
+
+logger = logging.getLogger(__name__)
+
+SPONSORBLOCK_API_URL = "https://sponsor.ajay.app/api/skipSegments"
+# Only paid-promotion categories — we cut sponsor reads and self-promo, not the
+# intro/outro/interaction categories SponsorBlock also tracks.
+SPONSORBLOCK_CATEGORIES = ("sponsor", "selfpromo")
+_REQUEST_TIMEOUT = 15
+
+_AI_MODEL = "claude-sonnet-4-6"  # matches the recommendation engine
+_AI_MAX_TOKENS = 1024  # a segment list is small
+
+_AI_PROMPT = """You are given a timestamped transcript of a YouTube video. \
+Identify the time ranges that are paid sponsor reads or self-promotion (e.g. \
+"this video is sponsored by", promo codes, "check out my merch/Patreon/Nord VPN"). \
+Do NOT mark the actual content, or intros/outros that aren't promotional.
+
+Return ONLY a JSON array (no prose, no markdown) where each element is:
+{{"start": <seconds, number>, "end": <seconds, number>, "category": "sponsor"}}
+Return [] if there are no sponsor segments.
+
+Transcript (start_seconds: text):
+{transcript}
+"""
+
+
+def fetch_sponsorblock_segments(youtube_video_id: str) -> list[dict] | None:
+    """Query SponsorBlock for sponsor segments.
+
+    Returns a list of ``{start, end, category}``; ``[]`` when SponsorBlock has no
+    data for the video (HTTP 404); or ``None`` on a transport/HTTP error, so the
+    caller can distinguish "no data" from "couldn't check" and fall back to AI in
+    both cases without treating an error as a definitive "no ads".
+    """
+    params = [("videoID", youtube_video_id)]
+    params += [("category", category) for category in SPONSORBLOCK_CATEGORIES]
+    try:
+        resp = httpx.get(SPONSORBLOCK_API_URL, params=params, timeout=_REQUEST_TIMEOUT)
+    except httpx.HTTPError as exc:
+        logger.warning("SponsorBlock request failed for %s: %s", youtube_video_id, exc)
+        return None
+
+    if resp.status_code == 404:
+        return []  # no community-submitted segments for this video
+    if resp.status_code != 200:
+        logger.warning(
+            "SponsorBlock returned HTTP %s for %s", resp.status_code, youtube_video_id
+        )
+        return None
+
+    try:
+        rows = resp.json()
+    except ValueError:
+        return None
+
+    segments: list[dict] = []
+    for row in rows:
+        seg = row.get("segment")
+        if isinstance(seg, list) and len(seg) == 2:
+            try:
+                start, end = float(seg[0]), float(seg[1])
+            except (TypeError, ValueError):
+                continue
+            if end > start:
+                segments.append(
+                    {
+                        "start": round(start, 2),
+                        "end": round(end, 2),
+                        "category": row.get("category", "sponsor"),
+                    }
+                )
+    return segments
+
+
+def _claude_complete(prompt: str) -> str:
+    """Run one synchronous Claude completion and return the response text."""
+    import anthropic
+
+    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    message = client.messages.create(
+        model=_AI_MODEL,
+        max_tokens=_AI_MAX_TOKENS,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    block = message.content[0]
+    return block.text if hasattr(block, "text") else ""
+
+
+def _parse_segments(text: str) -> list[dict]:
+    """Parse Claude's JSON array of segments, tolerating markdown code fences."""
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.strip("`").removeprefix("json").strip()
+    data = json.loads(text)
+    if not isinstance(data, list):
+        raise ValueError("Expected a JSON array of segments")
+
+    segments: list[dict] = []
+    for item in data:
+        try:
+            start, end = float(item["start"]), float(item["end"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if end > start:
+            segments.append(
+                {
+                    "start": round(start, 2),
+                    "end": round(end, 2),
+                    "category": item.get("category", "sponsor"),
+                }
+            )
+    return segments
+
+
+def detect_ad_segments_with_ai(youtube_video_id: str) -> list[dict]:
+    """AI fallback: read the transcript and ask Claude to mark sponsor reads.
+
+    Returns ``[]`` when no transcript is available or detection fails.
+    """
+    cues = fetch_transcript(youtube_video_id)
+    if not cues:
+        return []
+    transcript = "\n".join(f"{cue['start']}: {cue['text']}" for cue in cues)
+    try:
+        text = _claude_complete(_AI_PROMPT.format(transcript=transcript))
+        return _parse_segments(text)
+    except Exception as exc:
+        logger.warning("AI ad detection failed for %s: %s", youtube_video_id, exc)
+        return []
+
+
+def resolve_ad_segments(youtube_video_id: str) -> list[dict]:
+    """SponsorBlock first; fall back to AI-from-transcript only when SponsorBlock
+    has nothing (no data or an error) *and* an Anthropic key is configured.
+
+    Returns a possibly-empty list of ``{start, end, category}``.
+    """
+    sponsorblock = fetch_sponsorblock_segments(youtube_video_id)
+    if sponsorblock:
+        return sponsorblock
+    if settings.anthropic_api_key:
+        return detect_ad_segments_with_ai(youtube_video_id)
+    return []

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -5,6 +5,7 @@ import shutil
 import signal
 import subprocess
 import json
+import tempfile
 import threading
 import time
 import xml.etree.ElementTree as ET
@@ -360,6 +361,58 @@ def download_preview(
         "file_path": relative_path,
         "file_size_bytes": file_size,
     }
+
+
+def fetch_transcript(youtube_video_id: str) -> list[dict] | None:
+    """Fetch the timestamped English transcript (auto-captions) via yt-dlp.
+
+    Returns a list of ``{"start": float_seconds, "text": str}`` cues, or None if
+    no captions are available or extraction fails. Used as input to AI ad-segment
+    detection — it downloads only the subtitle track (``--skip-download``), parsed
+    from yt-dlp's json3 format.
+    """
+    url = f"https://www.youtube.com/watch?v={youtube_video_id}"
+    with tempfile.TemporaryDirectory() as tmp:
+        output_template = os.path.join(tmp, "%(id)s.%(ext)s")
+        cmd = [
+            "yt-dlp",
+            "--skip-download",
+            "--write-auto-subs",
+            "--write-subs",
+            "--sub-langs",
+            "en.*",
+            "--sub-format",
+            "json3",
+            "--no-playlist",
+            "--output",
+            output_template,
+            url,
+        ]
+        try:
+            subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        except subprocess.TimeoutExpired:
+            logger.warning("Transcript fetch timed out for %s", youtube_video_id)
+            return None
+
+        json3_files = [f for f in os.listdir(tmp) if f.endswith(".json3")]
+        if not json3_files:
+            return None
+        try:
+            with open(os.path.join(tmp, json3_files[0])) as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    cues: list[dict] = []
+    for event in data.get("events", []):
+        segs = event.get("segs")
+        start_ms = event.get("tStartMs")
+        if not segs or start_ms is None:
+            continue
+        text = "".join(seg.get("utf8", "") for seg in segs).strip()
+        if text:
+            cues.append({"start": round(start_ms / 1000.0, 2), "text": text})
+    return cues or None
 
 
 def _cleanup_partial_files(output_dir: str, youtube_video_id: str) -> None:

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -27,6 +27,7 @@ from app.services.download_manager import (
     download_preview,
     download_video,
 )
+from app.services.ad_segments import resolve_ad_segments
 from app.services.cache_retention import enforce_cache_retention
 from app.services.download_reaper import reap_stuck_downloads
 from app.services.retention import enforce_retention
@@ -481,6 +482,39 @@ def download_preview_task(self, video_id: str, user_id: str) -> dict:
         except Exception:
             pass
         raise exc
+    finally:
+        db.close()
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.detect_ad_segments_task",
+    bind=True,
+    max_retries=0,
+)
+def detect_ad_segments_task(self, video_id: str) -> dict:
+    """Detect sponsor/ad segments (SponsorBlock + AI fallback) and store them for
+    client-side skipping. ad_segments_status -> READY (list may be empty); reset
+    to NULL on failure so a later request can retry."""
+    db = _get_sync_db()
+    try:
+        video = db.get(Video, video_id)
+        if not video:
+            return {"status": "error", "reason": "not_found"}
+        segments = resolve_ad_segments(video.youtube_video_id)
+        video.ad_segments = segments
+        video.ad_segments_status = "READY"
+        db.commit()
+        return {"status": "ok", "count": len(segments)}
+    except Exception:
+        logger.exception("Ad-segment detection failed for video %s", video_id)
+        try:
+            video = db.get(Video, video_id)
+            if video:
+                video.ad_segments_status = None  # allow a retry
+                db.commit()
+        except Exception:
+            pass
+        return {"status": "error"}
     finally:
         db.close()
 

--- a/tests/test_ad_segments.py
+++ b/tests/test_ad_segments.py
@@ -1,0 +1,162 @@
+"""Sponsor/ad-segment detection: SponsorBlock + AI fallback + endpoint (#88)."""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from sqlalchemy import select
+
+import app.services.ad_segments as ad_segments
+from app.config import settings
+from app.database import async_session_factory
+from app.models.video import Video
+from tests.helpers import seed_channel, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+def _fail(*_args, **_kwargs):
+    raise AssertionError("should not be called")
+
+
+# --- SponsorBlock ---------------------------------------------------------
+
+
+async def test_fetch_sponsorblock_maps_segments(monkeypatch):
+    rows = [
+        {"segment": [10.0, 25.5], "category": "sponsor"},
+        {"segment": [120.0, 140.0], "category": "selfpromo"},
+        {"segment": [5.0], "category": "sponsor"},  # malformed -> skipped
+        {"segment": [50.0, 50.0], "category": "sponsor"},  # zero-length -> skipped
+    ]
+    monkeypatch.setattr(
+        ad_segments.httpx, "get", lambda *a, **k: httpx.Response(200, json=rows)
+    )
+    segs = ad_segments.fetch_sponsorblock_segments("yt-1")
+    assert segs == [
+        {"start": 10.0, "end": 25.5, "category": "sponsor"},
+        {"start": 120.0, "end": 140.0, "category": "selfpromo"},
+    ]
+
+
+async def test_fetch_sponsorblock_404_returns_empty(monkeypatch):
+    monkeypatch.setattr(ad_segments.httpx, "get", lambda *a, **k: httpx.Response(404))
+    assert ad_segments.fetch_sponsorblock_segments("yt-2") == []
+
+
+async def test_fetch_sponsorblock_error_returns_none(monkeypatch):
+    def boom(*a, **k):
+        raise httpx.ConnectError("down")
+
+    monkeypatch.setattr(ad_segments.httpx, "get", boom)
+    assert ad_segments.fetch_sponsorblock_segments("yt-3") is None
+
+
+# --- resolve (SponsorBlock first, AI fallback) ----------------------------
+
+
+async def test_resolve_prefers_sponsorblock(monkeypatch):
+    segs = [{"start": 1.0, "end": 2.0, "category": "sponsor"}]
+    monkeypatch.setattr(ad_segments, "fetch_sponsorblock_segments", lambda v: segs)
+    monkeypatch.setattr(ad_segments, "detect_ad_segments_with_ai", _fail)
+    assert ad_segments.resolve_ad_segments("yt") == segs
+
+
+async def test_resolve_falls_back_to_ai(monkeypatch):
+    monkeypatch.setattr(ad_segments, "fetch_sponsorblock_segments", lambda v: [])
+    ai_segs = [{"start": 3.0, "end": 4.0, "category": "sponsor"}]
+    monkeypatch.setattr(ad_segments, "detect_ad_segments_with_ai", lambda v: ai_segs)
+    monkeypatch.setattr(settings, "anthropic_api_key", "sk-test")
+    assert ad_segments.resolve_ad_segments("yt") == ai_segs
+
+
+async def test_resolve_no_ai_key_returns_empty(monkeypatch):
+    monkeypatch.setattr(ad_segments, "fetch_sponsorblock_segments", lambda v: [])
+    monkeypatch.setattr(ad_segments, "detect_ad_segments_with_ai", _fail)
+    monkeypatch.setattr(settings, "anthropic_api_key", "")
+    assert ad_segments.resolve_ad_segments("yt") == []
+
+
+# --- AI detection ---------------------------------------------------------
+
+
+async def test_ai_detection_parses_segments(monkeypatch):
+    monkeypatch.setattr(
+        ad_segments,
+        "fetch_transcript",
+        lambda v: [
+            {"start": 0.0, "text": "intro"},
+            {"start": 30.0, "text": "sponsor read"},
+        ],
+    )
+    monkeypatch.setattr(
+        ad_segments,
+        "_claude_complete",
+        lambda p: '```json\n[{"start": 30, "end": 60, "category": "sponsor"}]\n```',
+    )
+    assert ad_segments.detect_ad_segments_with_ai("yt") == [
+        {"start": 30.0, "end": 60.0, "category": "sponsor"}
+    ]
+
+
+async def test_ai_detection_no_transcript(monkeypatch):
+    monkeypatch.setattr(ad_segments, "fetch_transcript", lambda v: None)
+    monkeypatch.setattr(ad_segments, "_claude_complete", _fail)
+    assert ad_segments.detect_ad_segments_with_ai("yt") == []
+
+
+# --- endpoint -------------------------------------------------------------
+
+
+@pytest.fixture
+def detect_delay(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("app.api.videos.detect_ad_segments_task.delay", mock)
+    return mock
+
+
+async def test_ad_segments_requires_auth(client):
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+    resp = await client.get(f"/api/videos/{video.id}/ad-segments")
+    assert resp.status_code == 401
+
+
+async def test_ad_segments_unknown_video_404(client, make_user):
+    _, headers = await make_user()
+    resp = await client.get("/api/videos/nope/ad-segments", headers=headers)
+    assert resp.status_code == 404
+
+
+async def test_ad_segments_first_call_enqueues_pending(client, make_user, detect_delay):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+
+    resp = await client.get(f"/api/videos/{video.id}/ad-segments", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "PENDING", "segments": []}
+    detect_delay.assert_called_once_with(video.id)
+
+    async with async_session_factory() as db:
+        v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()
+        assert v.ad_segments_status == "PENDING"
+
+
+async def test_ad_segments_ready_returns_segments(client, make_user, detect_delay):
+    user, headers = await make_user()
+    segs = [{"start": 10.0, "end": 20.0, "category": "sponsor"}]
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel)
+        v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()
+        v.ad_segments_status = "READY"
+        v.ad_segments = segs
+        await db.commit()
+
+    resp = await client.get(f"/api/videos/{video.id}/ad-segments", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "READY", "segments": segs}
+    detect_delay.assert_not_called()


### PR DESCRIPTION
## What

The most on-brand feature for an ad-free YouTube alternative: **detect sponsor/ad segments** so clients can skip paid promotions during playback (SponsorBlock-style).

New endpoint **`GET /api/videos/{id}/ad-segments`** → `{status, segments}` where each segment is `{start, end, category}` in seconds. Lazily triggers detection on first request (returns `PENDING`); once ready, returns the cached segments (list may be empty = checked, no ads).

## Detection — SponsorBlock first, AI fallback

1. **SponsorBlock community API** — accurate, instant, one HTTP GET. Categories: `sponsor`, `selfpromo`.
2. **AI fallback** (only when SponsorBlock has no data **and** an Anthropic key is configured): `yt-dlp --skip-download` pulls the timestamped transcript (json3), and Claude (`claude-sonnet-4-6`, matching the recommendation engine) marks sponsor reads. `anthropic==0.43.0` predates `messages.parse`, so this parses a JSON array from the response — version-robust.

`resolve_ad_segments` falls back to AI on both "no data" (404) and transport errors, so an error is never mistaken for "no ads".

## Pieces

- `app/services/ad_segments.py` — pure (no DB), unit-testable: `fetch_sponsorblock_segments`, `detect_ad_segments_with_ai`, `resolve_ad_segments`.
- `download_manager.fetch_transcript` — yt-dlp auto-subs → cues.
- `detect_ad_segments_task` (Celery) stores results; `ad_segments_status` gates re-runs (NULL → PENDING → READY; reset to NULL on failure for retry).
- **Migration 014** adds `videos.ad_segments` (JSON) + `ad_segments_status`.

**Non-destructive** — this is detection + the data clients need to *skip*; server-side *cut* (ffmpeg removing segments from the file) is a deliberate follow-up.

## Tests

12 new in `test_ad_segments.py`: SponsorBlock mapping / 404→[] / error→None, resolve precedence + AI fallback + no-key, AI parse (fenced JSON), endpoint PENDING/READY/auth/404. **Full suite: 301 passed.** Migration head `014`, ruff clean.

## Follow-ups

- Flutter + tvOS: fetch `/ad-segments` on play and seek past segments (with a "Skipped sponsor" toast).
- Optional server-side **cut** for downloaded videos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)