### PR TITLE
feat(serve): bake the Flutter web app into the image and serve it at /

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          # Backend-only target: per-PR CI skips the (slow) Flutter web build.
+          # The web bundle is validated by the flutter repo's own Build Web CI;
+          # the full image with web is assembled at release (docker-publish).
+          target: runtime
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,6 +45,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          # Full image: backend + the Flutter web app baked in and served at /.
+          target: web
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Flutter SDK version + repo ref for the web-bundle build stage (see `webbuild`).
+ARG FLUTTER_VERSION=3.41.2
+ARG FLUTTER_WEB_REF=main
+
 FROM python:3.12-slim AS builder
 
 WORKDIR /build
@@ -6,7 +10,25 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 
 # ---------------------------------------------------------------------------
-FROM python:3.12-slim
+# Build the Flutter web bundle from the (public) flutter repo. Only the final
+# `web` image pulls this in, so the backend-only `runtime` target skips it.
+# The bundle's correctness is already gated by the flutter repo's own Build Web
+# CI on every PR, so this stage just packages main.
+# Pinned to the native build platform: the web bundle is arch-independent, so we
+# build it once (not once per target arch) and avoid emulating Flutter on arm64.
+FROM --platform=$BUILDPLATFORM ghcr.io/cirruslabs/flutter:${FLUTTER_VERSION} AS webbuild
+ARG FLUTTER_WEB_REF
+WORKDIR /src
+RUN git clone --depth 1 --branch ${FLUTTER_WEB_REF} \
+        https://github.com/windoze95/nullfeed-flutter.git . && \
+    git config --global --add safe.directory /src && \
+    flutter pub get && \
+    dart run build_runner build --delete-conflicting-outputs && \
+    flutter build web --release --no-tree-shake-icons
+
+# ---------------------------------------------------------------------------
+# Backend runtime (no web bundle). This is the fast per-PR CI target.
+FROM python:3.12-slim AS runtime
 
 LABEL maintainer="NullFeed" \
       description="NullFeed - Self-Hosted YouTube Media Center Backend"
@@ -42,3 +64,9 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -f http://localhost:${TUBEVAULT_PORT:-8484}/api/health || exit 1
 
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]
+
+# ---------------------------------------------------------------------------
+# Published image: the backend with the Flutter web app baked in and served at
+# `/` (see app/main.py). This is the default build target.
+FROM runtime AS web
+COPY --from=webbuild /src/build/web /app/web

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ NullFeed is a self-hosted YouTube media center that wraps **yt-dlp** with a poli
 - **Invisible Caching, Not a Collection** -- Following a channel quietly caches its new uploads in the background (configurable polling interval), and cold-pressed videos cache too. Cached content is reference-counted and bounded automatically -- LRU eviction for incidental cold-press cache, per-subscription retention for followed channels -- so there's no user-managed "download" collection to babysit.
 - **Download/Cache Manager** -- Celery-based task queue with configurable concurrency, retry logic, and exponential backoff.
 - **Media Streaming** -- Built-in static file server with HTTP range request support for native seeking and scrubbing.
+- **Built-in Web App** -- The published Docker image bakes in the Flutter web client and serves it at `/`, so a single URL gives you both the app and the API (`/docs`) -- no separate web host needed.
 - **Multi-User Support** -- Independent profiles with per-user subscriptions, watch history, and playback positions.
 - **Smart Deduplication** -- One copy of each video on disk, reference-counted across all subscribing users.
 - **AI Recommendations** -- Claude-powered channel and video suggestions derived from each user's subscription graph via the Anthropic API.
@@ -91,9 +92,9 @@ NullFeed is a self-hosted YouTube media center that wraps **yt-dlp** with a poli
    curl http://localhost:8484/api/health
    ```
 
-5. **Explore the API docs:**
+5. **Open the app / API docs:**
 
-   Open [http://localhost:8484/docs](http://localhost:8484/docs) in your browser for the interactive Swagger UI.
+   The published image serves the **web app** at [http://localhost:8484/](http://localhost:8484/), and the interactive API docs (Swagger UI) at [http://localhost:8484/docs](http://localhost:8484/docs).
 
 ---
 

--- a/app/main.py
+++ b/app/main.py
@@ -127,6 +127,15 @@ app.include_router(push.router)
 app.include_router(websub.router)
 
 
+# Serve the Flutter web app, baked into the image at /app/web by the Dockerfile's
+# `web` stage. Mounted last (after the API/WS routers, the thumbnail mount, and
+# the auto-docs) so those take precedence; the catch-all only handles the SPA
+# shell + its assets. Absent in plain backend/dev builds, so guard on the dir.
+_web_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "web")
+if os.path.isdir(_web_dir):
+    app.mount("/", StaticFiles(directory=_web_dir, html=True), name="web")
+
+
 # ---------------------------------------------------------------------------
 # Normalized error envelope (#3)
 #


### PR DESCRIPTION
## What

The published Docker image now ships the **Flutter web client**, served at `/`. One self-hosted URL gives you both the app (`/`) and the API (`/api`, `/docs`) — no separate web host.

## Changes

- **`Dockerfile`** — new `webbuild` stage builds the web bundle from the public flutter repo (`--platform=$BUILDPLATFORM` so it builds **once**, not once per arch, and never under arm64 emulation). `runtime` is the backend-only image; the default **`web`** stage = `runtime` + the bundle at `/app/web`. Configurable via `FLUTTER_VERSION` / `FLUTTER_WEB_REF` build args.
- **`app/main.py`** — mounts the bundle at `/` via `StaticFiles(html=True)`, **after** the API/WS/thumbnail routes and the auto-docs (so those win), guarded on the directory so plain backend/dev runs are unaffected. (Hash routing means no SPA catch-all is needed.)
- **CI** — per-PR Docker Build targets **`runtime`** (fast, no Flutter clone); `docker-publish` (on `v*` tags) builds **`web`**. The bundle's correctness is already gated by the flutter repo's Build Web CI, so it isn't rebuilt on every backend PR.

## Validated locally

`docker build --target web` succeeds end-to-end (git clone → `build_runner` → `flutter build web` → COPY). In the built image: `/app/web/index.html` + a 3.4 MB `main.dart.js` are present, the FastAPI **`web` mount registers**, and `/api/*` routes remain. (`cirruslabs/flutter:3.41.2` confirmed to have both amd64 + arm64.)

## Result

Deploying the next tagged release → visiting `http://<server>:8484/` loads the app (with the desktop NavigationRail on wide screens), and the riskiest web unknown — live playback against the real backend — becomes testable on your own server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)