### PR TITLE
feat(settings): manage YouTube cookies in-app (no filesystem fiddling)

### DIFF
--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -1,0 +1,65 @@
+"""Admin settings: in-app YouTube cookie management.
+
+Lets an admin paste a cookies.txt from the app so age-restricted / members-only
+videos can be extracted, without hand-placing a file on the server. Stored via
+``app/utils/ytdlp`` (hot-reloaded on the next yt-dlp call).
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from app.api.auth import get_current_user
+from app.models.user import User
+from app.utils.ytdlp import clear_cookies, cookies_status, save_cookies
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/settings", tags=["settings"])
+
+
+def _require_admin(user: User) -> None:
+    if not user.is_admin:
+        raise HTTPException(status_code=403, detail="Admin only")
+
+
+class YoutubeCookiesIn(BaseModel):
+    cookies: str = Field(..., min_length=1, max_length=1_000_000)
+
+
+@router.get("/youtube-cookies")
+async def get_youtube_cookies(user: User = Depends(get_current_user)) -> dict:
+    """Whether cookies are set, when, and whether they look expired."""
+    _require_admin(user)
+    return cookies_status()
+
+
+@router.put("/youtube-cookies")
+async def put_youtube_cookies(
+    body: YoutubeCookiesIn, user: User = Depends(get_current_user)
+) -> dict:
+    """Store a pasted cookies.txt (Netscape format)."""
+    _require_admin(user)
+    content = body.cookies.strip()
+    # Light sanity check so an obviously-wrong paste fails clearly rather than
+    # silently breaking every extraction. A cookies.txt is tab-separated and/or
+    # carries the standard Netscape header.
+    if "\t" not in content and "# Netscape" not in content and "# HTTP" not in content:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "That doesn't look like a cookies.txt — export it in Netscape "
+                "format (e.g. the 'Get cookies.txt LOCALLY' browser extension)."
+            ),
+        )
+    save_cookies(content + "\n")
+    logger.info("YouTube cookies updated by admin %s", user.id)
+    return cookies_status()
+
+
+@router.delete("/youtube-cookies")
+async def delete_youtube_cookies(user: User = Depends(get_current_user)) -> dict:
+    """Remove the stored cookies."""
+    _require_admin(user)
+    clear_cookies()
+    return cookies_status()

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from app.api import (
     websub,
     youtube,
 )
+from app.api import settings as settings_api
 from app.config import settings
 from app.services.progress_broadcaster import start_progress_listener
 
@@ -125,6 +126,7 @@ app.include_router(websocket.router)
 app.include_router(youtube.router)
 app.include_router(push.router)
 app.include_router(websub.router)
+app.include_router(settings_api.router)
 
 
 # Serve the Flutter web app, baked into the image at /app/web by the Dockerfile's

--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -27,7 +27,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 from fastapi.responses import StreamingResponse
 
-from app.utils.ytdlp import cookie_args
+from app.utils.ytdlp import cookie_args, note_extraction_error
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +106,10 @@ def _ytdlp_get_url(youtube_video_id: str) -> str:
         raise InstantStreamError(f"Resolve timed out for {youtube_video_id}") from exc
 
     if result.returncode != 0:
-        tail = (result.stderr or result.stdout or "").strip().splitlines()[-1:]
+        stderr = result.stderr or result.stdout or ""
+        # Flag cookies as likely-expired if this was an age gate despite cookies.
+        note_extraction_error(stderr)
+        tail = stderr.strip().splitlines()[-1:]
         detail = tail[0] if tail else "unknown error"
         raise InstantStreamError(
             f"Resolve failed for {youtube_video_id}: {detail[:300]}"

--- a/app/utils/ytdlp.py
+++ b/app/utils/ytdlp.py
@@ -1,28 +1,42 @@
-"""Shared yt-dlp invocation helpers.
+"""Shared yt-dlp invocation helpers + YouTube cookie management.
 
-The key one is :func:`cookie_args`: every yt-dlp call (resolve, download, preview,
-transcript, channel import) splices these in so a configured YouTube cookies file
-authenticates the request. Without it, age-restricted / members-only videos fail
-extraction entirely ("Sign in to confirm your age"), so none of the playback
-paths work for them.
+:func:`cookie_args` is spliced into every yt-dlp call so a configured YouTube
+cookies file authenticates the request — without it, age-restricted /
+members-only videos fail extraction entirely ("Sign in to confirm your age").
+
+Cookies are managed in-app (admins paste them via the settings API, see
+``app/api/settings.py``) rather than hand-placed on the filesystem. Reads are
+fresh on every call, so an updated cookies file takes effect immediately with no
+restart. When an age-gate error happens *despite* cookies being present, we flag
+them as likely-expired (a sentinel file) so the app can prompt for a refresh.
 """
 
 import os
+from datetime import datetime, timezone
 
 from app.config import settings
 
+# Substrings that identify YouTube's age/sign-in gate in a yt-dlp error.
+_AGE_GATE_MARKERS = ("confirm your age", "inappropriate for some users")
 
-def cookies_path() -> str | None:
-    """Resolve the YouTube cookies file path, or None if none is present.
+_STALE_SENTINEL_NAME = ".youtube_cookies_stale"
 
-    Uses ``settings.youtube_cookies_file`` when set, otherwise the conventional
-    ``<config_path>/cookies.txt`` (so dropping the file into the config volume is
-    enough). Returns None when the resolved path doesn't exist on disk.
-    """
-    candidate = settings.youtube_cookies_file or os.path.join(
+
+def _cookies_target() -> str:
+    """The path cookies are read from / written to."""
+    return settings.youtube_cookies_file or os.path.join(
         settings.config_path, "cookies.txt"
     )
-    return candidate if candidate and os.path.isfile(candidate) else None
+
+
+def _stale_sentinel() -> str:
+    return os.path.join(settings.config_path, _STALE_SENTINEL_NAME)
+
+
+def cookies_path() -> str | None:
+    """The cookies file path if it exists on disk, else None."""
+    target = _cookies_target()
+    return target if target and os.path.isfile(target) else None
 
 
 def cookie_args() -> list[str]:
@@ -32,3 +46,67 @@ def cookie_args() -> list[str]:
     """
     path = cookies_path()
     return ["--cookies", path] if path else []
+
+
+def save_cookies(content: str) -> None:
+    """Atomically write the cookies file and clear any stale flag."""
+    target = _cookies_target()
+    os.makedirs(os.path.dirname(target) or ".", exist_ok=True)
+    tmp = f"{target}.tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp, target)
+    _clear_stale()
+
+
+def clear_cookies() -> None:
+    """Remove the cookies file (and the stale flag)."""
+    for path in (_cookies_target(), _stale_sentinel()):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+
+
+def _clear_stale() -> None:
+    try:
+        os.remove(_stale_sentinel())
+    except FileNotFoundError:
+        pass
+
+
+def note_extraction_error(message: str) -> None:
+    """If an age-gate error occurred while cookies ARE configured, flag them as
+    likely expired so the app can prompt for a refresh. No-op otherwise (a gate
+    error with no cookies is a 'missing', not 'stale', state)."""
+    if cookies_path() is None:
+        return
+    lowered = message.lower()
+    if not any(marker in lowered for marker in _AGE_GATE_MARKERS):
+        return
+    try:
+        with open(_stale_sentinel(), "w", encoding="utf-8") as f:
+            f.write("")
+    except OSError:
+        pass
+
+
+def cookies_status() -> dict:
+    """Report cookie state for the settings UI.
+
+    ``configured``: a cookies file is present.
+    ``stale``: an age-gate error occurred since the cookies were last set —
+    they've probably expired and need refreshing.
+    ``updated_at``: when the cookies file was last written (ISO 8601, UTC).
+    """
+    path = cookies_path()
+    updated_at = None
+    if path is not None:
+        updated_at = datetime.fromtimestamp(
+            os.path.getmtime(path), tz=timezone.utc
+        ).isoformat()
+    return {
+        "configured": path is not None,
+        "stale": path is not None and os.path.isfile(_stale_sentinel()),
+        "updated_at": updated_at,
+    }

--- a/tests/test_settings_cookies.py
+++ b/tests/test_settings_cookies.py
@@ -1,0 +1,52 @@
+"""Admin YouTube-cookies settings endpoints (in-app cookie management)."""
+
+import pytest
+
+from app.config import settings
+from app.utils import ytdlp
+
+pytestmark = pytest.mark.asyncio
+
+COOKIE = "# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t0\tSID\tabc\n"
+
+
+@pytest.fixture(autouse=True)
+def _cookies_in_tmp(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "youtube_cookies_file", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+
+
+async def test_requires_admin(client, make_user):
+    await make_user("Admin")  # first profile created is the admin
+    _, viewer_headers = await make_user("Viewer")  # subsequent profiles are not
+    resp = await client.get("/api/settings/youtube-cookies", headers=viewer_headers)
+    assert resp.status_code == 403
+
+
+async def test_put_get_delete_cookies(client, make_user):
+    _, headers = await make_user("Admin")
+
+    resp = await client.get("/api/settings/youtube-cookies", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is False
+
+    resp = await client.put(
+        "/api/settings/youtube-cookies", json={"cookies": COOKIE}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is True
+    assert ytdlp.cookies_path() is not None
+
+    resp = await client.delete("/api/settings/youtube-cookies", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is False
+
+
+async def test_rejects_non_cookie_paste(client, make_user):
+    _, headers = await make_user("Admin")
+    resp = await client.put(
+        "/api/settings/youtube-cookies",
+        json={"cookies": "just some random words, not a cookies file"},
+        headers=headers,
+    )
+    assert resp.status_code == 400

--- a/tests/test_ytdlp_cookies.py
+++ b/tests/test_ytdlp_cookies.py
@@ -31,6 +31,41 @@ def test_cookie_args_missing_explicit_path_is_empty(monkeypatch, tmp_path):
     assert ytdlp.cookie_args() == []
 
 
+def test_save_status_and_clear(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "youtube_cookies_file", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+    assert ytdlp.cookies_status()["configured"] is False
+
+    ytdlp.save_cookies("# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t0\tA\tB\n")
+    st = ytdlp.cookies_status()
+    assert st["configured"] is True
+    assert st["stale"] is False
+    assert st["updated_at"]
+
+    ytdlp.clear_cookies()
+    assert ytdlp.cookies_status()["configured"] is False
+
+
+def test_note_extraction_error_marks_stale_only_with_cookies(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "youtube_cookies_file", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+
+    # No cookies configured -> an age-gate error is 'missing', never 'stale'.
+    ytdlp.note_extraction_error("ERROR: Sign in to confirm your age")
+    assert ytdlp.cookies_status()["stale"] is False
+
+    ytdlp.save_cookies("# Netscape\n.youtube.com\tTRUE\t/\tTRUE\t0\tA\tB\n")
+    # A non-age-gate failure doesn't flag the cookies.
+    ytdlp.note_extraction_error("ERROR: HTTP Error 404")
+    assert ytdlp.cookies_status()["stale"] is False
+    # An age-gate failure WITH cookies present means they likely expired.
+    ytdlp.note_extraction_error("ERROR: Sign in to confirm your age")
+    assert ytdlp.cookies_status()["stale"] is True
+    # Re-saving clears the stale flag.
+    ytdlp.save_cookies("# Netscape\n.youtube.com\tTRUE\t/\tTRUE\t0\tA\tC\n")
+    assert ytdlp.cookies_status()["stale"] is False
+
+
 def test_resolve_command_includes_cookies(monkeypatch):
     """The instant-stream resolve splices the cookie args into the yt-dlp call."""
     captured: dict = {}

--- a/tests/test_ytdlp_cookies.py
+++ b/tests/test_ytdlp_cookies.py
@@ -36,7 +36,9 @@ def test_save_status_and_clear(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "config_path", str(tmp_path))
     assert ytdlp.cookies_status()["configured"] is False
 
-    ytdlp.save_cookies("# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t0\tA\tB\n")
+    ytdlp.save_cookies(
+        "# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t0\tA\tB\n"
+    )
     st = ytdlp.cookies_status()
     assert st["configured"] is True
     assert st["stale"] is False


### PR DESCRIPTION
## Why

Age-restricted videos need YouTube auth, and **cookies are the only method that works** — yt-dlp itself rejects the alternatives now:
- `WARNING: Login with password is not supported for YouTube.`
- `ERROR: Login with OAuth is no longer supported.`

So instead of a password env var (which can't work), this makes the **cookie** flow turnkey: the admin pastes a `cookies.txt` from the app, no SSH / filesystem.

## Changes

- **`/api/settings/youtube-cookies`** (admin-only) — `PUT` stores a pasted cookies.txt (validated as Netscape format, atomic write, **hot-reloaded** on the next yt-dlp call — no restart); `GET` returns `{configured, stale, updated_at}`; `DELETE` clears it.
- **Expiry detection** — when an age-gate error occurs *despite* cookies being present (i.e. they've expired), `note_extraction_error` flags them via a sentinel file (works across the API + Celery processes). Wired into the instant-stream resolve so the app can prompt for a refresh. Re-saving clears the flag.

## Notes

One admin sets this up once; it covers all users and all age-restricted videos. The client Settings UI (paste box + status + "refresh" prompt) is the companion PR (Flutter, iOS + web).

## Tests

Helper (save/status/clear + stale detection) and endpoints (admin-gating, round-trip, bad-paste → 400). **314 passed**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)