### PR TITLE
fix(cookies): verify against an age-restricted video (honest age status)

### DIFF
--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -17,8 +17,8 @@ from app.utils.ytdlp import (
     cookies_status,
     has_cookie_rows,
     normalize_cookies,
-    note_extraction_error,
     save_cookies,
+    set_cookies_error,
     verify_cookies,
 )
 
@@ -61,10 +61,11 @@ async def put_youtube_cookies(
             ),
         )
     save_cookies(body.cookies)
-    # Verify they actually work so the UI reports "connected" only when true.
+    # Verify they actually work (against an age-restricted video) so the UI
+    # reports "connected" only when age-restricted playback will succeed.
     error = verify_cookies()
     if error:
-        note_extraction_error(error)
+        set_cookies_error(error)
     logger.info(
         "YouTube cookies updated by admin %s (working=%s)", user.id, error is None
     )

--- a/app/utils/ytdlp.py
+++ b/app/utils/ytdlp.py
@@ -24,9 +24,12 @@ from app.config import settings
 
 _NETSCAPE_HEADERS = ("# Netscape HTTP Cookie File", "# HTTP Cookie File")
 
-# Stable, public, non-restricted video used to check cookies actually work on
-# save (so "connected" means verified, not just "a file exists").
-_PROBE_VIDEO_ID = "dQw4w9WgXcQ"
+# Probe videos used to verify cookies on save (so "connected" means verified).
+# The age-restricted one is the meaningful test — the whole point of cookies is
+# age-restricted playback — with the normal one as a fallback to tell "session
+# broken" from "session ok but not age-authorized".
+_AGE_PROBE_VIDEO_ID = "HtVdAasjOgU"  # stable age-restricted (yt-dlp test video)
+_PROBE_VIDEO_ID = "dQw4w9WgXcQ"  # stable, public, non-restricted
 
 # Substrings in a yt-dlp error that mean "the cookies aren't working" — surfaced
 # to the admin so they know to refresh/fix them rather than guessing.
@@ -103,17 +106,12 @@ def normalize_cookies(content: str) -> str:
     return out + "\n"
 
 
-def verify_cookies() -> str | None:
-    """Check yt-dlp can actually use the saved cookies, so the UI only reports
-    "connected" when they work.
-
-    Returns a short error string if the cookies aren't working (bad format, or a
-    rejected/expired session), else None. Only cookie-related failures count — a
-    problem with the probe video itself is ignored.
-    """
+def _probe_error(video_id: str) -> str | None:
+    """``yt-dlp --simulate`` with the saved cookies; the last error line, or None
+    on success / no cookies / a slow probe."""
     path = cookies_path()
     if path is None:
-        return "No cookies file."
+        return None
     cmd = [
         "yt-dlp",
         "--cookies",
@@ -121,25 +119,48 @@ def verify_cookies() -> str | None:
         "--simulate",
         "--no-warnings",
         "--no-playlist",
-        f"https://www.youtube.com/watch?v={_PROBE_VIDEO_ID}",
+        f"https://www.youtube.com/watch?v={video_id}",
     ]
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     except (subprocess.TimeoutExpired, OSError):
-        return None  # don't block the save on a slow/odd probe
+        return None
     if result.returncode == 0:
         return None
     err = (result.stderr or result.stdout or "").strip()
-    if any(m in err.lower() for m in _COOKIE_TROUBLE_MARKERS):
-        line = next(
-            (
-                ln.strip()
-                for ln in err.splitlines()
-                if any(m in ln.lower() for m in _COOKIE_TROUBLE_MARKERS)
-            ),
-            err,
+    lines = [ln.strip() for ln in err.splitlines() if "error" in ln.lower()]
+    chosen = lines[-1] if lines else (err.splitlines() or [""])[-1]
+    return chosen[:300]
+
+
+def verify_cookies() -> str | None:
+    """Verify the saved cookies actually work, so the UI reports "connected" only
+    when true. Returns a short reason string if not working, else None.
+
+    Probes an *age-restricted* video (the whole point of cookies). If it resolves
+    the cookies fully work; an age gate means the session loads but isn't
+    age-authorized; a malformed-file / bot error is surfaced verbatim. A failure
+    unrelated to cookies (e.g. the probe video was removed) falls back to a
+    normal video so a genuinely broken session is still caught.
+    """
+    if cookies_path() is None:
+        return "No cookies file."
+    age_err = _probe_error(_AGE_PROBE_VIDEO_ID)
+    if age_err is None:
+        return None  # age-restricted resolved → fully working
+    low = age_err.lower()
+    if "confirm your age" in low or "inappropriate for some users" in low:
+        return (
+            "Cookies load, but don't unlock age-restricted videos — the account "
+            "may not be age-verified, or the cookies have gone stale. Re-export "
+            "from a browser that's signed in to YouTube."
         )
-        return line[:300]
+    if any(m in low for m in _COOKIE_TROUBLE_MARKERS):
+        return age_err
+    # Age probe failed for an unrelated reason; confirm the session at least.
+    normal_err = _probe_error(_PROBE_VIDEO_ID)
+    if normal_err and any(m in normal_err.lower() for m in _COOKIE_TROUBLE_MARKERS):
+        return normal_err
     return None
 
 
@@ -184,27 +205,33 @@ def _clear_error() -> None:
         pass
 
 
-def note_extraction_error(message: str) -> None:
-    """Record a cookie-related extraction failure so the UI can surface it.
+def set_cookies_error(message: str) -> None:
+    """Record a cookie problem so the settings UI surfaces it (cleared on save).
 
-    No-op unless cookies are configured and the error looks cookie-related
-    (works across the API + Celery processes via a file in the config volume).
+    Cross-process safe (a file in the config volume), so a failure seen in the
+    API or a Celery worker both reach the panel.
     """
+    try:
+        with open(_error_file(), "w", encoding="utf-8") as f:
+            f.write(message.strip()[:300])
+    except OSError:
+        pass
+
+
+def note_extraction_error(message: str) -> None:
+    """Record a cookie-related extraction failure (from the playback path) so the
+    UI can surface it. No-op unless cookies are configured and the error looks
+    cookie-related."""
     if cookies_path() is None:
         return
     lowered = message.lower()
     if not any(marker in lowered for marker in _COOKIE_TROUBLE_MARKERS):
         return
-    # Keep the most relevant single line, capped.
     line = next(
         (ln.strip() for ln in message.splitlines() if "error" in ln.lower()),
         message.strip().splitlines()[-1] if message.strip() else message,
     )
-    try:
-        with open(_error_file(), "w", encoding="utf-8") as f:
-            f.write(line[:300])
-    except OSError:
-        pass
+    set_cookies_error(line)
 
 
 def cookies_status() -> dict:

--- a/tests/test_ytdlp_cookies.py
+++ b/tests/test_ytdlp_cookies.py
@@ -112,39 +112,44 @@ def test_normalize_repairs_spaces_to_tabs():
     assert ytdlp.has_cookie_rows(out)
 
 
-def test_verify_cookies_distinguishes_cookie_vs_other_errors(monkeypatch, tmp_path):
+def test_verify_cookies_probes_age_restricted(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "youtube_cookies_file", "")
     monkeypatch.setattr(settings, "config_path", str(tmp_path))
     ytdlp.save_cookies(".youtube.com\tTRUE\t/\tTRUE\t0\tA\tB")
 
-    def result(returncode, stderr):
-        class _R:
-            pass
-
-        r = _R()
-        r.returncode = returncode
-        r.stdout = ""
-        r.stderr = stderr
-        return r
-
-    # Success → working.
-    monkeypatch.setattr(ytdlp.subprocess, "run", lambda *a, **k: result(0, ""))
+    # Age-restricted probe resolves → fully working.
+    monkeypatch.setattr(ytdlp, "_probe_error", lambda vid: None)
     assert ytdlp.verify_cookies() is None
 
-    # A cookie-related failure → reported.
+    # Age gate on the age probe → "doesn't unlock age-restricted".
     monkeypatch.setattr(
-        ytdlp.subprocess,
-        "run",
-        lambda *a, **k: result(
-            1, "ERROR: 'c.txt' does not look like a Netscape format cookies file"
+        ytdlp,
+        "_probe_error",
+        lambda vid: (
+            "ERROR: Sign in to confirm your age"
+            if vid == ytdlp._AGE_PROBE_VIDEO_ID
+            else None
         ),
     )
-    err = ytdlp.verify_cookies()
-    assert err is not None and "Netscape" in err
+    msg = ytdlp.verify_cookies()
+    assert msg is not None and "age-restricted" in msg
 
-    # A failure unrelated to cookies (e.g. the probe video) → not flagged.
+    # Malformed file → surfaced verbatim.
     monkeypatch.setattr(
-        ytdlp.subprocess, "run", lambda *a, **k: result(1, "ERROR: Video unavailable")
+        ytdlp,
+        "_probe_error",
+        lambda vid: "ERROR: does not look like a Netscape format cookies file",
+    )
+    msg = ytdlp.verify_cookies()
+    assert msg is not None and "Netscape" in msg
+
+    # Age probe unavailable but the normal session is fine → not flagged.
+    monkeypatch.setattr(
+        ytdlp,
+        "_probe_error",
+        lambda vid: (
+            "ERROR: Video unavailable" if vid == ytdlp._AGE_PROBE_VIDEO_ID else None
+        ),
     )
     assert ytdlp.verify_cookies() is None
 


### PR DESCRIPTION
The save-time check probed a *normal* video, so it could say "connected" while age-restricted playback still failed — exactly the false-positive seen on the live server (#772 plays, #771 age-gates).

`verify_cookies` now probes a **stable age-restricted** video (`HtVdAasjOgU`) first:
- resolves → fully working;
- **age gate → "cookies load but don't unlock age-restricted videos — the account may not be age-verified, or the cookies are stale; re-export from a signed-in browser"**;
- malformed/bot error → surfaced verbatim;
- age probe failing for an unrelated reason (e.g. removed) → falls back to a normal video so a broken session is still caught.

Recorded via `set_cookies_error` so the panel shows it **immediately on Save** — you can iterate exports until it says ✓ without playing a video each time.

321 passed, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)