### PR TITLE
fix(instant-stream): cap time-to-first-byte so the player can't hang

### DIFF
--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -17,6 +17,7 @@ just makes the instant tier instant. Resolved URLs are cached briefly (they
 carry a multi-hour ``expire``), so repeat presses skip the resolve entirely.
 """
 
+import asyncio
 import logging
 import subprocess
 import threading
@@ -43,6 +44,13 @@ _PROGRESSIVE_FORMAT = (
 # download, so it should be quick; keep it tight so a wedged extract surfaces as
 # a 502 fast instead of hanging the player on a spinner.
 _RESOLVE_TIMEOUT_SECONDS = 30
+
+# Cap on time-to-first-byte from the upstream source. The body stream itself is
+# left untimed (``read=None``) so long playback isn't interrupted, but a source
+# that accepts the connection and then stalls before sending the response must
+# NOT hang the request forever — that's what leaves the player spinning on
+# "Preparing your video…". Surface it as a 502 so the client falls back.
+_FIRST_BYTE_TIMEOUT_SECONDS = 20
 
 # Fallback cache TTL when the source URL has no parseable ``expire``. Source
 # URLs typically last ~6h; we re-resolve well before that.
@@ -167,8 +175,11 @@ async def stream_proxy(url: str, range_header: str | None) -> StreamingResponse:
     client = _make_client()
     try:
         request = client.build_request("GET", url, headers=req_headers)
-        upstream = await client.send(request, stream=True)
-    except httpx.HTTPError as exc:
+        # Bound time-to-first-byte only; the body generator below streams
+        # untimed so long playback isn't cut off.
+        async with asyncio.timeout(_FIRST_BYTE_TIMEOUT_SECONDS):
+            upstream = await client.send(request, stream=True)
+    except (httpx.HTTPError, TimeoutError) as exc:
         await client.aclose()
         raise InstantStreamError(f"Upstream fetch failed: {exc}") from exc
 

--- a/tests/test_instant_stream.py
+++ b/tests/test_instant_stream.py
@@ -1,5 +1,6 @@
 """Instant-start playback: progressive-URL resolve cache + reverse proxy (#85)."""
 
+import asyncio
 import os
 
 import httpx
@@ -142,6 +143,33 @@ async def test_instant_stream_resolve_failure_502(client, make_user, monkeypatch
         raise InstantStreamError("resolve failed")
 
     monkeypatch.setattr(videos_api, "resolve_progressive_url", boom)
+
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
+    assert resp.status_code == 502
+
+
+async def test_instant_stream_first_byte_timeout_502(client, make_user, monkeypatch):
+    """A source that accepts the connection then stalls before responding is a
+    502 (so the client falls back), not an indefinite hang on the spinner."""
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    monkeypatch.setattr(
+        videos_api, "resolve_progressive_url", lambda vid: "https://upstream.test/v.mp4"
+    )
+    monkeypatch.setattr(instant_stream, "_FIRST_BYTE_TIMEOUT_SECONDS", 0.05)
+
+    async def stalled(request: httpx.Request) -> httpx.Response:
+        await asyncio.sleep(1)  # never sends within the first-byte budget
+        return httpx.Response(200, content=b"")
+
+    monkeypatch.setattr(
+        instant_stream,
+        "_make_client",
+        lambda: httpx.AsyncClient(transport=httpx.MockTransport(stalled)),
+    )
 
     resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
     assert resp.status_code == 502


### PR DESCRIPTION
## Bug

Tapping some episodes (e.g. a long Kill Tony) **sometimes just spins on "Preparing your video…"** forever.

## Root cause

The instant-stream proxy intentionally disables the read timeout (`read=None`) so a long playback isn't cut off — but that also left the **initial** upstream fetch untimed. If the source accepts the TCP connection and then stalls *before sending the response*, `await client.send(...)` hangs indefinitely → the endpoint never responds → the client's `controller.initialize()` never returns → infinite spinner. (`yt-dlp` resolve already had a timeout; this is the proxy's first-byte gap.)

## Fix

Wrap **only** the initial `client.send` in `asyncio.timeout(20s)` (`_FIRST_BYTE_TIMEOUT_SECONDS`). On a stall it raises `InstantStreamError` → **502**, so the client falls back to the preview path instead of hanging. The body generator stays untimed, so legitimate long playback is unaffected.

Paired with the client-side init timeout in windoze95/nullfeed-flutter#58.

## Test

`test_instant_stream_first_byte_timeout_502` — a mock upstream that sleeps past the (patched-small) budget returns 502. Full instant-stream suite: 8 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)