### PR TITLE
feat(youtube): bundle po_token provider + adaptive preview (age-restricted playback)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,21 +34,37 @@ RUN echo "flutter web ${FLUTTER_WEB_REF}@${FLUTTER_WEB_SHA}" && \
     flutter build web --release --no-tree-shake-icons
 
 # ---------------------------------------------------------------------------
+# po_token provider (bgutil). YouTube serves cookie-authenticated sessions
+# SABR-only formats with no plain progressive URLs; the yt-dlp bgutil plugin
+# (requirements.txt) fetches a PO token from this local node server so those
+# formats become downloadable — required for age-restricted playback. Bundled
+# here (Debian 12, same base as runtime) so the all-in-one image needs no
+# separate container; started by the entrypoint on 127.0.0.1:4416.
+FROM brainicism/bgutil-ytdlp-pot-provider AS potprovider
+
+# ---------------------------------------------------------------------------
 # Backend runtime (no web bundle). This is the fast per-PR CI target.
 FROM python:3.12-slim AS runtime
 
 LABEL maintainer="NullFeed" \
       description="NullFeed - Self-Hosted YouTube Media Center Backend"
 
-# Install runtime dependencies: ffmpeg, redis-server, and gosu for UID mapping
+# Install runtime dependencies: ffmpeg, redis-server, gosu for UID mapping, and
+# libatomic1 (a runtime dep of the bundled node binary on some arches).
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         aria2 \
         ffmpeg \
         redis-server \
         gosu \
+        libatomic1 \
         curl && \
     rm -rf /var/lib/apt/lists/*
+
+# Bundle the bgutil po_token provider (node runtime + built server). The yt-dlp
+# plugin auto-connects to it at 127.0.0.1:4416 once the entrypoint starts it.
+COPY --from=potprovider /usr/local/bin/node /usr/local/bin/node
+COPY --from=potprovider /app /opt/bgutil-provider
 
 # Copy Python packages from builder stage
 COPY --from=builder /install /usr/local

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -304,17 +304,29 @@ def download_preview(
     video_id: str,
 ) -> dict:
     """
-    Download a low-quality pre-muxed 360p preview. Returns metadata dict on success.
-    No split streams, no merge step — fast and lightweight.
-    Raises RuntimeError on failure.
+    Download a low-quality (~360-480p) preview. Returns metadata dict on success.
+
+    Prefers a pre-muxed progressive file (fast, no merge). Falls back to muxing a
+    ≤480p video+audio pair for videos YouTube only serves as SABR/adaptive —
+    notably age-restricted ones, which the bundled po_token provider makes
+    downloadable but which have no progressive stream, so this fallback is the
+    only way they get a playable file (and thus the only cold-press path that
+    works for them). Raises RuntimeError on failure.
     """
     output_dir = os.path.join(settings.media_path, channel_slug)
     os.makedirs(output_dir, exist_ok=True)
 
     output_template = os.path.join(output_dir, f"{video_id}_preview.%(ext)s")
 
-    # Pre-muxed formats only — no merge needed
-    format_str = "best[height<=360][ext=mp4]/best[height<=480][ext=mp4]/worst[ext=mp4]"
+    # Progressive first (no merge); then an adaptive video+audio pair to mux for
+    # SABR-only videos (age-restricted) that have no progressive format.
+    format_str = (
+        "best[height<=360][ext=mp4]"
+        "/best[height<=480][ext=mp4]"
+        "/bestvideo[height<=480][vcodec^=avc1]+bestaudio[acodec^=mp4a]"
+        "/bestvideo[height<=480]+bestaudio"
+        "/worst[ext=mp4]"
+    )
 
     url = f"https://www.youtube.com/watch?v={youtube_video_id}"
 
@@ -323,6 +335,10 @@ def download_preview(
         *cookie_args(),
         "--format",
         format_str,
+        # Only takes effect when the adaptive fallback is selected (a merge);
+        # harmless for the progressive branch.
+        "--merge-output-format",
+        "mp4",
         "--output",
         output_template,
         "--no-playlist",
@@ -341,7 +357,9 @@ def download_preview(
             cmd,
             capture_output=True,
             text=True,
-            timeout=120,
+            # Muxing an adaptive ≤480p pair (the age-restricted path) downloads
+            # the full A/V streams, so allow more than the progressive case.
+            timeout=300,
         )
     except subprocess.TimeoutExpired:
         raise RuntimeError(f"Preview download timed out for {youtube_video_id}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,10 @@ aiosqlite==0.20.0
 celery==5.4.0
 redis==5.2.1
 yt-dlp==2026.6.9
+# yt-dlp plugin: fetches a PO token from the bundled bgutil provider (see
+# Dockerfile/entrypoint) so YouTube's cookie-authenticated SABR-only formats are
+# downloadable — required for age-restricted playback.
+bgutil-ytdlp-pot-provider==1.3.1
 anthropic==0.43.0
 pydantic==2.10.4
 pydantic-settings==2.7.1

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -28,6 +28,16 @@ python -m alembic upgrade head
 echo "Starting Redis..."
 redis-server --daemonize yes --loglevel warning
 
+# ── Start the po_token provider (bgutil) on 127.0.0.1:4416 ─────────────────
+# YouTube serves cookie-authenticated sessions SABR-only formats; the yt-dlp
+# bgutil plugin fetches a PO token from this local server so those formats are
+# downloadable (required for age-restricted playback). Backgrounded; if it dies
+# the plugin just falls back to no-token (non-age videos keep working).
+if [ -f /opt/bgutil-provider/build/main.js ]; then
+    echo "Starting po_token provider..."
+    ( cd /opt/bgutil-provider && node build/main.js ) >/tmp/bgutil.log 2>&1 &
+fi
+
 # ── Start Celery worker in the background ──────────────────────────────────
 echo "Starting Celery worker..."
 celery -A app.tasks.celery_app worker \


### PR DESCRIPTION
Makes **age-restricted videos play**, the deepest layer of the "won't play" saga. Cookies authenticate fine, but YouTube serves the authenticated web session **SABR-only** formats: no progressive stream (so instant-stream can't serve them) and the adaptive URLs need a **PO token** to download. No single yt-dlp client gives both age-pass *and* a playable stream — so two pieces work together:

### 1. po_token (the unlock)
- Bundle the **bgutil provider** (node server) into the all-in-one image via a multi-stage copy from `brainicism/bgutil-ytdlp-pot-provider` (Debian 12, same base; **multi-arch amd64+arm64**). Started by the entrypoint on `127.0.0.1:4416`.
- Add the **yt-dlp plugin** (`bgutil-ytdlp-pot-provider`) to requirements. yt-dlp then fetches a PO token automatically, making the authenticated **adaptive** formats downloadable.
- **Validated in the built image**: provider serves (`v1.3.1`), plugin loads, full stack boots with `Starting po_token provider...`.

### 2. Adaptive preview (the playback path)
- `download_preview` now falls back to muxing a `<=480p` video+audio pair (`--merge-output-format mp4`) when there's no progressive format — so the existing cold-press → preview fallback produces a **playable file** for age-restricted videos. Timeout `120→300s` for the full A/V pull.

### Notes
- **Non-age videos unchanged** (instant-stream via android client).
- **Graceful degradation**: if the provider doesn't start, the plugin skips the token; non-age playback is unaffected.
- Mechanism validated end-to-end locally (token fetch + adaptive download+merge → playable mp4). I built+booted the **arm64** image; **amd64** rides the same multi-arch bases and is built by CI. Final age-restricted check is on the live server (needs the real cookies).

**321 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)