### PR TITLE
fix(serve): rebuild the baked-in web bundle when flutter main changes

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,9 @@
 name: Docker Publish
 
 on:
+  # Manual rebuild — use this to pull the latest flutter web bundle into the
+  # image after a web-only change (the backend itself need not have changed).
+  workflow_dispatch:
   push:
     branches: [main]
     tags: ["v*"]
@@ -41,12 +44,21 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
 
+      - name: Resolve flutter main commit (cache-bust for the web build)
+        id: flutter
+        run: |
+          sha=$(git ls-remote https://github.com/windoze95/nullfeed-flutter.git refs/heads/main | cut -f1)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "flutter main is at $sha"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           # Full image: backend + the Flutter web app baked in and served at /.
           target: web
+          build-args: |
+            FLUTTER_WEB_SHA=${{ steps.flutter.outputs.sha }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,15 @@ RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
 # build it once (not once per target arch) and avoid emulating Flutter on arm64.
 FROM --platform=$BUILDPLATFORM ghcr.io/cirruslabs/flutter:${FLUTTER_VERSION} AS webbuild
 ARG FLUTTER_WEB_REF
+# Cache-bust the web build with the flutter main commit sha. Otherwise the
+# `git clone + flutter build web` layer is cached forever (its command text
+# never changes), freezing the served bundle at whatever flutter main was when
+# the cache was first filled. CI passes the current sha so this layer rebuilds
+# whenever flutter main advances.
+ARG FLUTTER_WEB_SHA=dev
 WORKDIR /src
-RUN git clone --depth 1 --branch ${FLUTTER_WEB_REF} \
+RUN echo "flutter web ${FLUTTER_WEB_REF}@${FLUTTER_WEB_SHA}" && \
+    git clone --depth 1 --branch ${FLUTTER_WEB_REF} \
         https://github.com/windoze95/nullfeed-flutter.git . && \
     git config --global --add safe.directory /src && \
     flutter pub get && \


### PR DESCRIPTION
## Bug

The web app served from the container has been **frozen** — it never picked up flutter changes (e.g. the YouTube cookies Settings panel shows in the iOS app but not the web app).

**Root cause:** the Dockerfile's webbuild stage runs the same `git clone <flutter> && flutter build web` command every build, so its Docker layer is **cached** (`type=gha`) and reused forever. Every published image since serving was added has been packaging the *same stale* web bundle from cache, regardless of new flutter commits.

## Fix

- **Dockerfile** — add a `FLUTTER_WEB_SHA` build-arg, referenced in the webbuild `RUN`, so the layer's cache key changes when flutter `main` advances.
- **docker-publish** — resolve flutter `main`'s sha via `git ls-remote` and pass it as that build-arg; add a **`workflow_dispatch`** trigger so you can rebuild the image on demand after a *web-only* change (no backend commit required).

`ci.yml`'s Docker Build targets `runtime` (skips webbuild), so it's unaffected.

## Effect

Merging this triggers a publish that resolves the **current** flutter main (incl. the cookies panel + the extension link) and rebuilds the web fresh → `:latest` will finally have the up-to-date web app. After that, **Actions → Docker Publish → Run workflow** rebuilds on demand whenever the web app changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)