### PR TITLE
fix(preview): aria2c + 360p for age-restricted; surface Celery logs

### DIFF
--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -319,12 +319,14 @@ def download_preview(
     output_template = os.path.join(output_dir, f"{video_id}_preview.%(ext)s")
 
     # Progressive first (no merge); then an adaptive video+audio pair to mux for
-    # SABR-only videos (age-restricted) that have no progressive format.
+    # SABR-only videos (age-restricted) that have no progressive format. Prefer
+    # 360p for the adaptive branch — it's the cold-press preview, so smaller and
+    # faster matters more than resolution.
     format_str = (
         "best[height<=360][ext=mp4]"
-        "/best[height<=480][ext=mp4]"
+        "/bestvideo[height<=360][vcodec^=avc1]+bestaudio[acodec^=mp4a]"
         "/bestvideo[height<=480][vcodec^=avc1]+bestaudio[acodec^=mp4a]"
-        "/bestvideo[height<=480]+bestaudio"
+        "/best[height<=480][ext=mp4]"
         "/worst[ext=mp4]"
     )
 
@@ -339,6 +341,11 @@ def download_preview(
         # harmless for the progressive branch.
         "--merge-output-format",
         "mp4",
+        # Parallel download (like the HQ path). A single-connection pull of a
+        # long adaptive stream is too slow and times out; aria2c keeps even a
+        # 2h+ episode well inside the cap so the preview is ready quickly.
+        "--downloader",
+        "aria2c",
         "--output",
         output_template,
         "--no-playlist",
@@ -357,9 +364,10 @@ def download_preview(
             cmd,
             capture_output=True,
             text=True,
-            # Muxing an adaptive ≤480p pair (the age-restricted path) downloads
-            # the full A/V streams, so allow more than the progressive case.
-            timeout=300,
+            # Muxing an adaptive pair (the age-restricted path) downloads the
+            # full A/V streams; with aria2c this is quick, but allow generous
+            # headroom for long episodes / slow links before giving up.
+            timeout=600,
         )
     except subprocess.TimeoutExpired:
         raise RuntimeError(f"Preview download timed out for {youtube_video_id}")

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -39,19 +39,18 @@ if [ -f /opt/bgutil-provider/build/main.js ]; then
 fi
 
 # ── Start Celery worker in the background ──────────────────────────────────
+# Run with `&` (not --detach) so the worker's stdout is inherited and its task
+# output — download/preview progress and failures — shows up in `docker logs`.
+# A detached worker daemonizes and its logs never reach the container stream.
 echo "Starting Celery worker..."
 celery -A app.tasks.celery_app worker \
     --loglevel=info \
-    --concurrency="${DOWNLOAD_CONCURRENCY:-2}" \
-    --detach \
-    --logfile=/dev/stdout
+    --concurrency="${DOWNLOAD_CONCURRENCY:-2}" &
 
 # ── Start Celery Beat scheduler in the background ─────────────────────────
 echo "Starting Celery Beat scheduler..."
 celery -A app.tasks.celery_app beat \
-    --loglevel=info \
-    --detach \
-    --logfile=/dev/stdout
+    --loglevel=info &
 
 # ── Start FastAPI ──────────────────────────────────────────────────────────
 echo "Starting FastAPI on port ${PORT}..."


### PR DESCRIPTION
Follow-up to #103. #771 (a **2h9m** age-restricted episode) instant-streams 502 as expected (no progressive), but its adaptive preview was failing — **invisibly**, because the Celery worker runs `--detach`'d so its logs never reach the container stream.

- **entrypoint**: start worker + beat with `&` instead of `--detach` → their task output (download/preview progress + failures) now shows in `docker logs`.
- **download_preview**: download the adaptive fallback with **aria2c** (parallel, like the HQ path) and prefer **360p** — a single-connection pull of a 2h adaptive stream is too slow and hit the timeout. Timeout 300→600s.

Verified the rebuilt image boots with worker/beat logging to stdout + the po_token provider running. **321 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)