### PR TITLE
fix(download): use web/android clients — default ones downgrade to storyboards

### DIFF
--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -14,7 +14,7 @@ from collections.abc import Callable
 import httpx
 
 from app.config import settings
-from app.utils.ytdlp import cookie_args
+from app.utils.ytdlp import cookie_args, player_client_args
 
 logger = logging.getLogger(__name__)
 
@@ -170,6 +170,9 @@ def download_video(
     cmd = [
         "yt-dlp",
         *cookie_args(),
+        # Default clients (tv/web_creator) get downgraded to storyboards-only for
+        # age-restricted videos; the web/android clients return the real formats.
+        *player_client_args(),
         "--format",
         format_str,
         "--merge-output-format",
@@ -337,6 +340,9 @@ def download_preview(
     cmd = [
         "yt-dlp",
         *cookie_args(),
+        # Default clients (tv/web_creator) get downgraded to storyboards-only for
+        # age-restricted videos; the web/android clients return the real formats.
+        *player_client_args(),
         "--format",
         format_str,
         # Only takes effect when the adaptive fallback is selected (a merge);
@@ -386,6 +392,7 @@ def download_preview(
                     [
                         "yt-dlp",
                         *cookie_args(),
+                        *player_client_args(),
                         "-F",
                         "--no-warnings",
                         "--no-playlist",


### PR DESCRIPTION
The format dump from #105 was conclusive — for an age-restricted video, the **default yt-dlp clients (tv, web_creator) get downgraded and return only storyboard images** (`sb0–sb3`), no video/audio:

```
[youtube] vyKU6Pd5KAA: Downloading tv downgraded player API JSON
[info] Available formats: sb3/sb2/sb1/sb0   ← storyboards only
```

Cookies pass the age gate and the po_token *is* fetched — but those clients still won't yield media. The **web/android clients return the real (SABR adaptive) formats** (that's why instant-stream got "format not available" rather than storyboards).

The download path passed **no** `player_client` (so it used the default clients). Fix: splice in the same `player_client_args()` instant-stream already uses, on `download_video`, `download_preview`, and the diagnostic `-F`. Age-restricted previews/downloads now see the real adaptive formats and mux them.

**321 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)