### PR TITLE
chore(potoken): unpin bgutil + auto-update it with yt-dlp at runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,10 @@ redis==5.2.1
 yt-dlp==2026.6.9
 # yt-dlp plugin: fetches a PO token from the bundled bgutil provider (see
 # Dockerfile/entrypoint) so YouTube's cookie-authenticated SABR-only formats are
-# downloadable — required for age-restricted playback.
-bgutil-ytdlp-pot-provider==1.3.1
+# downloadable — required for age-restricted playback. Intentionally unpinned:
+# YouTube's anti-bot keeps changing, so each build should pull the latest token
+# logic (the entrypoint also `-U`s it at runtime to stay matched with yt-dlp).
+bgutil-ytdlp-pot-provider
 anthropic==0.43.0
 pydantic==2.10.4
 pydantic-settings==2.7.1

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -15,9 +15,13 @@ if [ "$(id -u)" = "0" ]; then
     chown -R "${PUID}:${PGID}" /data
 fi
 
-# ── Auto-update yt-dlp ─────────────────────────────────────────────────────
-echo "Updating yt-dlp..."
-pip install --quiet --upgrade yt-dlp 2>/dev/null || echo "yt-dlp update check failed (non-fatal)"
+# ── Auto-update yt-dlp + the bgutil po_token plugin ────────────────────────
+# YouTube's anti-bot/format enforcement changes constantly; pulling both latest
+# on every start keeps the extractor and its PO-token plugin matched and current
+# (the bundled provider is rebuilt from :latest each image build).
+echo "Updating yt-dlp + po_token plugin..."
+pip install --quiet --upgrade yt-dlp bgutil-ytdlp-pot-provider 2>/dev/null \
+    || echo "yt-dlp/plugin update check failed (non-fatal)"
 
 # ── Run Alembic migrations ─────────────────────────────────────────────────
 echo "Running database migrations..."


### PR DESCRIPTION
Per the user's request — the storyboard-only wall on age-restricted videos is YouTube's anti-bot enforcement, and the realistic path to it working is a **newer po_token implementation**. So stop pinning bgutil:

- **requirements**: unpin `bgutil-ytdlp-pot-provider` (each image build pulls latest, matched with the `:latest` provider image).
- **entrypoint**: add the plugin to the existing `pip -U` so it auto-updates with yt-dlp on every restart, keeping the two matched.

**No behavior change today** (1.3.1 is current) — this just lets bgutil's future fixes land automatically instead of waiting on a manual re-pin. 321 passed; rebuilt image boots with `po_token provider ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)