### PR TITLE
feat(ad-segments): emit ad_segments_ready so first play skips too

### DIFF
--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -511,7 +511,7 @@ async def get_ad_segments(
     # double-enqueue) and kick off detection.
     video.ad_segments_status = "PENDING"
     await db.commit()
-    detect_ad_segments_task.delay(video_id)
+    detect_ad_segments_task.delay(video_id, user.id)
     return {"status": "PENDING", "segments": []}
 
 

--- a/app/services/progress_broadcaster.py
+++ b/app/services/progress_broadcaster.py
@@ -50,6 +50,25 @@ def publish_preview_ready(video_id: str, user_id: str) -> None:
     )
 
 
+def publish_ad_segments_ready(video_id: str, user_id: str) -> None:
+    """Publish ad_segments_ready event from the Celery worker (sync).
+
+    Emitted when sponsor/ad-segment detection finishes, so a player watching
+    this video (whose first request triggered detection) can fetch and apply the
+    segments mid-playback instead of only on the next open.
+    """
+    _get_sync_redis().publish(
+        PROGRESS_CHANNEL,
+        json.dumps(
+            {
+                "type": "ad_segments_ready",
+                "video_id": video_id,
+                "user_id": user_id,
+            }
+        ),
+    )
+
+
 def publish_download_complete(
     video_id: str,
     user_id: str,
@@ -133,10 +152,10 @@ async def _dispatch_event(payload: dict) -> None:
     user_id = payload["user_id"]
     msg_type = payload.get("type")
 
-    if msg_type == "preview_ready":
+    if msg_type in ("preview_ready", "ad_segments_ready"):
         await broadcast_to_user(
             user_id,
-            {"type": "preview_ready", "data": {"video_id": payload["video_id"]}},
+            {"type": msg_type, "data": {"video_id": payload["video_id"]}},
         )
     elif msg_type in ("download_complete", "new_episode"):
         # Both carry the same optional channel/title/youtube fields.

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -35,6 +35,7 @@ from app.services.session_reaper import reap_expired_sessions
 from app.services.websub import sync_subscriptions
 from app.utils.time import utcnow_naive
 from app.services.progress_broadcaster import (
+    publish_ad_segments_ready,
     publish_download_complete,
     publish_download_progress,
     publish_preview_ready,
@@ -491,10 +492,11 @@ def download_preview_task(self, video_id: str, user_id: str) -> dict:
     bind=True,
     max_retries=0,
 )
-def detect_ad_segments_task(self, video_id: str) -> dict:
+def detect_ad_segments_task(self, video_id: str, user_id: str) -> dict:
     """Detect sponsor/ad segments (SponsorBlock + AI fallback) and store them for
     client-side skipping. ad_segments_status -> READY (list may be empty); reset
-    to NULL on failure so a later request can retry."""
+    to NULL on failure so a later request can retry. Publishes ad_segments_ready
+    so a player already watching this video applies the segments mid-playback."""
     db = _get_sync_db()
     try:
         video = db.get(Video, video_id)
@@ -504,6 +506,7 @@ def detect_ad_segments_task(self, video_id: str) -> dict:
         video.ad_segments = segments
         video.ad_segments_status = "READY"
         db.commit()
+        publish_ad_segments_ready(video_id, user_id)
         return {"status": "ok", "count": len(segments)}
     except Exception:
         logger.exception("Ad-segment detection failed for video %s", video_id)

--- a/tests/test_ad_segments.py
+++ b/tests/test_ad_segments.py
@@ -138,7 +138,7 @@ async def test_ad_segments_first_call_enqueues_pending(client, make_user, detect
     resp = await client.get(f"/api/videos/{video.id}/ad-segments", headers=headers)
     assert resp.status_code == 200
     assert resp.json() == {"status": "PENDING", "segments": []}
-    detect_delay.assert_called_once_with(video.id)
+    detect_delay.assert_called_once_with(video.id, user["id"])
 
     async with async_session_factory() as db:
         v = (await db.execute(select(Video).where(Video.id == video.id))).scalar_one()

--- a/tests/test_progress_broadcaster.py
+++ b/tests/test_progress_broadcaster.py
@@ -66,6 +66,16 @@ async def test_dispatch_progress_updated(sent):
     )
 
 
+async def test_dispatch_ad_segments_ready(sent):
+    await _dispatch_event(
+        {"type": "ad_segments_ready", "user_id": "u1", "video_id": "v1"}
+    )
+    sent.assert_awaited_once_with(
+        "u1",
+        {"type": "ad_segments_ready", "data": {"video_id": "v1"}},
+    )
+
+
 async def test_dispatch_download_complete_still_works(sent):
     await _dispatch_event(
         {


### PR DESCRIPTION
## What

Closes the first-play gap in sponsor-skip. Detection is lazy: the **first** time a video is opened, the endpoint kicks off detection and returns `PENDING`, so that playback session got no segments (it only skipped on a later re-open).

Now the backend emits an **`ad_segments_ready`** WebSocket event when detection finishes, so a player already watching can fetch + apply the segments mid-playback. Since sponsor reads are rarely in the first few seconds, the BlewChew-style read still gets skipped on the first watch.

## Changes

- `progress_broadcaster.py`: `publish_ad_segments_ready(video_id, user_id)` (mirrors `publish_preview_ready`); `_dispatch_event` broadcasts `{type: "ad_segments_ready", data: {video_id}}`.
- `detect_ad_segments_task(video_id, user_id)`: publishes on success; the `/ad-segments` endpoint passes the requesting user's id when enqueuing.

## Tests

Broadcaster dispatch test for `ad_segments_ready`; endpoint test updated to assert it enqueues with the user id. **Full suite: 302 passed**, mypy + ruff clean.

## Follow-up

Clients add an `adSegmentsReady` WS handler that re-fetches `/ad-segments` and applies them to the running player (Flutter + tvOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)