### PR TITLE
Point canonical/OG URLs at nullfeed.lol

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5,13 +5,13 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>NullFeed — Self-hosted YouTube, minus the algorithm</title>
 <meta name="description" content="NullFeed is a self-hosted YouTube media center: follow your channels, cache every new upload to your own server, and watch ad-free on iPhone, Apple TV, and the web. No ads. No tracking. No algorithm.">
-<link rel="canonical" href="https://nullfeed.wtf/">
+<link rel="canonical" href="https://nullfeed.lol/">
 <meta property="og:site_name" content="NullFeed">
 <meta property="og:title" content="NullFeed — Self-hosted YouTube, minus the algorithm">
 <meta property="og:description" content="Follow your channels. Cache every upload to your own server. Watch ad-free on iPhone, Apple TV, and the web. No ads. No tracking. No algorithm.">
-<meta property="og:url" content="https://nullfeed.wtf/">
+<meta property="og:url" content="https://nullfeed.lol/">
 <meta property="og:type" content="website">
-<meta property="og:image" content="https://nullfeed.wtf/static/og.png">
+<meta property="og:image" content="https://nullfeed.lol/static/og.png">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="theme-color" content="#050505">
 <link rel="icon" href="/static/favicon.png" type="image/png">
@@ -21,7 +21,7 @@
 <link rel="preload" href="/static/fonts/martianmono-var.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/site.css">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"SoftwareApplication","name":"NullFeed","operatingSystem":"iOS, tvOS, Web, Self-hosted (Docker)","applicationCategory":"MultimediaApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://nullfeed.wtf/","image":"https://nullfeed.wtf/static/og.png","description":"Self-hosted YouTube media center: follow your channels, cache new uploads to your own server, and watch ad-free on iPhone, Apple TV, and the web — with sponsor-segment skipping and zero tracking.","license":"https://www.gnu.org/licenses/gpl-3.0.html","sameAs":["https://github.com/windoze95/nullfeed-backend"]}
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"NullFeed","operatingSystem":"iOS, tvOS, Web, Self-hosted (Docker)","applicationCategory":"MultimediaApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://nullfeed.lol/","image":"https://nullfeed.lol/static/og.png","description":"Self-hosted YouTube media center: follow your channels, cache new uploads to your own server, and watch ad-free on iPhone, Apple TV, and the web — with sponsor-segment skipping and zero tracking.","license":"https://www.gnu.org/licenses/gpl-3.0.html","sameAs":["https://github.com/windoze95/nullfeed-backend"]}
 </script>
 </head>
 <body>


### PR DESCRIPTION
Domain purchased: **nullfeed.lol** (chosen over .wtf — funnier, given how hard they push ads). Swaps canonical, og:url, og:image, and JSON-LD URLs from the placeholder nullfeed.wtf.

Infra already wired (zone created, NS flipped at Namecheap, apex + www attached to the Pages project with proxied CNAMEs). Merging this triggers the site deploy via site.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)