### PR TITLE
fix(cookies): cookie status reflects auth, not playback (stop false "invalid")

### DIFF
--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -30,7 +30,6 @@ from fastapi.responses import StreamingResponse
 from app.utils.ytdlp import (
     PROGRESSIVE_FORMAT,
     cookie_args,
-    note_extraction_error,
     player_client_args,
 )
 
@@ -102,8 +101,11 @@ def _ytdlp_get_url(youtube_video_id: str) -> str:
 
     if result.returncode != 0:
         stderr = result.stderr or result.stdout or ""
-        # Flag cookies as likely-expired if this was an age gate despite cookies.
-        note_extraction_error(stderr)
+        # NB: deliberately do NOT flag cookie status here. With the android
+        # client an age-restricted video age-gates even when the cookies are
+        # valid (android can't use them; web passes age but is SABR-only), so a
+        # resolve failure is not a reliable cookie signal. Cookie validity is
+        # owned by the save-time verify (see app/utils/ytdlp.verify_cookies).
         tail = stderr.strip().splitlines()[-1:]
         detail = tail[0] if tail else "unknown error"
         raise InstantStreamError(

--- a/app/utils/ytdlp.py
+++ b/app/utils/ytdlp.py
@@ -130,10 +130,16 @@ def normalize_cookies(content: str) -> str:
 
 
 def _probe_error(video_id: str) -> str | None:
-    """Resolve a progressive URL for ``video_id`` with the saved cookies exactly
-    as playback does; the last error line, or None on success / no cookies / a
-    slow probe. Using the real resolve (not ``--simulate``) means a green check
-    reflects what the player will actually get."""
+    """``yt-dlp --simulate`` with the saved cookies — checks the cookies
+    *authenticate* (pass the age gate). The last error line, or None on success /
+    no cookies / a slow probe.
+
+    Deliberately does NOT force the progressive player client or a muxed format:
+    whether a progressive stream exists is a playback concern (YouTube serves the
+    cookie-auth web client SABR-only, and the android client that has progressive
+    age-gates), not a cookie-validity one — so we must not mark valid cookies
+    "broken" just because an age-restricted video is SABR-only.
+    """
     path = cookies_path()
     if path is None:
         return None
@@ -141,10 +147,7 @@ def _probe_error(video_id: str) -> str | None:
         "yt-dlp",
         "--cookies",
         path,
-        *player_client_args(),
-        "--format",
-        PROGRESSIVE_FORMAT,
-        "--get-url",
+        "--simulate",
         "--no-warnings",
         "--no-playlist",
         f"https://www.youtube.com/watch?v={video_id}",
@@ -185,13 +188,6 @@ def verify_cookies() -> str | None:
         )
     if any(m in low for m in _COOKIE_TROUBLE_MARKERS):
         return age_err
-    if "requested format is not available" in low:
-        # Age unlocked but no progressive/muxed stream came back — exactly the
-        # SABR failure the player can't use. Don't claim "connected".
-        return (
-            "Cookies load, but no playable (progressive) stream was available "
-            "for an age-restricted video — age-restricted playback may not work."
-        )
     # Age probe video itself unavailable (removed/private/geo); fall back to a
     # normal video to at least catch a broken session.
     normal_err = _probe_error(_PROBE_VIDEO_ID)

--- a/tests/test_ytdlp_cookies.py
+++ b/tests/test_ytdlp_cookies.py
@@ -153,7 +153,8 @@ def test_verify_cookies_probes_age_restricted(monkeypatch, tmp_path):
     )
     assert ytdlp.verify_cookies() is None
 
-    # Age unlocked but no progressive stream (SABR) → don't claim connected.
+    # A format/playback error (not auth) must NOT mark valid cookies broken —
+    # whether a progressive stream exists is a playback concern, not the cookies'.
     monkeypatch.setattr(
         ytdlp,
         "_probe_error",
@@ -163,8 +164,7 @@ def test_verify_cookies_probes_age_restricted(monkeypatch, tmp_path):
             else None
         ),
     )
-    msg = ytdlp.verify_cookies()
-    assert msg is not None and "progressive" in msg
+    assert ytdlp.verify_cookies() is None
 
 
 def test_resolve_command_includes_cookies(monkeypatch):


### PR DESCRIPTION
After #101, two paths wrongly marked **valid** cookies invalid:

1. `verify_cookies` probed the *progressive resolve* (android client) — which age-gates age-restricted videos even with good cookies → **save showed invalid**.
2. The instant-stream resolve called `note_extraction_error` on its stderr; with the android client an age video age-gates ("confirm your age"), flagging cookies **stale on every play**.

Both conflate *"is a progressive stream available"* (a playback/SABR concern) with *"do the cookies authenticate"* (the age gate). Separated:

- `_probe_error` → back to `--simulate` (no forced client/format): checks the cookies pass the age gate, their actual job.
- the instant-stream resolve no longer touches cookie status; validity is owned by the save-time verify.

Valid cookies now stay green. (Age-restricted **playback** still fails on YouTube's SABR-only authenticated formats — separate issue, needs po_token or the download path; tracked next.)

**321 passed**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)