### PR TITLE
Give cold-start instant playback hero billing

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -6,6 +6,7 @@
 <title>404 — NullFeed</title>
 <meta name="robots" content="noindex">
 <meta name="theme-color" content="#050505">
+<meta name="color-scheme" content="dark">
 <link rel="icon" href="/static/favicon.png" type="image/png">
 <link rel="stylesheet" href="/site.css">
 <style>

--- a/site/index.html
+++ b/site/index.html
@@ -14,6 +14,7 @@
 <meta property="og:image" content="https://nullfeed.lol/static/og.png?v=2">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="theme-color" content="#050505">
+<meta name="color-scheme" content="dark">
 <link rel="icon" href="/static/favicon.png" type="image/png">
 <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
 <link rel="preload" href="/static/fonts/bigshoulders-var.woff2" as="font" type="font/woff2" crossorigin>
@@ -81,6 +82,7 @@
         </div>
       </figure>
       <span class="float-chip chip-cache"><i></i>CACHED · 1080p</span>
+      <span class="float-chip chip-cold"><i></i>COLD START · INSTANT</span>
       <span class="float-chip chip-new"><i></i>NEW UPLOAD · 14m</span>
     </div>
   </div>
@@ -110,7 +112,7 @@
       <article class="tcard reveal">
         <span class="tnum">03</span>
         <h3>You watch, in peace</h3>
-        <p>Native apps on iPhone and Apple&nbsp;TV, plus a web app baked into the container. Sponsor segments get skipped, positions sync everywhere, and nothing autoplays you down a rabbit hole at 2&nbsp;a.m.</p>
+        <p>Tap play and it starts instantly — cached or not — on the iPhone and Apple&nbsp;TV apps or the web app baked into the container. Sponsor segments get skipped, positions sync everywhere, and nothing autoplays you down a rabbit hole at 2&nbsp;a.m.</p>
       </article>
     </div>
   </div>
@@ -122,7 +124,7 @@
     <h2 class="section-title reveal">Every feature holds a&nbsp;grudge.</h2>
     <div class="fgrid">
       <article class="fcard reveal">
-        <h3>Instant playback, even uncached</h3>
+        <h3>Cold start? Still instant.</h3>
         <p>Tap a video that isn't cached yet and it plays immediately — reverse-proxied through your server — while the full-quality copy lands in the background and swaps in mid-watch. No spinner. No waiting.</p>
       </article>
       <article class="fcard reveal">

--- a/site/site.css
+++ b/site/site.css
@@ -31,6 +31,7 @@
 }
 
 :root {
+  color-scheme: dark;
   --bg: #050505;
   --bg-2: #0A0912;
   --surface: #0B0A12;
@@ -373,6 +374,8 @@ h1 em { font-style: normal; color: var(--violet-bright); }
 .chip-cache i { background: var(--green); box-shadow: 0 0 8px var(--green); }
 .chip-new { bottom: -14px; left: -16px; transform: rotate(-2deg); animation: bob 6.5s ease-in-out infinite reverse; }
 .chip-new i { background: var(--amber); box-shadow: 0 0 8px var(--amber); }
+.chip-cold { top: 37%; left: -20px; transform: rotate(-2deg); animation: bob 7.5s ease-in-out infinite .8s; }
+.chip-cold i { background: var(--violet-bright); box-shadow: 0 0 8px var(--violet-bright); }
 
 /* ---------- marquee — the wall of NOs ---------- */
 .marquee {
@@ -615,6 +618,7 @@ section { position: relative; z-index: 1; }
   .marquee-track span { font-size: 1.2rem; }
   .chip-cache { right: -4px; }
   .chip-new { left: -4px; }
+  .chip-cold { left: -4px; }
   .get-panel { padding: 48px 22px 46px; }
   .foot-row { flex-direction: column; }
 }


### PR DESCRIPTION
The near-instant cold-start playback deserved more than a feature card:

- Hero player mock gets a third floating chip: **COLD START · INSTANT** (violet, riding the left edge)
- Feature card #1 retitled **"Cold start? Still instant."**
- How-it-works step 03 now opens with "Tap play and it starts instantly — cached or not"

Also declares `color-scheme: dark` (meta + `:root` CSS) — verified live that this stops Dark Reader/Chrome auto-dark from re-theming the already-dark page and washing the violet out to gray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)