### PR TITLE
fix(instant-stream): force android player client (cookie-auth web is SABR-only)

### DIFF
--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -27,20 +27,14 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 from fastapi.responses import StreamingResponse
 
-from app.utils.ytdlp import cookie_args, note_extraction_error
+from app.utils.ytdlp import (
+    PROGRESSIVE_FORMAT,
+    cookie_args,
+    note_extraction_error,
+    player_client_args,
+)
 
 logger = logging.getLogger(__name__)
-
-# Progressive (muxed) selectors only — a single file AVPlayer / video_player can
-# play without a merge step. Prefer H.264 + AAC for native decode, then any
-# progressive mp4, then itag 18 (the canonical 360p muxed format), then any
-# format that carries both audio and video.
-_PROGRESSIVE_FORMAT = (
-    "best[vcodec^=avc1][acodec^=mp4a]"
-    "/best[ext=mp4][acodec!=none][vcodec!=none]"
-    "/18"
-    "/best[acodec!=none][vcodec!=none]"
-)
 
 # yt-dlp resolve timeout. Resolve is a metadata/extraction round-trip, not a
 # download, so it should be quick; keep it tight so a wedged extract surfaces as
@@ -91,8 +85,9 @@ def _ytdlp_get_url(youtube_video_id: str) -> str:
     cmd = [
         "yt-dlp",
         *cookie_args(),
+        *player_client_args(),
         "--format",
-        _PROGRESSIVE_FORMAT,
+        PROGRESSIVE_FORMAT,
         "--get-url",
         "--no-playlist",
         "--no-warnings",

--- a/app/utils/ytdlp.py
+++ b/app/utils/ytdlp.py
@@ -31,6 +31,29 @@ _NETSCAPE_HEADERS = ("# Netscape HTTP Cookie File", "# HTTP Cookie File")
 _AGE_PROBE_VIDEO_ID = "HtVdAasjOgU"  # stable age-restricted (yt-dlp test video)
 _PROBE_VIDEO_ID = "dQw4w9WgXcQ"  # stable, public, non-restricted
 
+# Progressive (muxed, single-file) format selector — what the instant-stream
+# proxy needs (a file the player can play with no merge step). Prefer H.264+AAC,
+# then any progressive mp4, then itag 18 (canonical 360p muxed), then any muxed.
+# Shared with the cookie probe so "connected" reflects the real resolve.
+PROGRESSIVE_FORMAT = (
+    "best[vcodec^=avc1][acodec^=mp4a]"
+    "/best[ext=mp4][acodec!=none][vcodec!=none]"
+    "/18"
+    "/best[acodec!=none][vcodec!=none]"
+)
+
+# Force progressive-capable YouTube player clients. A cookie-authenticated `web`
+# session gets SABR-only formats from YouTube (no progressive itag), so muxed
+# formats vanish and every resolve dies "Requested format is not available". The
+# `android` client still serves itag 18; `web` is kept for age-gate auth.
+_PLAYER_CLIENTS = "android,web"
+
+
+def player_client_args() -> list[str]:
+    """``--extractor-args`` forcing progressive-capable YouTube player clients."""
+    return ["--extractor-args", f"youtube:player_client={_PLAYER_CLIENTS}"]
+
+
 # Substrings in a yt-dlp error that mean "the cookies aren't working" — surfaced
 # to the admin so they know to refresh/fix them rather than guessing.
 _COOKIE_TROUBLE_MARKERS = (
@@ -107,8 +130,10 @@ def normalize_cookies(content: str) -> str:
 
 
 def _probe_error(video_id: str) -> str | None:
-    """``yt-dlp --simulate`` with the saved cookies; the last error line, or None
-    on success / no cookies / a slow probe."""
+    """Resolve a progressive URL for ``video_id`` with the saved cookies exactly
+    as playback does; the last error line, or None on success / no cookies / a
+    slow probe. Using the real resolve (not ``--simulate``) means a green check
+    reflects what the player will actually get."""
     path = cookies_path()
     if path is None:
         return None
@@ -116,7 +141,10 @@ def _probe_error(video_id: str) -> str | None:
         "yt-dlp",
         "--cookies",
         path,
-        "--simulate",
+        *player_client_args(),
+        "--format",
+        PROGRESSIVE_FORMAT,
+        "--get-url",
         "--no-warnings",
         "--no-playlist",
         f"https://www.youtube.com/watch?v={video_id}",
@@ -157,7 +185,15 @@ def verify_cookies() -> str | None:
         )
     if any(m in low for m in _COOKIE_TROUBLE_MARKERS):
         return age_err
-    # Age probe failed for an unrelated reason; confirm the session at least.
+    if "requested format is not available" in low:
+        # Age unlocked but no progressive/muxed stream came back — exactly the
+        # SABR failure the player can't use. Don't claim "connected".
+        return (
+            "Cookies load, but no playable (progressive) stream was available "
+            "for an age-restricted video — age-restricted playback may not work."
+        )
+    # Age probe video itself unavailable (removed/private/geo); fall back to a
+    # normal video to at least catch a broken session.
     normal_err = _probe_error(_PROBE_VIDEO_ID)
     if normal_err and any(m in normal_err.lower() for m in _COOKIE_TROUBLE_MARKERS):
         return normal_err

--- a/tests/test_ytdlp_cookies.py
+++ b/tests/test_ytdlp_cookies.py
@@ -143,7 +143,7 @@ def test_verify_cookies_probes_age_restricted(monkeypatch, tmp_path):
     msg = ytdlp.verify_cookies()
     assert msg is not None and "Netscape" in msg
 
-    # Age probe unavailable but the normal session is fine → not flagged.
+    # Age probe unavailable (probe video removed) but normal session fine → ok.
     monkeypatch.setattr(
         ytdlp,
         "_probe_error",
@@ -152,6 +152,19 @@ def test_verify_cookies_probes_age_restricted(monkeypatch, tmp_path):
         ),
     )
     assert ytdlp.verify_cookies() is None
+
+    # Age unlocked but no progressive stream (SABR) → don't claim connected.
+    monkeypatch.setattr(
+        ytdlp,
+        "_probe_error",
+        lambda vid: (
+            "ERROR: Requested format is not available"
+            if vid == ytdlp._AGE_PROBE_VIDEO_ID
+            else None
+        ),
+    )
+    msg = ytdlp.verify_cookies()
+    assert msg is not None and "progressive" in msg
 
 
 def test_resolve_command_includes_cookies(monkeypatch):
@@ -175,3 +188,5 @@ def test_resolve_command_includes_cookies(monkeypatch):
 
     assert url == "https://upstream.test/v.mp4"
     assert captured["cmd"][:3] == ["yt-dlp", "--cookies", "/c.txt"]
+    # Forces a progressive-capable player client (cookie-auth web is SABR-only).
+    assert "youtube:player_client=android,web" in captured["cmd"]


### PR DESCRIPTION
## The actual root cause (from the server log)

```
WARNING:app.api.videos:instant-stream resolve/proxy failed for … vyKU6Pd5KAA: Requested format is not available
WARNING:app.api.videos:instant-stream resolve/proxy failed for … ns-FD_AnYCc: Requested format is not available
```

It was never (just) cookies or age. Once requests are **authenticated with cookies**, YouTube serves the `web` client **SABR-only** formats — no progressive/muxed `itag`. The instant-stream proxies a single muxed file, so the progressive selector matched nothing and **every** resolve 502'd (which is why #772 broke the moment valid cookies went in). The age gate was a *separate, earlier* layer we already solved.

## Fix

- Resolve passes **`--extractor-args youtube:player_client=android,web`** — `android` still serves `itag 18` (progressive), `web` is kept for age-gate auth. Verified locally end-to-end: resolves **and** fetches `HTTP 206`, valid MP4 (no po-token wall).
- Hoisted `PROGRESSIVE_FORMAT` + `player_client_args()` into `app.utils.ytdlp` so the **cookie probe resolves exactly as playback does** — green now means the real progressive resolve worked, not just that `--simulate` read metadata.
- `verify_cookies` treats `"requested format is not available"` on the age probe as a failure, so the panel won't claim "connected" when no playable stream came back.

## Tests

resolve splices the player-client args; verify handles resolved / age-gate / malformed / probe-removed / **SABR-no-progressive**. **321 passed**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)