### PR TITLE
feat(library): treat followed-channel episodes as invisible cache, not a collection

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -12,7 +12,7 @@ from app.database import get_db
 from app.models.channel import Channel
 from app.models.subscription import UserSubscription
 from app.models.user import User
-from app.models.user_video_ref import UserVideoRef
+from app.models.user_video_ref import REF_KIND_CACHE, UserVideoRef
 from app.models.video import Video
 from app.schemas.channel import (
     BulkSubscribeItem,
@@ -76,10 +76,16 @@ async def _ensure_refs_for_channel(
         )
     )
     refs_by_video = {ref.video_id: ref for ref in ref_result.scalars().all()}
+    # Following a channel quietly caches its episodes (so they open instantly) —
+    # it is not a user-managed "download/library". Refs are CACHE; the cache
+    # reaper leaves followed-channel videos alone (per-subscription retention
+    # bounds them instead), so they persist while subscribed.
     for video_id in video_ids:
         ref = refs_by_video.get(video_id)
         if ref is None:
-            db.add(UserVideoRef(user_id=user_id, video_id=video_id))
+            db.add(
+                UserVideoRef(user_id=user_id, video_id=video_id, kind=REF_KIND_CACHE)
+            )
         elif ref.removed_at is not None:
             ref.removed_at = None
 

--- a/app/api/feed.py
+++ b/app/api/feed.py
@@ -7,7 +7,7 @@ from app.database import get_db
 from app.models.channel import Channel
 from app.models.subscription import UserSubscription
 from app.models.user import User
-from app.models.user_video_ref import REF_KIND_LIBRARY, UserVideoRef
+from app.models.user_video_ref import UserVideoRef
 from app.models.video import Video
 from app.schemas.channel import ChannelOut
 from app.schemas.feed import FeedItem, HomeFeed
@@ -110,10 +110,8 @@ async def _new_episodes_items(
         .where(
             UserVideoRef.user_id == user.id,
             UserVideoRef.removed_at.is_(None),
-            UserVideoRef.kind == REF_KIND_LIBRARY,
             UserVideoRef.is_watched == False,  # noqa: E712
             Video.channel_id.in_(subscribed_ids),
-            Video.status == "COMPLETE",
         )
         .subquery()
     )
@@ -143,7 +141,18 @@ async def _new_episodes_items(
 async def _recently_added_items(
     user: User, db: AsyncSession, limit: int
 ) -> list[FeedItem]:
-    """Chronological list of newly downloaded videos across subscribed channels."""
+    """Most recent uploads across the user's followed channels.
+
+    Episode-based and cache-agnostic: a new upload shows here as soon as it's
+    cataloged, whether or not it has been cached yet.
+    """
+    sub_result = await db.execute(
+        select(UserSubscription.channel_id).where(UserSubscription.user_id == user.id)
+    )
+    subscribed_ids = [row[0] for row in sub_result.all()]
+    if not subscribed_ids:
+        return []
+
     result = await db.execute(
         select(UserVideoRef, Video, Channel)
         .join(Video, UserVideoRef.video_id == Video.id)
@@ -151,12 +160,11 @@ async def _recently_added_items(
         .where(
             UserVideoRef.user_id == user.id,
             UserVideoRef.removed_at.is_(None),
-            UserVideoRef.kind == REF_KIND_LIBRARY,
-            Video.status == "COMPLETE",
+            Video.channel_id.in_(subscribed_ids),
         )
         .order_by(
-            Video.downloaded_at.desc().nullslast(),
-            Video.created_at.desc(),
+            func.coalesce(Video.uploaded_at, Video.created_at).desc(),
+            Video.id.desc(),
         )
         .limit(limit)
     )

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -122,12 +122,11 @@ async def search_videos(
     """
     sort_key = func.coalesce(Video.uploaded_at, Video.created_at)
 
-    # The library grid is the user's *collection* — LIBRARY refs only. Videos
-    # held merely as a play cache never appear here.
+    # Search spans every episode the user holds (followed-channel episodes are
+    # cached, so they're CACHE refs) — not a separate "downloaded" collection.
     filters = [
         UserVideoRef.user_id == user.id,
         UserVideoRef.removed_at.is_(None),
-        UserVideoRef.kind == REF_KIND_LIBRARY,
     ]
     if q and q.strip():
         pattern = f"%{escape_like(q.strip())}%"

--- a/app/services/cache_retention.py
+++ b/app/services/cache_retention.py
@@ -24,8 +24,10 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session as DBSession
 
 from app.config import settings
+from app.models.subscription import UserSubscription
 from app.models.user_queue import UserQueue
 from app.models.user_video_ref import REF_KIND_CACHE, UserVideoRef
+from app.models.video import Video
 from app.services.storage import check_and_delete_orphan_sync
 from app.utils.time import utcnow_naive
 
@@ -33,8 +35,13 @@ logger = logging.getLogger(__name__)
 
 
 def _cache_refs_to_drop(db: DBSession, user_id: str, keep: int) -> list[UserVideoRef]:
-    """Return the user's CACHE refs to soft-remove: those beyond the newest
-    ``keep``, excluding any video pinned by the watch-later queue.
+    """Return the user's evictable CACHE refs to soft-remove: those beyond the
+    newest ``keep``, after pinning videos that must not be dropped here.
+
+    Pinned (never evicted, and excluded from the budget): videos in the user's
+    watch-later queue, and episodes of channels the user follows (those are a
+    deliberate background cache bounded per-channel by subscription retention).
+    So this LRU budget only applies to incidental cold-press cache.
 
     A negative ``keep`` disables eviction (returns nothing); ``keep == 0`` drops
     every non-pinned cache ref.
@@ -42,34 +49,43 @@ def _cache_refs_to_drop(db: DBSession, user_id: str, keep: int) -> list[UserVide
     if keep < 0:
         return []
 
-    refs = (
-        db.execute(
-            select(UserVideoRef)
-            .where(
-                UserVideoRef.user_id == user_id,
-                UserVideoRef.removed_at.is_(None),
-                UserVideoRef.kind == REF_KIND_CACHE,
-            )
-            # Most-recently-watched first; never-watched cache (last_watched_at
-            # NULL) sorts last, with added_at as a stable tiebreaker.
-            .order_by(
-                UserVideoRef.last_watched_at.desc().nullslast(),
-                UserVideoRef.added_at.desc(),
-            )
+    rows = db.execute(
+        select(UserVideoRef, Video.channel_id)
+        .join(Video, UserVideoRef.video_id == Video.id)
+        .where(
+            UserVideoRef.user_id == user_id,
+            UserVideoRef.removed_at.is_(None),
+            UserVideoRef.kind == REF_KIND_CACHE,
         )
-        .scalars()
-        .all()
-    )
+        # Most-recently-watched first; never-watched cache (last_watched_at
+        # NULL) sorts last, with added_at as a stable tiebreaker.
+        .order_by(
+            UserVideoRef.last_watched_at.desc().nullslast(),
+            UserVideoRef.added_at.desc(),
+        )
+    ).all()
 
     queued = set(
         db.execute(select(UserQueue.video_id).where(UserQueue.user_id == user_id))
         .scalars()
         .all()
     )
+    followed = set(
+        db.execute(
+            select(UserSubscription.channel_id).where(
+                UserSubscription.user_id == user_id
+            )
+        )
+        .scalars()
+        .all()
+    )
 
-    # Pinned (queued) videos are never dropped and don't consume the budget.
-    non_queued = [ref for ref in refs if ref.video_id not in queued]
-    return non_queued[keep:]
+    evictable = [
+        ref
+        for ref, channel_id in rows
+        if ref.video_id not in queued and channel_id not in followed
+    ]
+    return evictable[keep:]
 
 
 def enforce_cache_retention(db: DBSession, now: datetime | None = None) -> dict:

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from app.models.channel import Channel
 from app.models.subscription import UserSubscription
-from app.models.user_video_ref import UserVideoRef
+from app.models.user_video_ref import REF_KIND_CACHE, UserVideoRef
 from app.models.video import Video
 from app.services.download_manager import (
     fetch_channel_images,
@@ -634,7 +634,13 @@ def _ensure_user_refs_bulk(video_ids: list[str], channel_id: str, db: Session) -
         ).all()
     )
 
+    # New episodes of followed channels are cached quietly for subscribers (they
+    # will likely open them) — a background prefetch, not a visible download.
     for user_id in subscriber_ids:
         for video_id in unique_video_ids:
             if (user_id, video_id) not in existing_pairs:
-                db.add(UserVideoRef(user_id=user_id, video_id=video_id))
+                db.add(
+                    UserVideoRef(
+                        user_id=user_id, video_id=video_id, kind=REF_KIND_CACHE
+                    )
+                )

--- a/app/services/retention.py
+++ b/app/services/retention.py
@@ -26,7 +26,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session as DBSession
 
 from app.models.subscription import UserSubscription
-from app.models.user_video_ref import REF_KIND_LIBRARY, UserVideoRef
+from app.models.user_video_ref import REF_KIND_CACHE, UserVideoRef
 from app.models.video import Video
 from app.services.storage import check_and_delete_orphan_sync
 from app.utils.time import utcnow_naive
@@ -70,9 +70,11 @@ def _refs_to_drop_for_subscription(
                     Video.status == "COMPLETE",
                     UserVideoRef.user_id == sub.user_id,
                     UserVideoRef.removed_at.is_(None),
-                    # Subscription retention governs the collection only; cache
-                    # refs are evicted separately by the cache reaper.
-                    UserVideoRef.kind == REF_KIND_LIBRARY,
+                    # Followed-channel episodes are cached (CACHE refs). This is
+                    # where their disk use is bounded per channel; the global
+                    # cache reaper deliberately leaves followed-channel videos to
+                    # this policy and only evicts cold-press cache.
+                    UserVideoRef.kind == REF_KIND_CACHE,
                 )
                 .order_by(
                     func.coalesce(Video.uploaded_at, Video.created_at).desc(),

--- a/tests/test_cache_refs.py
+++ b/tests/test_cache_refs.py
@@ -129,20 +129,22 @@ async def test_download_promotes_cache_ref_to_library(
     assert ref.kind == REF_KIND_LIBRARY
 
 
-async def test_library_grid_excludes_cache_refs(client, make_user):
+async def test_library_grid_includes_cached_episodes(client, make_user):
+    """Search/library spans the user's episodes regardless of how they're held —
+    followed-channel episodes are cached, not a separate 'downloads' collection."""
     user, headers = await make_user()
     async with async_session_factory() as db:
         channel = await seed_channel(db)
-        lib = await seed_video(db, channel, status="COMPLETE", title="Lib")
         cached = await seed_video(db, channel, status="COMPLETE", title="Cached")
-        await seed_ref(db, user["id"], lib.id, kind=REF_KIND_LIBRARY)
+        other = await seed_video(db, channel, status="COMPLETE", title="Other")
         await seed_ref(db, user["id"], cached.id, kind=REF_KIND_CACHE)
+        await seed_ref(db, user["id"], other.id, kind=REF_KIND_LIBRARY)
 
     resp = await client.get("/api/videos", headers=headers)
     assert resp.status_code == 200
     ids = {item["id"] for item in resp.json()["items"]}
-    assert lib.id in ids
-    assert cached.id not in ids
+    assert cached.id in ids
+    assert other.id in ids
 
 
 async def test_downloads_list_excludes_cache(client, make_user):

--- a/tests/test_cache_retention.py
+++ b/tests/test_cache_retention.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import sessionmaker
 
 from app.config import settings
 from app.models import Base
+from app.models.subscription import UserSubscription
 from app.models.user_queue import UserQueue
 from app.models.user_video_ref import (
     REF_KIND_CACHE,
@@ -43,16 +44,16 @@ def _abs_media(rel_path: str) -> str:
     return os.path.join(settings.media_path, rel_path)
 
 
-def _seed_downloaded_video(db) -> Video:
+def _seed_downloaded_video(db, channel_id: str = CHANNEL_ID) -> Video:
     vid_id = str(uuid.uuid4())
     yt_id = f"yt{uuid.uuid4().hex[:9]}"
-    rel_path = f"{CHANNEL_ID}/{vid_id}.mp4"
+    rel_path = f"{channel_id}/{vid_id}.mp4"
     _write(_abs_media(rel_path))
     _write(os.path.join(settings.thumbnails_path, f"{yt_id}.jpg"), b"thumb")
     video = Video(
         id=vid_id,
         youtube_video_id=yt_id,
-        channel_id=CHANNEL_ID,
+        channel_id=channel_id,
         title="V",
         status="COMPLETE",
         file_path=rel_path,
@@ -175,4 +176,29 @@ def test_shared_cache_not_reclaimed_while_another_ref_active(monkeypatch):
     assert _ref(db, "u1", v.id).removed_at is not None
     assert _ref(db, "u2", v.id).removed_at is None
     assert os.path.exists(_abs_media(v.file_path))  # shared file survives
+    db.close()
+
+
+def test_followed_channel_cache_is_pinned(monkeypatch):
+    """Followed-channel episodes are pinned in the global reaper (their disk use
+    is bounded per-channel by subscription retention instead); only incidental
+    cold-press cache for unfollowed channels is LRU-evicted."""
+    monkeypatch.setattr(settings, "cache_retention_count", 0)  # evict all non-pinned
+    db = _make_db()
+    followed = _seed_downloaded_video(db, channel_id="chan-followed")
+    cold = _seed_downloaded_video(db, channel_id="chan-cold")
+    _seed_ref(db, "u1", followed.id, REF_KIND_CACHE)
+    _seed_ref(db, "u1", cold.id, REF_KIND_CACHE)
+    db.add(
+        UserSubscription(
+            user_id="u1", channel_id="chan-followed", retention_policy="KEEP_ALL"
+        )
+    )
+    db.commit()
+
+    enforce_cache_retention(db)
+
+    assert _ref(db, "u1", followed.id).removed_at is None
+    assert _ref(db, "u1", cold.id).removed_at is not None
+    assert os.path.exists(_abs_media(followed.file_path))
     db.close()

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -40,27 +40,26 @@ async def test_continue_watching_ordered_by_last_watched(client, make_user):
     assert [item["video"]["id"] for item in items] == [video_b.id, video_a.id]
 
 
-async def test_recently_added_ordered_by_downloaded_at(client, make_user):
+async def test_recently_added_shows_uploads_regardless_of_cache(client, make_user):
+    """Recent uploads from followed channels, newest-upload first — cache-
+    agnostic: a not-yet-cached (CATALOGED) upload still appears."""
     user, headers = await make_user()
     now = utcnow_naive()
     async with async_session_factory() as db:
         channel = await seed_channel(db)
-        old = await seed_video(
-            db,
-            channel,
-            status="COMPLETE",
-            downloaded_at=now - timedelta(days=1),
+        await seed_subscription(db, user["id"], channel.id)
+        older = await seed_video(
+            db, channel, status="COMPLETE", uploaded_at=now - timedelta(days=1)
         )
-        new = await seed_video(db, channel, status="COMPLETE", downloaded_at=now)
-        # Legacy row without downloaded_at sorts last (NULLS LAST).
-        legacy = await seed_video(db, channel, status="COMPLETE")
-        for video in (old, new, legacy):
+        # Newest upload, not cached yet — still shows, and sorts first by upload.
+        newest = await seed_video(db, channel, status="CATALOGED", uploaded_at=now)
+        for video in (older, newest):
             await seed_ref(db, user["id"], video.id)
 
     resp = await client.get("/api/feed/recently-added", headers=headers)
     assert resp.status_code == 200
-    items = resp.json()
-    assert [item["video"]["id"] for item in items] == [new.id, old.id, legacy.id]
+    ids = [item["video"]["id"] for item in resp.json()]
+    assert ids == [newest.id, older.id]
 
 
 async def test_home_feed_aggregates_all_sections(client, make_user):
@@ -143,10 +142,10 @@ async def test_new_episodes_newest_per_channel_and_bounded_by_limit(client, make
     assert channel_ids == [channels[i].id for i in range(limit)]
 
 
-async def test_new_episodes_ranks_only_unwatched_complete_in_channel(client, make_user):
-    """The window-function ranking runs over the filtered set, so a channel's
-    newest *eligible* video wins even when more-recent uploads are watched,
-    removed, or still downloading."""
+async def test_new_episodes_ranks_newest_unwatched_cache_agnostic(client, make_user):
+    """The window-function ranking picks each channel's newest unwatched, present
+    episode — regardless of whether it's been cached yet (download status is
+    invisible here). Watched and removed episodes are still excluded."""
     user, headers = await make_user()
     now = utcnow_naive()
     async with async_session_factory() as db:
@@ -160,17 +159,14 @@ async def test_new_episodes_ranks_only_unwatched_complete_in_channel(client, mak
             db, channel, status="COMPLETE", uploaded_at=now - timedelta(hours=1)
         )
         await seed_ref(db, user["id"], removed.id, removed_at=now)
-        downloading = await seed_video(
-            db, channel, status="DOWNLOADING", uploaded_at=now - timedelta(hours=2)
-        )
-        await seed_ref(db, user["id"], downloading.id)
 
-        # The newest video that is unwatched, present, and COMPLETE.
+        # The newest unwatched, present episode — NOT cached yet (CATALOGED),
+        # but it still wins because download status no longer gates the feed.
         answer = await seed_video(
-            db, channel, status="COMPLETE", uploaded_at=now - timedelta(hours=3)
+            db, channel, status="CATALOGED", uploaded_at=now - timedelta(hours=2)
         )
         await seed_ref(db, user["id"], answer.id)
-        # An older COMPLETE/unwatched video must lose to ``answer``.
+        # An older unwatched episode must lose to ``answer``.
         await seed_ref(
             db,
             user["id"],
@@ -179,7 +175,7 @@ async def test_new_episodes_ranks_only_unwatched_complete_in_channel(client, mak
                     db,
                     channel,
                     status="COMPLETE",
-                    uploaded_at=now - timedelta(hours=4),
+                    uploaded_at=now - timedelta(hours=3),
                 )
             ).id,
         )

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import sessionmaker
 from app.config import settings
 from app.models import Base
 from app.models.subscription import UserSubscription
-from app.models.user_video_ref import UserVideoRef
+from app.models.user_video_ref import REF_KIND_CACHE, UserVideoRef
 from app.models.video import Video
 from app.services.retention import KEEP_ALL, KEEP_LAST_N, enforce_retention
 from app.utils.time import utcnow_naive
@@ -83,7 +83,9 @@ def _seed_cataloged_video(db, channel_id: str = CHANNEL_ID):
 
 
 def _seed_ref(db, user_id: str, video_id: str) -> None:
-    db.add(UserVideoRef(user_id=user_id, video_id=video_id))
+    # Followed-channel episodes are cached (CACHE refs); per-subscription
+    # retention bounds those.
+    db.add(UserVideoRef(user_id=user_id, video_id=video_id, kind=REF_KIND_CACHE))
     db.commit()
 
 


### PR DESCRIPTION
## What

Reframes downloads per the product model: **following a channel quietly caches its episodes** (so they open instantly) — it is *not* a user-managed "download/library" collection, and new episodes are **prefetched in the background** without the user noticing. The only deliberate per-video save remains "save offline" (client-side, on device).

This walks back the part of #86 that made subscription auto-downloads a visible LIBRARY collection.

## Changes

- **Subscription + new-episode refs → CACHE** (`channels._ensure_refs_for_channel`, `channel_poller._ensure_user_refs_bulk`). Following / new episodes are a quiet prefetch.
- **Feeds are episode/recency-based and cache-agnostic:** `new-episodes` and `recently-added` no longer gate on `status == COMPLETE` or `kind == LIBRARY`, so an upload appears the moment it's cataloged (while it caches in the background). `recently-added` is scoped to followed channels and ordered by upload recency. **Search** spans every episode the user holds, regardless of kind.
- **Eviction split** so caching stays invisible *and* bounded:
  - per-subscription retention (`KEEP_LAST_N`) now bounds **followed-channel CACHE** per channel (`retention.py`);
  - the global cache reaper **pins followed-channel videos** (and watch-later-queued ones) and only LRU-evicts incidental **cold-press** cache (`cache_retention.py`).

## Tests

Updated feed/search/retention tests for the new cache-agnostic behavior; added a reaper test that followed-channel cache is pinned while cold-press cache is evicted. **303 passed**, mypy + ruff clean.

## Follow-up (clients)

Remove the "Download to server" action, make the Downloads tab "Saved offline" only, and hide download/caching status badges (Flutter + tvOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)