### PR TITLE
Cache-bust og:image URL (?v=2)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -11,7 +11,7 @@
 <meta property="og:description" content="Follow your channels. Cache every upload to your own server. Watch ad-free on iPhone, Apple TV, and the web. No ads. No tracking. No algorithm.">
 <meta property="og:url" content="https://nullfeed.lol/">
 <meta property="og:type" content="website">
-<meta property="og:image" content="https://nullfeed.lol/static/og.png">
+<meta property="og:image" content="https://nullfeed.lol/static/og.png?v=2">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="theme-color" content="#050505">
 <link rel="icon" href="/static/favicon.png" type="image/png">
@@ -21,7 +21,7 @@
 <link rel="preload" href="/static/fonts/martianmono-var.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="stylesheet" href="/site.css">
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"SoftwareApplication","name":"NullFeed","operatingSystem":"iOS, tvOS, Web, Self-hosted (Docker)","applicationCategory":"MultimediaApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://nullfeed.lol/","image":"https://nullfeed.lol/static/og.png","description":"Self-hosted YouTube media center: follow your channels, cache new uploads to your own server, and watch ad-free on iPhone, Apple TV, and the web — with sponsor-segment skipping and zero tracking.","license":"https://www.gnu.org/licenses/gpl-3.0.html","sameAs":["https://github.com/windoze95/nullfeed-backend"]}
+{"@context":"https://schema.org","@type":"SoftwareApplication","name":"NullFeed","operatingSystem":"iOS, tvOS, Web, Self-hosted (Docker)","applicationCategory":"MultimediaApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://nullfeed.lol/","image":"https://nullfeed.lol/static/og.png?v=2","description":"Self-hosted YouTube media center: follow your channels, cache new uploads to your own server, and watch ad-free on iPhone, Apple TV, and the web — with sponsor-segment skipping and zero tracking.","license":"https://www.gnu.org/licenses/gpl-3.0.html","sameAs":["https://github.com/windoze95/nullfeed-backend"]}
 </script>
 </head>
 <body>


### PR DESCRIPTION
The updated og.png (NO PROMOS) was stale on edge colos that cached v1 under the immutable /static/* policy, and the deploy token doesn't hold Cache Purge. Versioning the og:image/JSON-LD image URL (`?v=2`) sidesteps the cache entirely — verified `?v=2` returns the new bytes (cf-cache-status: MISS). Bump the version on future og.png changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)