### PR TITLE
chore: set backend version to 0.1.0 (pre-release)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -93,7 +93,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 app = FastAPI(
     title="NullFeed",
     description="Self-Hosted YouTube Media Center API",
-    version="1.0.0",
+    version="0.1.0",
     lifespan=lifespan,
 )
 
@@ -205,4 +205,4 @@ async def _http_exception_handler(
 
 @app.get("/")
 async def root() -> dict:
-    return {"service": "NullFeed", "version": "1.0.0", "docs": "/docs"}
+    return {"service": "NullFeed", "version": "0.1.0", "docs": "/docs"}


### PR DESCRIPTION
NullFeed is pre-release — nothing should self-report 1.0.0. The backend's FastAPI `version` and the `GET /` response said `1.0.0`; set both to **0.1.0** to match the clients (flutter `pubspec` and tvOS `MARKETING_VERSION` are already `0.1.0`).

304 tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)