### PR TITLE
fix(ytdlp): authenticate with a cookies file so age-restricted videos play

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ DOWNLOAD_CONCURRENCY=2
 # Default download quality: 720p | 1080p | 4k | best
 MEDIA_QUALITY=1080p
 
+# Path to a cookies.txt (logged-in YouTube session) so yt-dlp can play
+# age-restricted / members-only videos. Defaults to <config>/cookies.txt if
+# present, so this is optional. See the README "Age-restricted videos" section.
+YOUTUBE_COOKIES_FILE=
+
 # Adaptive channel polling.
 # The scheduler wakes every CHECK_INTERVAL_MINUTES and polls only the channels
 # that are due. Each channel's interval adapts within the floor/cap below: it

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ NullFeed is a self-hosted YouTube media center that wraps **yt-dlp** with a poli
 | `ANTHROPIC_API_KEY`      | _(none)_  | Anthropic API key for AI recommendations (Discover tab)  |
 | `DOWNLOAD_CONCURRENCY`   | `2`       | Max simultaneous yt-dlp downloads                        |
 | `MEDIA_QUALITY`          | `1080p`   | Default download quality (`720p` / `1080p` / `4k` / `best`) |
+| `YOUTUBE_COOKIES_FILE`   | _(auto)_  | Path to a `cookies.txt` so yt-dlp can play **age-restricted / members-only** videos. Defaults to `<config>/cookies.txt` if present. See [Age-restricted videos](#age-restricted-videos). |
 | `CHECK_INTERVAL_MINUTES` | `60`      | How often to poll subscribed channels for new uploads    |
 | `PUID`                   | `1000`    | User ID for file permissions (Unraid standard)           |
 | `PGID`                   | `1000`    | Group ID for file permissions (Unraid standard)          |
@@ -122,6 +123,27 @@ NullFeed is a self-hosted YouTube media center that wraps **yt-dlp** with a poli
 | `/data/db`         | SQLite database + migrations     | `/mnt/user/appdata/nullfeed/db`         |
 | `/data/config`     | App configuration, API keys      | `/mnt/user/appdata/nullfeed/config`     |
 | `/data/thumbnails` | Cached channel art and thumbnails| `/mnt/user/appdata/nullfeed/thumbs`     |
+
+---
+
+## Age-restricted videos
+
+YouTube blocks extraction of **age-restricted and members-only** videos for
+anonymous requests ("Sign in to confirm your age"). Since the backend uses
+`yt-dlp` for streaming, previews, and downloads, those videos won't play unless
+yt-dlp is authenticated with your YouTube cookies.
+
+To enable them:
+
+1. Export a `cookies.txt` from a browser **logged in to YouTube** (e.g. the
+   "Get cookies.txt LOCALLY" extension, in Netscape format). Use a throwaway
+   account if you'd rather not use your main one.
+2. Drop it at **`/data/config/cookies.txt`** (auto-detected), or set
+   `YOUTUBE_COOKIES_FILE` to a custom path.
+3. Restart the container.
+
+Notes: cookies expire and YouTube rotates them, so you may need to refresh the
+file occasionally; yt-dlp updates the file in place, so it must be writable.
 
 ---
 

--- a/app/config.py
+++ b/app/config.py
@@ -16,6 +16,11 @@ class Settings(BaseSettings):
     catalog_fetch_count: int = 50
     download_concurrency: int = 2
     media_quality: str = "1080p"
+    # Path to a Netflix-style cookies.txt exported from a logged-in YouTube
+    # session. Required for age-restricted / members-only videos (yt-dlp can't
+    # extract them otherwise — "Sign in to confirm your age"). Empty falls back
+    # to <config_path>/cookies.txt if that file exists.
+    youtube_cookies_file: str = ""
     metadata_refresh_interval_hours: int = 12
 
     # Polling cadence (adaptive, per channel).

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 import httpx
 
 from app.config import settings
+from app.utils.ytdlp import cookie_args
 
 logger = logging.getLogger(__name__)
 
@@ -168,6 +169,7 @@ def download_video(
 
     cmd = [
         "yt-dlp",
+        *cookie_args(),
         "--format",
         format_str,
         "--merge-output-format",
@@ -318,6 +320,7 @@ def download_preview(
 
     cmd = [
         "yt-dlp",
+        *cookie_args(),
         "--format",
         format_str,
         "--output",
@@ -376,6 +379,7 @@ def fetch_transcript(youtube_video_id: str) -> list[dict] | None:
         output_template = os.path.join(tmp, "%(id)s.%(ext)s")
         cmd = [
             "yt-dlp",
+            *cookie_args(),
             "--skip-download",
             "--write-auto-subs",
             "--write-subs",

--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -27,6 +27,8 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 from fastapi.responses import StreamingResponse
 
+from app.utils.ytdlp import cookie_args
+
 logger = logging.getLogger(__name__)
 
 # Progressive (muxed) selectors only — a single file AVPlayer / video_player can
@@ -88,6 +90,7 @@ def _ytdlp_get_url(youtube_video_id: str) -> str:
     url = f"https://www.youtube.com/watch?v={youtube_video_id}"
     cmd = [
         "yt-dlp",
+        *cookie_args(),
         "--format",
         _PROGRESSIVE_FORMAT,
         "--get-url",

--- a/app/services/youtube_import.py
+++ b/app/services/youtube_import.py
@@ -12,6 +12,8 @@ import subprocess
 import time
 from typing import Any
 
+from app.utils.ytdlp import cookie_args
+
 logger = logging.getLogger(__name__)
 
 CACHE_TTL_SECONDS = 3600
@@ -89,7 +91,15 @@ def _run_yt_dlp_json(url: str, extra_args: list[str], timeout: int) -> dict[str,
     Blocking; callers run this via asyncio.to_thread. Always passes
     --no-update so the version nag never pollutes stderr.
     """
-    cmd = ["yt-dlp", "--no-update", "--flat-playlist", *extra_args, "-J", url]
+    cmd = [
+        "yt-dlp",
+        *cookie_args(),
+        "--no-update",
+        "--flat-playlist",
+        *extra_args,
+        "-J",
+        url,
+    ]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:

--- a/app/utils/ytdlp.py
+++ b/app/utils/ytdlp.py
@@ -1,0 +1,34 @@
+"""Shared yt-dlp invocation helpers.
+
+The key one is :func:`cookie_args`: every yt-dlp call (resolve, download, preview,
+transcript, channel import) splices these in so a configured YouTube cookies file
+authenticates the request. Without it, age-restricted / members-only videos fail
+extraction entirely ("Sign in to confirm your age"), so none of the playback
+paths work for them.
+"""
+
+import os
+
+from app.config import settings
+
+
+def cookies_path() -> str | None:
+    """Resolve the YouTube cookies file path, or None if none is present.
+
+    Uses ``settings.youtube_cookies_file`` when set, otherwise the conventional
+    ``<config_path>/cookies.txt`` (so dropping the file into the config volume is
+    enough). Returns None when the resolved path doesn't exist on disk.
+    """
+    candidate = settings.youtube_cookies_file or os.path.join(
+        settings.config_path, "cookies.txt"
+    )
+    return candidate if candidate and os.path.isfile(candidate) else None
+
+
+def cookie_args() -> list[str]:
+    """``["--cookies", <path>]`` when a cookies file is present, else ``[]``.
+
+    Splice right after ``"yt-dlp"`` in any command list.
+    """
+    path = cookies_path()
+    return ["--cookies", path] if path else []

--- a/tests/test_ytdlp_cookies.py
+++ b/tests/test_ytdlp_cookies.py
@@ -1,0 +1,54 @@
+"""YouTube cookies for yt-dlp (age-restricted / members-only auth)."""
+
+import app.services.instant_stream as instant_stream
+import app.utils.ytdlp as ytdlp
+from app.config import settings
+
+
+def test_cookie_args_empty_when_no_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "youtube_cookies_file", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))  # no cookies.txt here
+    assert ytdlp.cookie_args() == []
+
+
+def test_cookie_args_uses_explicit_path(monkeypatch, tmp_path):
+    cookies = tmp_path / "my-cookies.txt"
+    cookies.write_text("# Netscape HTTP Cookie File\n")
+    monkeypatch.setattr(settings, "youtube_cookies_file", str(cookies))
+    assert ytdlp.cookie_args() == ["--cookies", str(cookies)]
+
+
+def test_cookie_args_falls_back_to_config_dir(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "youtube_cookies_file", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+    (tmp_path / "cookies.txt").write_text("# cookies\n")
+    assert ytdlp.cookie_args() == ["--cookies", str(tmp_path / "cookies.txt")]
+
+
+def test_cookie_args_missing_explicit_path_is_empty(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "youtube_cookies_file", str(tmp_path / "nope.txt"))
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+    assert ytdlp.cookie_args() == []
+
+
+def test_resolve_command_includes_cookies(monkeypatch):
+    """The instant-stream resolve splices the cookie args into the yt-dlp call."""
+    captured: dict = {}
+
+    class _Result:
+        returncode = 0
+        stdout = "https://upstream.test/v.mp4\n"
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _Result()
+
+    monkeypatch.setattr(instant_stream, "cookie_args", lambda: ["--cookies", "/c.txt"])
+    monkeypatch.setattr(instant_stream.subprocess, "run", fake_run)
+    instant_stream._resolve_cache.clear()
+
+    url = instant_stream.resolve_progressive_url("vid-123")
+
+    assert url == "https://upstream.test/v.mp4"
+    assert captured["cmd"][:3] == ["yt-dlp", "--cookies", "/c.txt"]


### PR DESCRIPTION
## The real root cause

Some episodes (e.g. **Kill Tony #771**) wouldn't play — not a timeout/format issue. They're **age-restricted**. `yt-dlp` can't extract age-restricted/members-only videos anonymously (`ERROR: Sign in to confirm your age`), so *every* backend path that shells out to yt-dlp fails: instant-stream resolve, preview generation, HQ download, and transcript.

Reproduced directly against YouTube with the backend's exact resolve command:
- #770 (`Rr9Dk72tdMI`) → resolves a `googlevideo` URL ✅
- #772 (`ns-FD_AnYCc`) → resolves ✅
- **#771 (`vyKU6Pd5KAA`) → `ERROR: [youtube] … Sign in to confirm your age` ❌**

That's the "sometimes": the raunchier episodes get age-flagged.

## Fix

Splice `--cookies <file>` into **every** yt-dlp call (resolve, download, preview, transcript, channel import) when a cookies file is present — the standard yt-dlp solution for age-gated content.

- New `YOUTUBE_COOKIES_FILE` setting; defaults to **`<config>/cookies.txt`** if present (drop-in via the config volume), overridable.
- Centralized in `app/utils/ytdlp.cookie_args()`.
- **Zero regression** when no cookies file exists: the commands are unchanged.

The user provides their own `cookies.txt` (exported from a logged-in YouTube session) — README adds an **Age-restricted videos** section with the steps.

## Tests

`test_ytdlp_cookies.py` — helper resolution (explicit path / config-dir fallback / absent) + that the instant-stream resolve command includes the cookie args. **309 passed**, ruff + mypy clean.

> Note: I can't fully verify the bypass here (no YouTube login in this environment), but the diagnosis is definitive and `--cookies` is the documented fix. Once a `cookies.txt` is mounted, #771 will extract like any other video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)