### PR TITLE
Label unplayable videos with a reason (age gate, members-only, premium, …)

### DIFF
--- a/alembic/versions/015_video_unplayable_reason.py
+++ b/alembic/versions/015_video_unplayable_reason.py
@@ -1,0 +1,26 @@
+"""Why YouTube refuses a video, for client banners: videos.unplayable_reason
+
+Revision ID: 015_video_unplayable_reason
+Revises: 014_video_ad_segments
+Create Date: 2026-07-07
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "015_video_unplayable_reason"
+down_revision: Union[str, None] = "014_video_ad_segments"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "videos", sa.Column("unplayable_reason", sa.String(length=32), nullable=True)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("videos", "unplayable_reason")

--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -526,6 +526,8 @@ async def list_channel_videos(
             uploaded_at=v.uploaded_at,
             file_size_bytes=v.file_size_bytes or 0,
             status=v.status,
+            preview_status=v.preview_status,
+            unplayable_reason=v.unplayable_reason,
             thumbnail_url=f"/data/thumbnails/{v.youtube_video_id}.jpg",
             watch_position_seconds=ref.watch_position_seconds if ref else 0,
             is_watched=ref.is_watched if ref else False,

--- a/app/api/feed.py
+++ b/app/api/feed.py
@@ -33,6 +33,7 @@ def _video_out(video: Video, ref: UserVideoRef | None = None) -> VideoOut:
         file_size_bytes=video.file_size_bytes or 0,
         status=video.status,
         preview_status=video.preview_status,
+        unplayable_reason=video.unplayable_reason,
         thumbnail_url=f"/data/thumbnails/{video.youtube_video_id}.jpg",
         watch_position_seconds=ref.watch_position_seconds if ref else 0,
         is_watched=ref.is_watched if ref else False,

--- a/app/api/videos.py
+++ b/app/api/videos.py
@@ -53,6 +53,7 @@ from app.utils.tickets import (
     verify_ticket,
 )
 from app.utils.time import utcnow_naive
+from app.utils.unplayable import SOFT_REASONS
 
 router = APIRouter(prefix="/api/videos", tags=["videos"])
 logger = logging.getLogger(__name__)
@@ -188,6 +189,7 @@ async def search_videos(
             file_size_bytes=video.file_size_bytes or 0,
             status=video.status,
             preview_status=video.preview_status,
+            unplayable_reason=video.unplayable_reason,
             thumbnail_url=f"/data/thumbnails/{video.youtube_video_id}.jpg",
             watch_position_seconds=ref.watch_position_seconds,
             is_watched=ref.is_watched,
@@ -247,6 +249,7 @@ async def get_active_downloads(
             file_size_bytes=v.file_size_bytes or 0,
             status=v.status,
             preview_status=v.preview_status,
+            unplayable_reason=v.unplayable_reason,
             thumbnail_url=f"/data/thumbnails/{v.youtube_video_id}.jpg",
             channel_name=v.channel.name if v.channel else "",
         )
@@ -279,6 +282,14 @@ async def prewarm_previews(
             Video.id.in_(video_ids),
             Video.status != "COMPLETE",
             Video.preview_status.is_(None),
+            # A video YouTube refuses for a hard, video-inherent reason
+            # (members-only, premium, removed, …) can't be pre-warmed; soft
+            # reasons stay eligible — an age gate passes once cookies work and
+            # a premiere airs eventually, and the success clears the label.
+            or_(
+                Video.unplayable_reason.is_(None),
+                Video.unplayable_reason.in_(SOFT_REASONS),
+            ),
         )
     )
     eligible = result.scalars().all()
@@ -330,6 +341,7 @@ async def get_video(
         file_size_bytes=video.file_size_bytes or 0,
         status=video.status,
         preview_status=video.preview_status,
+        unplayable_reason=video.unplayable_reason,
         thumbnail_url=f"/data/thumbnails/{video.youtube_video_id}.jpg",
         watch_position_seconds=ref.watch_position_seconds if ref else 0,
         is_watched=ref.is_watched if ref else False,
@@ -676,9 +688,31 @@ async def instant_stream(
 
     try:
         url = await asyncio.to_thread(resolve_progressive_url, video.youtube_video_id)
+    except InstantStreamError as exc:
+        logger.warning("instant-stream resolve failed for %s: %s", video_id, exc)
+        if exc.reason:
+            # The refusal is inherent to the video (age gate, members-only,
+            # removed, …): persist it so listings banner the video from now on.
+            video.unplayable_reason = exc.reason
+            await db.commit()
+            raise HTTPException(
+                status_code=502,
+                detail=f"Could not start instant stream ({exc.reason})",
+            ) from exc
+        raise HTTPException(
+            status_code=502, detail="Could not start instant stream"
+        ) from exc
+
+    # A successful resolve proves the video is fetchable — drop any stale label
+    # (a premiere that has since aired, an age gate after cookies were added).
+    if video.unplayable_reason is not None:
+        video.unplayable_reason = None
+        await db.commit()
+
+    try:
         return await stream_proxy(url, range_header)
     except InstantStreamError as exc:
-        logger.warning("instant-stream resolve/proxy failed for %s: %s", video_id, exc)
+        logger.warning("instant-stream proxy failed for %s: %s", video_id, exc)
         raise HTTPException(
             status_code=502, detail="Could not start instant stream"
         ) from exc

--- a/app/models/video.py
+++ b/app/models/video.py
@@ -41,6 +41,12 @@ class Video(Base):
     # no ads were found).
     ad_segments: Mapped[list | None] = mapped_column(JSON, nullable=True)
     ad_segments_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # Why YouTube refuses this video (age_restricted, members_only, premium,
+    # private, geo_blocked, removed, drm, upcoming, unavailable — see
+    # app/utils/unplayable.py). Set when a poll, download, preview, or
+    # instant-stream attempt hits a video-inherent refusal; cleared whenever an
+    # attempt later succeeds. NULL = playable as far as we know.
+    unplayable_reason: Mapped[str | None] = mapped_column(String(32), nullable=True)
     downloaded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     # Liveness signal for an in-flight download: set when the row enters
     # DOWNLOADING and refreshed by the worker as yt-dlp produces output. The

--- a/app/schemas/video.py
+++ b/app/schemas/video.py
@@ -14,6 +14,10 @@ class VideoOut(BaseModel):
     file_size_bytes: int = 0
     status: str = "CATALOGED"
     preview_status: str | None = None
+    # Why YouTube refuses this video (age_restricted, members_only, premium,
+    # private, geo_blocked, removed, drm, upcoming, unavailable), or None when
+    # playable as far as we know. Clients render this as a banner.
+    unplayable_reason: str | None = None
     thumbnail_url: str | None = None
     watch_position_seconds: int = 0
     is_watched: bool = False

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -19,6 +19,7 @@ from app.services.download_manager import (
 from app.services.progress_broadcaster import publish_new_episode
 from app.services.push_gateway import send_to_users
 from app.utils.time import utcnow_naive
+from app.utils.unplayable import SOFT_REASONS
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +239,14 @@ def _catalog_videos(
             except (ValueError, TypeError):
                 pass
 
+        # A video-inherent refusal known at discovery time (members-only /
+        # premium badge, unaired premiere, or a classified extraction failure).
+        # Hard reasons never auto-download (it can't succeed) and stay out of
+        # new-episode pushes (notifying about unwatchable content is noise) —
+        # the labeled row in the feed is the visibility.
+        reason = yt_vid.get("unplayable_reason")
+        hard_blocked = bool(reason) and reason not in SOFT_REASONS
+
         # Create new video record as CATALOGED (not PENDING)
         video = Video(
             id=str(uuid.uuid4()),
@@ -247,6 +256,7 @@ def _catalog_videos(
             duration_seconds=yt_vid.get("duration_seconds", 0),
             uploaded_at=uploaded_at,
             status="CATALOGED",
+            unplayable_reason=reason,
             created_at=poll_started_at - timedelta(seconds=index),
         )
         db.add(video)
@@ -255,15 +265,17 @@ def _catalog_videos(
         id_by_ytid[yt_video_id] = video.id
 
         video_ids_for_refs.append(video.id)
-        new_video_ids.append(video.id)
+        if not hard_blocked:
+            new_video_ids.append(video.id)
         cataloged_ids.append(video.id)
-        new_videos_for_events.append(
-            {
-                "id": video.id,
-                "title": video.title,
-                "youtube_video_id": video.youtube_video_id,
-            }
-        )
+        if not hard_blocked:
+            new_videos_for_events.append(
+                {
+                    "id": video.id,
+                    "title": video.title,
+                    "youtube_video_id": video.youtube_video_id,
+                }
+            )
         logger.info("New video cataloged: %s (%s)", yt_video_id, video.title)
 
     # One batched ref-ensure over every video this batch touched, instead of the
@@ -408,7 +420,13 @@ def _discover_routine(channel: Channel, db: Session) -> list[dict] | None:
         return None
 
     logger.info("RSS surfaced %d new video(s) for channel %s", len(new_ids), channel.id)
-    return fetch_videos_metadata(new_ids)
+    # The feed already named every id; pass the titles along so an id whose
+    # extraction fails for a video-inherent reason (members-only, premiere) is
+    # cataloged under its real title rather than the bare video id.
+    rss_titles = {
+        e["youtube_video_id"]: e["title"] for e in rss["entries"] if e.get("title")
+    }
+    return fetch_videos_metadata(new_ids, titles=rss_titles)
 
 
 def refresh_stale_channel_metadata(db: Session) -> int:

--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -188,6 +188,11 @@ def _catalog_videos(
     adaptive cadence are folded into the same commit; the WebSub path passes
     ``False`` so the poll schedule (the RSS fallback) is left entirely untouched.
     Returns ``{"cataloged_ids", "auto_download_ids"}``.
+
+    Entries carrying a hard ``unplayable_reason`` (members-only, premium,
+    removed, …) are still cataloged — visibility is the point — but sit out
+    auto-download and new-episode notifications, since fetching can't succeed
+    and notifying about unwatchable content is noise.
     """
     channel_id = channel.id
     cataloged_ids: list[str] = []

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -14,6 +14,12 @@ from collections.abc import Callable
 import httpx
 
 from app.config import settings
+from app.utils.unplayable import (
+    UnplayableVideoError,
+    classify_entry,
+    classify_extraction_error,
+    extract_error_text,
+)
 from app.utils.ytdlp import cookie_args, player_client_args
 
 logger = logging.getLogger(__name__)
@@ -207,6 +213,10 @@ def download_video(
     progress_re = re.compile(r"\[download\]\s+([\d.]+)%|\((\d+)%\)")
     last_callback_time = 0.0
     last_line = ""
+    # stderr is merged into stdout, and yt-dlp's "ERROR: …" line isn't always
+    # last (aria2c chatter can follow) — track it separately so a failure is
+    # reported/classified from the actual error, not trailing noise.
+    last_error_line = ""
 
     # Read the tuning constants at call time (not via the watchdog's default
     # args, which bind at import) so they can be overridden in tests.
@@ -223,6 +233,8 @@ def download_video(
         for line in stdout_lines:
             watchdog.note_output()
             last_line = line
+            if "error" in line.lower():
+                last_error_line = line
 
             if heartbeat_callback is not None:
                 heartbeat_callback()
@@ -274,8 +286,15 @@ def download_video(
         )
 
     if process.returncode != 0:
-        logger.error("yt-dlp failed for %s: %s", youtube_video_id, last_line)
-        raise RuntimeError(f"yt-dlp failed: {last_line[:500]}")
+        err_text = (last_error_line or last_line).strip()
+        logger.error("yt-dlp failed for %s: %s", youtube_video_id, err_text)
+        reason = classify_extraction_error(err_text)
+        if reason:
+            # Video-inherent refusal (age gate, members-only, removed, …):
+            # retrying can't succeed, so raise the non-retried error and let
+            # the task record why.
+            raise UnplayableVideoError(reason, f"yt-dlp failed: {err_text[:500]}")
+        raise RuntimeError(f"yt-dlp failed: {err_text[:500]}")
 
     # Find the downloaded file
     file_path = _find_downloaded_file(output_dir, youtube_video_id)
@@ -381,8 +400,9 @@ def download_preview(
         raise RuntimeError(f"Preview download timed out for {youtube_video_id}")
 
     if result.returncode != 0:
-        tail = (result.stderr or result.stdout or "").strip().splitlines()[-1:]
-        detail = tail[0] if tail else "unknown error"
+        detail = (
+            extract_error_text(result.stderr or result.stdout or "") or "unknown error"
+        )
         # "Requested format is not available" usually means the po_token provider
         # is down (authenticated SABR formats stay hidden). Dump what yt-dlp does
         # see so we can tell "no formats at all" (po_token) from "selector miss".
@@ -409,6 +429,12 @@ def download_preview(
                 )
             except Exception:
                 logger.warning("Could not list formats for %s", youtube_video_id)
+        reason = classify_extraction_error(detail)
+        if reason:
+            raise UnplayableVideoError(
+                reason,
+                f"Preview download failed for {youtube_video_id}: {detail[:300]}",
+            )
         raise RuntimeError(
             f"Preview download failed for {youtube_video_id}: {detail[:300]}"
         )
@@ -727,6 +753,11 @@ def fetch_channel_videos(
                         "title": data.get("title", ""),
                         "duration_seconds": int(data.get("duration") or 0),
                         "upload_date": data.get("upload_date"),
+                        # Flat entries carry availability derived from the tab
+                        # badges ("Members only", premium) and a live_status, so
+                        # membership/premium/upcoming videos get labeled at
+                        # catalog time instead of on their first failed fetch.
+                        "unplayable_reason": classify_entry(data),
                     }
                 )
                 # Extract channel metadata from the first entry
@@ -840,13 +871,29 @@ def fetch_channel_rss(
     }
 
 
-def fetch_videos_metadata(video_ids: list[str]) -> list[dict]:
+# Per-video failure line in yt-dlp's stderr for a multi-URL batch, e.g.
+# "ERROR: [youtube] dQw4w9WgXcQ: Join this channel to get access …". The 11-char
+# id ties the message back to the video that failed.
+_YTDLP_ERROR_RE = re.compile(r"ERROR:\s*(?:\[[^\]]+\]\s*)?([A-Za-z0-9_-]{11}):\s*(.+)")
+
+
+def fetch_videos_metadata(
+    video_ids: list[str], titles: dict[str, str] | None = None
+) -> list[dict]:
     """Fetch yt-dlp metadata for specific video IDs, preserving input order.
 
     Used after RSS discovery surfaces genuinely-new uploads: only those IDs are
     extracted (typically one or two), instead of re-scanning the whole channel.
-    Returns dicts shaped like ``fetch_channel_videos`` entries; IDs that fail to
-    extract (private, removed, geo-blocked) are simply omitted.
+    Returns dicts shaped like ``fetch_channel_videos`` entries.
+
+    IDs whose extraction fails for a video-inherent reason (members-only, age
+    gate, premium, private, removed, an unaired premiere) are still returned, as
+    stub entries carrying ``unplayable_reason`` — so they get cataloged and the
+    clients can banner them instead of the video silently never appearing.
+    ``titles`` (id -> title, e.g. from the RSS entries that surfaced the ids)
+    names those stubs; without it the stub falls back to the video id. IDs that
+    fail for any other reason (network, bot check) are omitted as before, so a
+    flaky poll doesn't catalog mislabeled rows.
     """
     if not video_ids:
         return []
@@ -855,6 +902,7 @@ def fetch_videos_metadata(video_ids: list[str]) -> list[dict]:
     cmd = ["yt-dlp", "--dump-json", "--no-playlist", *urls]
 
     by_id: dict[str, dict] = {}
+    failures: dict[str, str] = {}
     try:
         # One video may fail (returncode != 0) while others succeed, so parse
         # whatever JSON lines came back regardless of the exit status.
@@ -873,8 +921,15 @@ def fetch_videos_metadata(video_ids: list[str]) -> list[dict]:
                     "title": data.get("title", ""),
                     "duration_seconds": int(data.get("duration") or 0),
                     "upload_date": data.get("upload_date"),
+                    # Extraction succeeded, but the availability badges can
+                    # still say the media itself is gated (members/premium).
+                    "unplayable_reason": classify_entry(data),
                 }
         if result.returncode != 0:
+            for err_line in (result.stderr or "").splitlines():
+                match = _YTDLP_ERROR_RE.search(err_line)
+                if match:
+                    failures[match.group(1)] = match.group(2)
             logger.warning(
                 "yt-dlp metadata fetch returned %s for %d id(s); got %d",
                 result.returncode,
@@ -883,6 +938,20 @@ def fetch_videos_metadata(video_ids: list[str]) -> list[dict]:
             )
     except Exception as e:
         logger.warning("Failed to fetch metadata for %s: %s", video_ids, e)
+
+    for vid, error in failures.items():
+        if vid in by_id or vid not in video_ids:
+            continue
+        reason = classify_extraction_error(error)
+        if reason is None:
+            continue  # transient/unrecognized: drop the id, as before
+        by_id[vid] = {
+            "youtube_video_id": vid,
+            "title": (titles or {}).get(vid) or vid,
+            "duration_seconds": 0,
+            "upload_date": None,
+            "unplayable_reason": reason,
+        }
 
     # Preserve the requested (newest-first) order; drop any that didn't resolve.
     return [by_id[vid] for vid in video_ids if vid in by_id]

--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -27,6 +27,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 from fastapi.responses import StreamingResponse
 
+from app.utils.unplayable import classify_extraction_error, extract_error_text
 from app.utils.ytdlp import (
     PROGRESSIVE_FORMAT,
     cookie_args,
@@ -71,7 +72,16 @@ _cache_lock = threading.Lock()
 
 
 class InstantStreamError(Exception):
-    """Raised when a progressive source URL cannot be resolved."""
+    """Raised when a progressive source URL cannot be resolved.
+
+    ``reason`` carries the canonical unplayable reason (app/utils/unplayable)
+    when the failure is inherent to the video — age gate, members-only,
+    removed, … — and None for infrastructural/transient failures.
+    """
+
+    def __init__(self, message: str, reason: str | None = None):
+        super().__init__(message)
+        self.reason = reason
 
 
 def _ytdlp_get_url(youtube_video_id: str) -> str:
@@ -106,10 +116,10 @@ def _ytdlp_get_url(youtube_video_id: str) -> str:
         # valid (android can't use them; web passes age but is SABR-only), so a
         # resolve failure is not a reliable cookie signal. Cookie validity is
         # owned by the save-time verify (see app/utils/ytdlp.verify_cookies).
-        tail = stderr.strip().splitlines()[-1:]
-        detail = tail[0] if tail else "unknown error"
+        detail = extract_error_text(stderr) or "unknown error"
         raise InstantStreamError(
-            f"Resolve failed for {youtube_video_id}: {detail[:300]}"
+            f"Resolve failed for {youtube_video_id}: {detail[:300]}",
+            reason=classify_extraction_error(detail),
         )
 
     # -g prints one URL per selected stream; a progressive format yields exactly

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -34,6 +34,7 @@ from app.services.retention import enforce_retention
 from app.services.session_reaper import reap_expired_sessions
 from app.services.websub import sync_subscriptions
 from app.utils.time import utcnow_naive
+from app.utils.unplayable import UnplayableVideoError
 from app.services.progress_broadcaster import (
     publish_ad_segments_ready,
     publish_download_complete,
@@ -336,6 +337,9 @@ def download_video_task(
         video.duration_seconds = result["duration_seconds"]
         video.metadata_json = result.get("metadata_json")
         video.status = "COMPLETE"
+        # A finished download proves the video is fetchable; drop any stale
+        # refusal label (e.g. an age gate recorded before cookies were added).
+        video.unplayable_reason = None
         video.downloaded_at = utcnow_naive()
 
         if result.get("uploaded_at"):
@@ -399,6 +403,26 @@ def download_video_task(
         except Exception:
             logger.exception("Could not confirm cancel for video %s", video_id)
         return {"status": "cancelled", "video_id": video_id}
+
+    except UnplayableVideoError as exc:
+        # YouTube refused the video for a reason inherent to it (age gate,
+        # members-only, premium, removed, …). Retrying can't succeed — the
+        # exception type is outside autoretry_for on purpose — so mark the
+        # video FAILED and record why, for the clients to banner.
+        logger.warning("Video %s is unplayable (%s): %s", video_id, exc.reason, exc)
+        try:
+            db.rollback()
+            video = db.get(Video, video_id)
+            if video:
+                if video.status == "DOWNLOADING":
+                    video.status = "FAILED"
+                video.unplayable_reason = exc.reason
+                db.commit()
+        except Exception:
+            logger.exception(
+                "Could not record unplayable reason for video %s", video_id
+            )
+        return {"status": "unplayable", "reason": exc.reason, "video_id": video_id}
 
     except Exception as exc:
         logger.exception("Download failed for video %s", video_id)
@@ -466,12 +490,34 @@ def download_preview_task(self, video_id: str, user_id: str) -> dict:
 
         video.preview_file_path = result["file_path"]
         video.preview_status = "READY"
+        # A working preview proves the video is fetchable; drop any stale label.
+        video.unplayable_reason = None
         db.commit()
 
         publish_preview_ready(video_id, user_id)
 
         logger.info("Preview ready: %s (%s)", video.youtube_video_id, video.title)
         return {"status": "complete", "video_id": video_id}
+
+    except UnplayableVideoError as exc:
+        # Video-inherent refusal: record why (for client banners) and reset
+        # preview_status so nothing looks in-flight. Not re-raised — the type
+        # is outside autoretry_for on purpose, a retry can't succeed.
+        logger.warning(
+            "Preview for video %s is unplayable (%s): %s", video_id, exc.reason, exc
+        )
+        try:
+            db.rollback()
+            video = db.get(Video, video_id)
+            if video:
+                video.preview_status = None
+                video.unplayable_reason = exc.reason
+                db.commit()
+        except Exception:
+            logger.exception(
+                "Could not record unplayable reason for video %s", video_id
+            )
+        return {"status": "unplayable", "reason": exc.reason, "video_id": video_id}
 
     except Exception as exc:
         logger.exception("Preview download failed for video %s", video_id)

--- a/app/utils/unplayable.py
+++ b/app/utils/unplayable.py
@@ -1,0 +1,174 @@
+"""Classify why a video can't be played or downloaded.
+
+YouTube refuses some videos for reasons that are properties of the *video*, not
+of our infrastructure: age restriction, channel-membership ("members only")
+gating, paid/Premium content, private/removed videos, region locks, DRM, and
+not-yet-premiered uploads. yt-dlp surfaces each as an error string (and, on
+successful metadata extraction, as an ``availability`` value). This module maps
+those onto a small canonical vocabulary stored in ``videos.unplayable_reason``
+and exposed through the API so clients can label the video instead of failing
+with a generic error.
+
+Classification is deliberately conservative: anything transient (bot checks,
+captchas, rate limits, network trouble) or simply unrecognized returns ``None``
+so a flaky attempt never brands a playable video. A stored reason is cleared
+whenever a download, preview, or instant-stream resolve later succeeds — so a
+stale label (e.g. age restriction once cookies are configured, or a premiere
+that has since gone live) heals itself on the next successful attempt.
+"""
+
+# Canonical reason values (also the client-facing API vocabulary).
+AGE_RESTRICTED = "age_restricted"
+MEMBERS_ONLY = "members_only"
+PREMIUM = "premium"
+PRIVATE = "private"
+GEO_BLOCKED = "geo_blocked"
+REMOVED = "removed"
+DRM = "drm"
+UPCOMING = "upcoming"
+UNAVAILABLE = "unavailable"
+
+# Reasons the server may still overcome, so automatic work (auto-download,
+# preview pre-warm) should keep trying: an age gate passes once working YouTube
+# cookies are configured (the poll's anonymous extraction can't know that), and
+# an upcoming premiere becomes downloadable the moment it airs. Everything else
+# is a hard wall no amount of retrying gets past.
+SOFT_REASONS = frozenset({AGE_RESTRICTED, UPCOMING})
+
+# Failures that must never label a video: they describe the session/network at
+# that moment, not the video. Checked before the reason markers because a
+# couple of them ("try again later", "not a bot") share words with permanent
+# messages.
+_TRANSIENT_MARKERS = (
+    "not a bot",
+    "captcha",
+    "try again later",
+    "rate limit",
+    "rate-limit",
+    "timed out",
+    "timeout",
+    "connection reset",
+    "temporary failure",
+    "unable to download webpage",
+    "unable to download api page",
+    "http error 5",
+)
+
+# Ordered (reason, markers) pairs matched against a lowercased yt-dlp error.
+# Order matters where messages overlap: "Video unavailable. This video has been
+# removed…" must classify as REMOVED, so REMOVED precedes UNAVAILABLE; the
+# private-video message contains "sign in" but is matched by "private video"
+# before any age marker could see it.
+_REASON_MARKERS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (MEMBERS_ONLY, ("members-only", "join this channel", "channel's members")),
+    (PREMIUM, ("requires payment", "premium member")),
+    (
+        AGE_RESTRICTED,
+        (
+            "confirm your age",
+            "age-restricted",
+            "age restricted",
+            "inappropriate for some users",
+            "age_verification_required",
+            "age_check_required",
+        ),
+    ),
+    (PRIVATE, ("private video", "video is private")),
+    (
+        GEO_BLOCKED,
+        (
+            "not made this video available in your country",
+            "not available in your country",
+            "geo restricted",
+            "geo-restricted",
+        ),
+    ),
+    (DRM, ("drm protected", "drm-protected")),
+    (UPCOMING, ("premieres in", "this live event will begin")),
+    (
+        REMOVED,
+        (
+            "has been removed",
+            "been terminated",
+            "copyright claim",
+            "copyright grounds",
+        ),
+    ),
+    (UNAVAILABLE, ("video unavailable", "no longer available")),
+)
+
+# yt-dlp ``availability`` values (from successful extraction, full or
+# flat-playlist badges) that imply the video can't be fetched. ``needs_auth``
+# is deliberately absent: it marks age-restricted videos whose extraction
+# *succeeded*, i.e. the server is authorized and the video is playable.
+_AVAILABILITY_REASONS = {
+    "subscriber_only": MEMBERS_ONLY,
+    "premium_only": PREMIUM,
+    "private": PRIVATE,
+}
+
+
+class UnplayableVideoError(Exception):
+    """A download/preview attempt failed for a reason inherent to the video.
+
+    Deliberately not a ``RuntimeError``: the Celery download tasks auto-retry
+    RuntimeErrors, and retrying a members-only or removed video is pointless.
+    """
+
+    def __init__(self, reason: str, message: str):
+        super().__init__(message)
+        self.reason = reason
+
+
+def extract_error_text(output: str) -> str:
+    """The most error-relevant line of a yt-dlp output blob.
+
+    yt-dlp prints its failure as an ``ERROR:`` line that is usually — but not
+    always — last (aria2c chatter and diagnostics can follow). Prefer the last
+    ERROR line; fall back to the last non-empty line.
+    """
+    lines = [ln.strip() for ln in (output or "").splitlines() if ln.strip()]
+    for line in reversed(lines):
+        if "error" in line.lower():
+            return line
+    return lines[-1] if lines else ""
+
+
+def classify_extraction_error(message: str | None) -> str | None:
+    """Map a yt-dlp error message to a canonical reason, or None.
+
+    None means "don't label": the error is transient, infrastructural, or
+    unrecognized.
+    """
+    if not message:
+        return None
+    lowered = message.lower()
+    if any(marker in lowered for marker in _TRANSIENT_MARKERS):
+        return None
+    for reason, markers in _REASON_MARKERS:
+        if any(marker in lowered for marker in markers):
+            return reason
+    return None
+
+
+def classify_availability(availability: str | None) -> str | None:
+    """Map yt-dlp's ``availability`` field to a canonical reason, or None."""
+    if not availability:
+        return None
+    return _AVAILABILITY_REASONS.get(availability)
+
+
+def classify_live_status(live_status: str | None) -> str | None:
+    """Map yt-dlp's ``live_status`` to a canonical reason, or None.
+
+    Only ``is_upcoming`` (scheduled premieres / streams) is unplayable; a live
+    or finished stream is left unlabeled.
+    """
+    return UPCOMING if live_status == "is_upcoming" else None
+
+
+def classify_entry(entry: dict) -> str | None:
+    """Reason for a yt-dlp metadata entry (full or flat), or None."""
+    return classify_availability(entry.get("availability")) or classify_live_status(
+        entry.get("live_status")
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -74,6 +74,7 @@ async def seed_video(
     uploaded_at: datetime | None = None,
     preview_file_path: str | None = None,
     preview_status: str | None = None,
+    unplayable_reason: str | None = None,
 ) -> Video:
     video = Video(
         id=str(uuid.uuid4()),
@@ -86,6 +87,7 @@ async def seed_video(
         uploaded_at=uploaded_at,
         preview_file_path=preview_file_path,
         preview_status=preview_status,
+        unplayable_reason=unplayable_reason,
     )
     db.add(video)
     await db.commit()

--- a/tests/test_adaptive_poll.py
+++ b/tests/test_adaptive_poll.py
@@ -238,7 +238,7 @@ def test_routine_new_upload_poll_shortens_cadence(monkeypatch):
     monkeypatch.setattr(
         channel_poller,
         "fetch_videos_metadata",
-        lambda ids: [
+        lambda ids, titles=None: [
             {
                 "youtube_video_id": vid,
                 "title": vid,

--- a/tests/test_channel_poller.py
+++ b/tests/test_channel_poller.py
@@ -307,7 +307,7 @@ def test_routine_poll_rss_new_id_catalogs_via_metadata(monkeypatch):
     )
     meta_calls = {}
 
-    def fake_meta(ids):
+    def fake_meta(ids, titles=None):
         meta_calls["ids"] = ids
         return [
             {

--- a/tests/test_parallel_poll.py
+++ b/tests/test_parallel_poll.py
@@ -194,7 +194,7 @@ def test_failing_channel_job_does_not_abort_others(eager_celery, task_db, monkey
     monkeypatch.setattr(
         channel_poller,
         "fetch_videos_metadata",
-        lambda ids: [
+        lambda ids, titles=None: [
             {
                 "youtube_video_id": vid,
                 "title": vid,

--- a/tests/test_unplayable.py
+++ b/tests/test_unplayable.py
@@ -1,0 +1,556 @@
+"""Unplayable-reason detection: classify why YouTube refuses a video (age gate,
+members-only, premium, private, geo block, removed, DRM, unaired premiere),
+persist it on the row, surface it via the API, and clear it on any success."""
+
+import json
+import subprocess
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+import app.api.videos as videos_api
+from app.database import async_session_factory
+from app.models import Base
+from app.models.channel import Channel
+from app.models.video import Video
+from app.services import channel_poller, download_manager
+from app.services.download_manager import (
+    download_video,
+    fetch_channel_videos,
+    fetch_videos_metadata,
+)
+from app.services.instant_stream import InstantStreamError
+from app.utils.unplayable import (
+    AGE_RESTRICTED,
+    MEMBERS_ONLY,
+    PREMIUM,
+    PRIVATE,
+    REMOVED,
+    UPCOMING,
+    SOFT_REASONS,
+    UnplayableVideoError,
+    classify_availability,
+    classify_extraction_error,
+    classify_live_status,
+    extract_error_text,
+)
+from tests.helpers import fake_completed_process, seed_channel, seed_video
+
+# --- classifier ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        # Real yt-dlp / YouTube playability strings, one per reason.
+        (
+            "ERROR: [youtube] abc: Sign in to confirm your age. "
+            "This video may be inappropriate for some users.",
+            "age_restricted",
+        ),
+        (
+            "ERROR: [youtube] abc: Join this channel to get access to "
+            "members-only content like this video, and other exclusive perks.",
+            "members_only",
+        ),
+        ("ERROR: [youtube] abc: This video requires payment to watch.", "premium"),
+        (
+            "ERROR: [youtube] abc: This video is available to Music Premium "
+            "members only",
+            "premium",
+        ),
+        (
+            "ERROR: [youtube] abc: Private video. Sign in if you've been "
+            "granted access to this video",
+            "private",
+        ),
+        (
+            "ERROR: [youtube] abc: The uploader has not made this video "
+            "available in your country",
+            "geo_blocked",
+        ),
+        ("ERROR: [youtube] abc: This video is DRM protected", "drm"),
+        ("ERROR: [youtube] abc: Premieres in 3 hours", "upcoming"),
+        ("ERROR: [youtube] abc: This live event will begin in 2 hours", "upcoming"),
+        (
+            "ERROR: [youtube] abc: Video unavailable. This video has been "
+            "removed by the uploader",
+            "removed",
+        ),
+        (
+            "ERROR: [youtube] abc: This video is no longer available because "
+            "the YouTube account associated with this video has been terminated.",
+            "removed",
+        ),
+        ("ERROR: [youtube] abc: Video unavailable", "unavailable"),
+    ],
+)
+def test_classify_recognizes_permanent_reasons(message, expected):
+    assert classify_extraction_error(message) == expected
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        # Session/infrastructure trouble must never label the video.
+        "ERROR: [youtube] abc: Sign in to confirm you're not a bot.",
+        "ERROR: [youtube] abc: This content isn't available, try again later.",
+        "ERROR: [youtube] abc: YouTube is requiring a captcha challenge",
+        "ERROR: unable to download webpage: HTTP Error 500",
+        "ERROR: [youtube] abc: Requested format is not available",
+        "some random failure",
+        "",
+        None,
+    ],
+)
+def test_classify_ignores_transient_and_unknown(message):
+    assert classify_extraction_error(message) is None
+
+
+def test_classify_availability_maps_gated_values():
+    assert classify_availability("subscriber_only") == MEMBERS_ONLY
+    assert classify_availability("premium_only") == PREMIUM
+    assert classify_availability("private") == PRIVATE
+    # needs_auth means extraction *succeeded* while age-gated -> playable here.
+    assert classify_availability("needs_auth") is None
+    assert classify_availability("public") is None
+    assert classify_availability(None) is None
+
+
+def test_classify_live_status_only_flags_upcoming():
+    assert classify_live_status("is_upcoming") == UPCOMING
+    assert classify_live_status("is_live") is None
+    assert classify_live_status(None) is None
+
+
+def test_extract_error_text_prefers_error_line_over_trailing_noise():
+    blob = (
+        "[download] 12.3%\n"
+        "ERROR: [youtube] abc: Join this channel to get access to members-only "
+        "content\n"
+        "[aria2c] shutting down\n"
+    )
+    assert extract_error_text(blob).startswith("ERROR: [youtube] abc: Join")
+    assert extract_error_text("") == ""
+
+
+# --- poll-time labeling ------------------------------------------------------
+
+
+def test_fetch_channel_videos_labels_flat_entries(monkeypatch):
+    entries = [
+        {"id": "AAA00000001", "title": "Public", "duration": 10},
+        {
+            "id": "BBB00000002",
+            "title": "Members",
+            "duration": 20,
+            "availability": "subscriber_only",
+        },
+        {
+            "id": "CCC00000003",
+            "title": "Premiere",
+            "duration": 0,
+            "live_status": "is_upcoming",
+        },
+    ]
+    stdout = "\n".join(json.dumps(e) for e in entries)
+    monkeypatch.setattr(
+        download_manager.subprocess,
+        "run",
+        lambda *a, **k: fake_completed_process(stdout),
+    )
+
+    videos = fetch_channel_videos("UCabc")["videos"]
+
+    assert [v["unplayable_reason"] for v in videos] == [None, MEMBERS_ONLY, UPCOMING]
+
+
+def test_fetch_videos_metadata_stubs_unplayable_ids(monkeypatch):
+    ok_entry = {"id": "AAA00000001", "title": "Public", "duration": 10}
+    stderr = (
+        "ERROR: [youtube] BBB00000002: Join this channel to get access to "
+        "members-only content like this video, and other exclusive perks.\n"
+        "ERROR: [youtube] CCC00000003: Sign in to confirm you're not a bot.\n"
+    )
+    monkeypatch.setattr(
+        download_manager.subprocess,
+        "run",
+        lambda *a, **k: fake_completed_process(
+            json.dumps(ok_entry), returncode=1, stderr=stderr
+        ),
+    )
+
+    result = fetch_videos_metadata(
+        ["AAA00000001", "BBB00000002", "CCC00000003"],
+        titles={"BBB00000002": "Members Episode"},
+    )
+
+    # Order preserved; the members-only id is a labeled stub with the RSS
+    # title; the bot-check (transient) id is omitted as before.
+    assert [v["youtube_video_id"] for v in result] == ["AAA00000001", "BBB00000002"]
+    assert result[0]["unplayable_reason"] is None
+    assert result[1]["unplayable_reason"] == MEMBERS_ONLY
+    assert result[1]["title"] == "Members Episode"
+
+
+def test_fetch_videos_metadata_stub_title_falls_back_to_id(monkeypatch):
+    stderr = "ERROR: [youtube] BBB00000002: This video requires payment to watch.\n"
+    monkeypatch.setattr(
+        download_manager.subprocess,
+        "run",
+        lambda *a, **k: fake_completed_process("", returncode=1, stderr=stderr),
+    )
+
+    result = fetch_videos_metadata(["BBB00000002"])
+
+    assert len(result) == 1
+    assert result[0]["title"] == "BBB00000002"
+    assert result[0]["unplayable_reason"] == PREMIUM
+
+
+# --- cataloging --------------------------------------------------------------
+
+
+def _mem_session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_catalog_videos_labels_and_gates_hard_blocked(monkeypatch):
+    db = _mem_session()
+    channel = Channel(
+        id=str(uuid.uuid4()),
+        youtube_channel_id="UCabc1230000000000000000",
+        name="Test",
+        slug="test",
+    )
+    db.add(channel)
+    db.commit()
+
+    emit_mock = MagicMock()
+    monkeypatch.setattr(channel_poller, "_emit_new_episode_events", emit_mock)
+    auto_mock = MagicMock(return_value=[])
+    monkeypatch.setattr(channel_poller, "_determine_auto_downloads", auto_mock)
+
+    yt_videos = [
+        {"youtube_video_id": "AAA00000001", "title": "Public"},
+        {
+            "youtube_video_id": "BBB00000002",
+            "title": "Members",
+            "unplayable_reason": MEMBERS_ONLY,
+        },
+        {
+            "youtube_video_id": "CCC00000003",
+            "title": "Age gated",
+            "unplayable_reason": AGE_RESTRICTED,
+        },
+    ]
+    result = channel_poller._catalog_videos(
+        channel, yt_videos, db, had_initial_poll=True, update_schedule=False
+    )
+
+    # All three are cataloged (visibility is the point)…
+    assert len(result["cataloged_ids"]) == 3
+    reasons = dict(
+        db.execute(select(Video.youtube_video_id, Video.unplayable_reason)).all()
+    )
+    assert reasons == {
+        "AAA00000001": None,
+        "BBB00000002": MEMBERS_ONLY,
+        "CCC00000003": AGE_RESTRICTED,
+    }
+
+    # …but the hard-blocked one is excluded from auto-download candidates and
+    # from new-episode events; the soft (age-gated) one stays in both.
+    candidate_ytids = {
+        db.get(Video, vid).youtube_video_id for vid in auto_mock.call_args.args[0]
+    }
+    assert candidate_ytids == {"AAA00000001", "CCC00000003"}
+    emitted_titles = {v["title"] for v in emit_mock.call_args.args[1]}
+    assert emitted_titles == {"Public", "Age gated"}
+    db.close()
+
+
+# --- download task ------------------------------------------------------------
+
+
+@pytest.fixture
+def eager_celery(monkeypatch):
+    from app.tasks.celery_app import celery_app
+
+    monkeypatch.setattr(celery_app.conf, "task_always_eager", True)
+    monkeypatch.setattr(celery_app.conf, "task_eager_propagates", True)
+    return celery_app
+
+
+def test_download_video_raises_unplayable_on_members_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(download_manager.settings, "media_path", str(tmp_path))
+    monkeypatch.setattr(download_manager, "WATCHDOG_POLL_INTERVAL_SECONDS", 0.05)
+    real_popen = subprocess.Popen
+    script = (
+        "echo 'ERROR: [youtube] vid123: Join this channel to get access to "
+        "members-only content like this video, and other exclusive perks.'; "
+        "exit 1"
+    )
+    monkeypatch.setattr(
+        download_manager.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: real_popen(["sh", "-c", script], **kwargs),
+    )
+
+    with pytest.raises(UnplayableVideoError) as excinfo:
+        download_video("vid123", "test-slug")
+
+    assert excinfo.value.reason == MEMBERS_ONLY
+
+
+@pytest.mark.asyncio
+async def test_download_task_records_reason_without_retry(
+    client, make_user, monkeypatch, eager_celery
+):
+    await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="PENDING")
+    vid = video.id
+
+    import app.tasks.download_tasks as dt
+
+    attempts = []
+
+    def refused(**kwargs):
+        attempts.append(1)
+        raise UnplayableVideoError(MEMBERS_ONLY, "yt-dlp failed: members only")
+
+    monkeypatch.setattr(dt, "download_video", refused)
+
+    result = dt.download_video_task.delay(vid).get()
+
+    assert result == {"status": "unplayable", "reason": MEMBERS_ONLY, "video_id": vid}
+    assert attempts == [1]  # outside autoretry_for -> exactly one attempt
+    async with async_session_factory() as db:
+        row = (await db.execute(select(Video).where(Video.id == vid))).scalars().one()
+    assert row.status == "FAILED"
+    assert row.unplayable_reason == MEMBERS_ONLY
+
+
+@pytest.mark.asyncio
+async def test_download_task_success_clears_stale_reason(
+    client, make_user, monkeypatch, eager_celery, tmp_path
+):
+    await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(
+            db, channel, status="PENDING", unplayable_reason=AGE_RESTRICTED
+        )
+    vid = video.id
+
+    import app.tasks.download_tasks as dt
+
+    monkeypatch.setattr(dt.settings, "media_path", str(tmp_path))
+    monkeypatch.setattr(
+        dt,
+        "download_video",
+        lambda **kwargs: {
+            "file_path": "slug/vid.mp4",
+            "file_size_bytes": 123,
+            "title": "Now playable",
+            "duration_seconds": 60,
+            "uploaded_at": None,
+            "metadata_json": None,
+        },
+    )
+
+    result = dt.download_video_task.delay(vid).get()
+
+    assert result["status"] == "complete"
+    async with async_session_factory() as db:
+        row = (await db.execute(select(Video).where(Video.id == vid))).scalars().one()
+    assert row.status == "COMPLETE"
+    assert row.unplayable_reason is None
+
+
+@pytest.mark.asyncio
+async def test_preview_task_records_reason_and_resets_status(
+    client, make_user, monkeypatch, eager_celery
+):
+    user, _ = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+    vid = video.id
+
+    import app.tasks.download_tasks as dt
+
+    def refused(**kwargs):
+        raise UnplayableVideoError(
+            MEMBERS_ONLY, "Preview download failed for x: members only"
+        )
+
+    monkeypatch.setattr(dt, "download_preview", refused)
+
+    result = dt.download_preview_task.delay(vid, user["id"]).get()
+
+    assert result == {"status": "unplayable", "reason": MEMBERS_ONLY, "video_id": vid}
+    async with async_session_factory() as db:
+        row = (await db.execute(select(Video).where(Video.id == vid))).scalars().one()
+    assert row.preview_status is None
+    assert row.unplayable_reason == MEMBERS_ONLY
+
+
+# --- prewarm gating -----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prewarm_skips_hard_unplayable_allows_soft(
+    client, make_user, monkeypatch
+):
+    _, headers = await make_user()
+    delay_mock = MagicMock()
+    monkeypatch.setattr("app.api.videos.download_preview_task.delay", delay_mock)
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        members = await seed_video(
+            db, channel, status="CATALOGED", unplayable_reason=MEMBERS_ONLY
+        )
+        age_gated = await seed_video(
+            db, channel, status="CATALOGED", unplayable_reason=AGE_RESTRICTED
+        )
+        plain = await seed_video(db, channel, status="CATALOGED")
+
+    resp = await client.post(
+        "/api/videos/prewarm",
+        json={"video_ids": [members.id, age_gated.id, plain.id]},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert set(resp.json()["enqueued"]) == {age_gated.id, plain.id}
+    assert AGE_RESTRICTED in SOFT_REASONS  # the invariant the filter relies on
+
+
+# --- instant-stream endpoint ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_instant_stream_persists_classified_reason(
+    client, make_user, monkeypatch
+):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    def refused(vid: str) -> str:
+        raise InstantStreamError("Resolve failed for x: members", reason=MEMBERS_ONLY)
+
+    monkeypatch.setattr(videos_api, "resolve_progressive_url", refused)
+
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
+
+    assert resp.status_code == 502
+    assert MEMBERS_ONLY in resp.json()["detail"]
+    async with async_session_factory() as db:
+        reason = (
+            await db.execute(
+                select(Video.unplayable_reason).where(Video.id == video.id)
+            )
+        ).scalar_one()
+    assert reason == MEMBERS_ONLY
+
+
+@pytest.mark.asyncio
+async def test_instant_stream_unclassified_failure_leaves_video_unlabeled(
+    client, make_user, monkeypatch
+):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(db, channel, status="CATALOGED")
+
+    def flaky(vid: str) -> str:
+        raise InstantStreamError("Resolve timed out for x")
+
+    monkeypatch.setattr(videos_api, "resolve_progressive_url", flaky)
+
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
+
+    assert resp.status_code == 502
+    async with async_session_factory() as db:
+        reason = (
+            await db.execute(
+                select(Video.unplayable_reason).where(Video.id == video.id)
+            )
+        ).scalar_one()
+    assert reason is None
+
+
+@pytest.mark.asyncio
+async def test_instant_stream_success_clears_stale_reason(
+    client, make_user, monkeypatch
+):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(
+            db, channel, status="CATALOGED", unplayable_reason=UPCOMING
+        )
+
+    monkeypatch.setattr(
+        videos_api, "resolve_progressive_url", lambda vid: "https://upstream.test/v"
+    )
+
+    async def fake_proxy(url, range_header):
+        from fastapi.responses import Response
+
+        return Response(content=b"ok", media_type="video/mp4")
+
+    monkeypatch.setattr(videos_api, "stream_proxy", fake_proxy)
+
+    resp = await client.get(f"/api/videos/{video.id}/instant-stream", headers=headers)
+
+    assert resp.status_code == 200
+    async with async_session_factory() as db:
+        reason = (
+            await db.execute(
+                select(Video.unplayable_reason).where(Video.id == video.id)
+            )
+        ).scalar_one()
+    assert reason is None
+
+
+# --- API surface ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_video_detail_exposes_unplayable_reason(client, make_user):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        video = await seed_video(
+            db, channel, status="FAILED", unplayable_reason=MEMBERS_ONLY
+        )
+
+    resp = await client.get(f"/api/videos/{video.id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["unplayable_reason"] == MEMBERS_ONLY
+
+
+@pytest.mark.asyncio
+async def test_channel_videos_expose_unplayable_reason(client, make_user):
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        await seed_video(db, channel, unplayable_reason=REMOVED)
+
+    resp = await client.get(f"/api/channels/{channel.id}/videos", headers=headers)
+
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert items and items[0]["unplayable_reason"] == REMOVED


### PR DESCRIPTION
## Summary

Some videos can never be fetched: age-restricted uploads (without working cookies), members-only channel content (e.g. exclusive episodes behind a channel membership), Premium/paid videos, private/removed videos, region locks, DRM, and not-yet-aired premieres. Today these fail generically — or worse, never get cataloged at all — so the clients can't tell the user *why*. This PR gives every video a nullable `unplayable_reason` the clients render as a banner (flutter/tvos PRs follow).

**Vocabulary:** `age_restricted`, `members_only`, `premium`, `private`, `geo_blocked`, `removed`, `drm`, `upcoming`, `unavailable`.

## How reasons get set

- **Poll time** — flat back-catalog entries carry per-video `availability` badges (Members only / Premium) and `live_status` (premieres); the RSS/WebSub full extraction additionally classifies per-id yt-dlp errors and now catalogs those uploads as labeled stubs (titled from the RSS feed) instead of silently dropping them.
- **Download / preview failure** — a classified refusal raises `UnplayableVideoError` (deliberately outside `autoretry_for`: retrying a members-only video can't succeed), records the reason, and marks the row `FAILED`.
- **Instant-stream resolve failure** — the reason is persisted and mentioned in the 502 detail.

Classification is conservative: bot checks, captchas, rate limits, timeouts, and unrecognized errors never label a video (`app/utils/unplayable.py`).

## How reasons get cleared (self-healing)

Any later success — HQ download, preview download, or instant-stream resolve — clears the label. So an age gate heals once cookies are configured, and a premiere heals after it airs.

## Gating

Hard-blocked videos are excluded from auto-download, new-episode pushes, and preview pre-warm. Soft reasons (`age_restricted`, `upcoming`) stay eligible for all three so they can self-heal.

## Also

- `GET /api/channels/{id}/videos` items now include `preview_status` (was omitted from that build site).
- `videos.unplayable_reason` migration `015`, nullable — fully backward compatible; clients that don't know the field ignore it.

## Tests

24 new tests (`tests/test_unplayable.py`): classifier matrix against real yt-dlp strings, poll-time labeling/stubs, catalog gating, task handling without retry, clear-on-success, prewarm gating, instant-stream persist/clear, API exposure. Suite: 358 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)