### PR TITLE
fix(potoken): verify provider up + dump formats on "format not available"

### DIFF
--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -326,6 +326,8 @@ def download_preview(
         "best[height<=360][ext=mp4]"
         "/bestvideo[height<=360][vcodec^=avc1]+bestaudio[acodec^=mp4a]"
         "/bestvideo[height<=480][vcodec^=avc1]+bestaudio[acodec^=mp4a]"
+        "/bestvideo[height<=720][vcodec^=avc1]+bestaudio[acodec^=mp4a]"
+        "/bestvideo[height<=720][vcodec^=avc1]+bestaudio"  # any audio if no m4a
         "/best[height<=480][ext=mp4]"
         "/worst[ext=mp4]"
     )
@@ -375,6 +377,31 @@ def download_preview(
     if result.returncode != 0:
         tail = (result.stderr or result.stdout or "").strip().splitlines()[-1:]
         detail = tail[0] if tail else "unknown error"
+        # "Requested format is not available" usually means the po_token provider
+        # is down (authenticated SABR formats stay hidden). Dump what yt-dlp does
+        # see so we can tell "no formats at all" (po_token) from "selector miss".
+        if "format is not available" in detail.lower():
+            try:
+                probe = subprocess.run(
+                    [
+                        "yt-dlp",
+                        *cookie_args(),
+                        "-F",
+                        "--no-warnings",
+                        "--no-playlist",
+                        url,
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+                logger.warning(
+                    "Available formats for %s (diagnostic):\n%s",
+                    youtube_video_id,
+                    (probe.stdout or probe.stderr or "(none)").strip()[-1800:],
+                )
+            except Exception:
+                logger.warning("Could not list formats for %s", youtube_video_id)
         raise RuntimeError(
             f"Preview download failed for {youtube_video_id}: {detail[:300]}"
         )

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -31,11 +31,20 @@ redis-server --daemonize yes --loglevel warning
 # ── Start the po_token provider (bgutil) on 127.0.0.1:4416 ─────────────────
 # YouTube serves cookie-authenticated sessions SABR-only formats; the yt-dlp
 # bgutil plugin fetches a PO token from this local server so those formats are
-# downloadable (required for age-restricted playback). Backgrounded; if it dies
-# the plugin just falls back to no-token (non-age videos keep working).
+# downloadable (required for age-restricted playback). Its absence silently
+# hides those formats ("Requested format is not available"), so log its output
+# to stdout and confirm it's actually serving.
 if [ -f /opt/bgutil-provider/build/main.js ]; then
     echo "Starting po_token provider..."
-    ( cd /opt/bgutil-provider && node build/main.js ) >/tmp/bgutil.log 2>&1 &
+    ( cd /opt/bgutil-provider && node build/main.js ) &
+    for i in $(seq 1 15); do
+        if curl -sf -m 2 http://127.0.0.1:4416/ping >/dev/null 2>&1; then
+            echo "po_token provider ready on :4416"
+            break
+        fi
+        [ "$i" = 15 ] && echo "WARNING: po_token provider not responding on :4416 — age-restricted downloads will fail"
+        sleep 1
+    done
 fi
 
 # ── Start Celery worker in the background ──────────────────────────────────


### PR DESCRIPTION
Progress — with fresh cookies, #771 now **passes the age gate**; the preview now fails `Requested format is not available`, which usually means the **po_token provider isn't serving** (authenticated SABR formats stay hidden). node runs on amd64 (verified), so it *should* be up — but we couldn't see it (its log was hidden) or what formats yt-dlp sees.

- **entrypoint**: log the provider to stdout + poll `/ping` → boot prints `po_token provider ready on :4416` (or a WARNING if it never answers).
- **download_preview**: on a "format is not available" failure, run `yt-dlp -F` and log the formats — tells "no formats" (po_token down) from "selector miss".
- broaden the preview format (720p avc1 + any-audio fallbacks) in case the SABR set lacks a ≤480p avc1+m4a pair.

Verified the rebuilt image logs the provider ready on boot. **321 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)