### PR TITLE
fix(cookies): repair/validate the paste + surface why extraction fails

### DIFF
--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -12,7 +12,13 @@ from pydantic import BaseModel, Field
 
 from app.api.auth import get_current_user
 from app.models.user import User
-from app.utils.ytdlp import clear_cookies, cookies_status, save_cookies
+from app.utils.ytdlp import (
+    clear_cookies,
+    cookies_status,
+    has_cookie_rows,
+    normalize_cookies,
+    save_cookies,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/settings", tags=["settings"])
@@ -40,19 +46,19 @@ async def put_youtube_cookies(
 ) -> dict:
     """Store a pasted cookies.txt (Netscape format)."""
     _require_admin(user)
-    content = body.cookies.strip()
-    # Light sanity check so an obviously-wrong paste fails clearly rather than
-    # silently breaking every extraction. A cookies.txt is tab-separated and/or
-    # carries the standard Netscape header.
-    if "\t" not in content and "# Netscape" not in content and "# HTTP" not in content:
+    # Validate there are real cookie rows (yt-dlp aborts on a file that isn't a
+    # valid Netscape cookies file, which breaks every video). The missing header
+    # — the most common mistake — is repaired by save_cookies/normalize_cookies.
+    if not has_cookie_rows(normalize_cookies(body.cookies)):
         raise HTTPException(
             status_code=400,
             detail=(
-                "That doesn't look like a cookies.txt — export it in Netscape "
-                "format (e.g. the 'Get cookies.txt LOCALLY' browser extension)."
+                "That doesn't look like a cookies.txt — it has no cookie entries. "
+                "Export it in Netscape format (the 'Get cookies.txt LOCALLY' "
+                "extension's Export does this) and paste the whole file."
             ),
         )
-    save_cookies(content + "\n")
+    save_cookies(body.cookies)
     logger.info("YouTube cookies updated by admin %s", user.id)
     return cookies_status()
 

--- a/app/utils/ytdlp.py
+++ b/app/utils/ytdlp.py
@@ -7,8 +7,13 @@ members-only videos fail extraction entirely ("Sign in to confirm your age").
 Cookies are managed in-app (admins paste them via the settings API, see
 ``app/api/settings.py``) rather than hand-placed on the filesystem. Reads are
 fresh on every call, so an updated cookies file takes effect immediately with no
-restart. When an age-gate error happens *despite* cookies being present, we flag
-them as likely-expired (a sentinel file) so the app can prompt for a refresh.
+restart. :func:`save_cookies` normalizes the paste (yt-dlp aborts on a file
+whose first line isn't the Netscape header — "does not look like a Netscape
+format cookies file" — which breaks *every* video, not just age-gated ones).
+
+When extraction fails in a way that points at the cookies (bad/expired/wrong
+format, age gate, bot check), :func:`note_extraction_error` records it so the
+settings UI can show what's wrong instead of silently failing.
 """
 
 import os
@@ -16,10 +21,19 @@ from datetime import datetime, timezone
 
 from app.config import settings
 
-# Substrings that identify YouTube's age/sign-in gate in a yt-dlp error.
-_AGE_GATE_MARKERS = ("confirm your age", "inappropriate for some users")
+_NETSCAPE_HEADERS = ("# Netscape HTTP Cookie File", "# HTTP Cookie File")
 
-_STALE_SENTINEL_NAME = ".youtube_cookies_stale"
+# Substrings in a yt-dlp error that mean "the cookies aren't working" — surfaced
+# to the admin so they know to refresh/fix them rather than guessing.
+_COOKIE_TROUBLE_MARKERS = (
+    "does not look like a netscape format",  # malformed paste
+    "confirm your age",  # cookies missing / not age-verified
+    "inappropriate for some users",
+    "confirm you're not a bot",  # session rejected / bot-flagged
+    "sign in to confirm",
+)
+
+_ERROR_FILE_NAME = ".youtube_cookies_error"
 
 
 def _cookies_target() -> str:
@@ -29,8 +43,8 @@ def _cookies_target() -> str:
     )
 
 
-def _stale_sentinel() -> str:
-    return os.path.join(settings.config_path, _STALE_SENTINEL_NAME)
+def _error_file() -> str:
+    return os.path.join(settings.config_path, _ERROR_FILE_NAME)
 
 
 def cookies_path() -> str | None:
@@ -48,45 +62,80 @@ def cookie_args() -> list[str]:
     return ["--cookies", path] if path else []
 
 
+def normalize_cookies(content: str) -> str:
+    """Coerce a pasted cookies blob into a yt-dlp-loadable Netscape file.
+
+    Strips a BOM/whitespace and, crucially, prepends the Netscape header when
+    it's missing — pasting just the cookie rows (without that first line) is the
+    most common way the file ends up rejected and breaking all playback.
+    """
+    content = content.lstrip("﻿").strip()
+    first_line = content.splitlines()[0].strip() if content else ""
+    if not any(first_line.startswith(h) for h in _NETSCAPE_HEADERS):
+        content = f"{_NETSCAPE_HEADERS[0]}\n{content}"
+    return content + "\n"
+
+
+def has_cookie_rows(content: str) -> bool:
+    """True if the blob contains at least one Netscape cookie row.
+
+    A Netscape cookie line has 7 tab-separated fields (so ≥6 tabs); comment and
+    blank lines don't count. Lets the API reject an empty / wrong paste clearly.
+    """
+    for line in content.splitlines():
+        if line.startswith("#") or not line.strip():
+            continue
+        if line.count("\t") >= 6:
+            return True
+    return False
+
+
 def save_cookies(content: str) -> None:
-    """Atomically write the cookies file and clear any stale flag."""
+    """Normalize and atomically write the cookies file; clear the error flag."""
     target = _cookies_target()
     os.makedirs(os.path.dirname(target) or ".", exist_ok=True)
     tmp = f"{target}.tmp"
     with open(tmp, "w", encoding="utf-8") as f:
-        f.write(content)
+        f.write(normalize_cookies(content))
     os.replace(tmp, target)
-    _clear_stale()
+    _clear_error()
 
 
 def clear_cookies() -> None:
-    """Remove the cookies file (and the stale flag)."""
-    for path in (_cookies_target(), _stale_sentinel()):
+    """Remove the cookies file (and the error flag)."""
+    for path in (_cookies_target(), _error_file()):
         try:
             os.remove(path)
         except FileNotFoundError:
             pass
 
 
-def _clear_stale() -> None:
+def _clear_error() -> None:
     try:
-        os.remove(_stale_sentinel())
+        os.remove(_error_file())
     except FileNotFoundError:
         pass
 
 
 def note_extraction_error(message: str) -> None:
-    """If an age-gate error occurred while cookies ARE configured, flag them as
-    likely expired so the app can prompt for a refresh. No-op otherwise (a gate
-    error with no cookies is a 'missing', not 'stale', state)."""
+    """Record a cookie-related extraction failure so the UI can surface it.
+
+    No-op unless cookies are configured and the error looks cookie-related
+    (works across the API + Celery processes via a file in the config volume).
+    """
     if cookies_path() is None:
         return
     lowered = message.lower()
-    if not any(marker in lowered for marker in _AGE_GATE_MARKERS):
+    if not any(marker in lowered for marker in _COOKIE_TROUBLE_MARKERS):
         return
+    # Keep the most relevant single line, capped.
+    line = next(
+        (ln.strip() for ln in message.splitlines() if "error" in ln.lower()),
+        message.strip().splitlines()[-1] if message.strip() else message,
+    )
     try:
-        with open(_stale_sentinel(), "w", encoding="utf-8") as f:
-            f.write("")
+        with open(_error_file(), "w", encoding="utf-8") as f:
+            f.write(line[:300])
     except OSError:
         pass
 
@@ -95,8 +144,9 @@ def cookies_status() -> dict:
     """Report cookie state for the settings UI.
 
     ``configured``: a cookies file is present.
-    ``stale``: an age-gate error occurred since the cookies were last set —
-    they've probably expired and need refreshing.
+    ``stale``: a cookie-related extraction error has happened since they were
+    last set — they likely need refreshing/fixing.
+    ``last_error``: the yt-dlp error that flagged them (so the admin can see why).
     ``updated_at``: when the cookies file was last written (ISO 8601, UTC).
     """
     path = cookies_path()
@@ -105,8 +155,16 @@ def cookies_status() -> dict:
         updated_at = datetime.fromtimestamp(
             os.path.getmtime(path), tz=timezone.utc
         ).isoformat()
+    last_error = None
+    if path is not None and os.path.isfile(_error_file()):
+        try:
+            with open(_error_file(), encoding="utf-8") as f:
+                last_error = f.read().strip() or None
+        except OSError:
+            last_error = None
     return {
         "configured": path is not None,
-        "stale": path is not None and os.path.isfile(_stale_sentinel()),
+        "stale": last_error is not None,
+        "last_error": last_error,
         "updated_at": updated_at,
     }

--- a/tests/test_ytdlp_cookies.py
+++ b/tests/test_ytdlp_cookies.py
@@ -68,6 +68,42 @@ def test_note_extraction_error_marks_stale_only_with_cookies(monkeypatch, tmp_pa
     assert ytdlp.cookies_status()["stale"] is False
 
 
+def test_normalize_prepends_missing_header():
+    raw = ".youtube.com\tTRUE\t/\tTRUE\t0\tSID\tabc"
+    out = ytdlp.normalize_cookies(raw)
+    assert out.startswith("# Netscape HTTP Cookie File\n")
+    assert ytdlp.has_cookie_rows(out)
+
+
+def test_normalize_keeps_existing_header_and_strips_bom():
+    raw = "﻿# Netscape HTTP Cookie File\n.youtube.com\tTRUE\t/\tTRUE\t0\tA\tB"
+    out = ytdlp.normalize_cookies(raw)
+    assert out.count("# Netscape HTTP Cookie File") == 1
+    assert out.startswith("# Netscape HTTP Cookie File\n")
+
+
+def test_has_cookie_rows_rejects_non_cookies():
+    assert ytdlp.has_cookie_rows("just some words\nno tabs here") is False
+    assert ytdlp.has_cookie_rows("# Netscape HTTP Cookie File\n") is False
+    assert ytdlp.has_cookie_rows(".youtube.com\tTRUE\t/\tTRUE\t0\tA\tB") is True
+
+
+def test_status_surfaces_last_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(settings, "youtube_cookies_file", "")
+    monkeypatch.setattr(settings, "config_path", str(tmp_path))
+    ytdlp.save_cookies(".youtube.com\tTRUE\t/\tTRUE\t0\tA\tB")
+    assert ytdlp.cookies_status()["stale"] is False
+    ytdlp.note_extraction_error(
+        "ERROR: 'cookies.txt' does not look like a Netscape format cookies file"
+    )
+    st = ytdlp.cookies_status()
+    assert st["stale"] is True
+    assert "Netscape" in (st["last_error"] or "")
+    # Re-saving clears the error.
+    ytdlp.save_cookies(".youtube.com\tTRUE\t/\tTRUE\t0\tA\tC")
+    assert ytdlp.cookies_status()["stale"] is False
+
+
 def test_resolve_command_includes_cookies(monkeypatch):
     """The instant-stream resolve splices the cookie args into the yt-dlp call."""
     captured: dict = {}


### PR DESCRIPTION
## What I found (live test)

Tested #771 (age-restricted) **and** #772 (normal) through the server's instant-stream — **both 502'd**, even though #772 resolves fine without cookies from a clean IP. So it wasn't age restriction; **all** resolves were failing.

Reproduced the cause: yt-dlp aborts with **`'cookies.txt' does not look like a Netscape format cookies file`** when the file's first line isn't the Netscape header — and that failure applies to **every** video. The save-validation only checked "has a tab", so a paste missing the header line got stored and silently broke all playback.

## Fix

- **`normalize_cookies`** — strip BOM/whitespace and **prepend the Netscape header when missing** (the most common paste mistake), so pasting just the cookie rows still works.
- **`has_cookie_rows`** — `PUT` now requires a real tab-separated cookie row; a wrong paste gets a clear **400** instead of silently breaking everything.
- **Surface the failure** — `note_extraction_error` now matches the cookie-trouble errors (bad format / age gate / "not a bot") and records the message; `cookies_status` returns **`last_error`**, so the Settings panel shows *exactly* why cookies aren't working. (Companion Flutter PR renders it.)

## Tests

normalize/has_cookie_rows/header-prepend + last_error surfacing. **318 passed**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)