### PR TITLE
Stop site.css going stale after deploys

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -8,7 +8,7 @@
 <meta name="theme-color" content="#050505">
 <meta name="color-scheme" content="dark">
 <link rel="icon" href="/static/favicon.png" type="image/png">
-<link rel="stylesheet" href="/site.css">
+<link rel="stylesheet" href="/site.css?v=2">
 <style>
   .nf-404 { min-height: 82vh; display: grid; place-items: center; text-align: center; padding: 40px 24px; position: relative; z-index: 1; }
   .nf-404 h1 { font-size: clamp(5rem, 16vw, 11rem); margin-bottom: 8px; }

--- a/site/_headers
+++ b/site/_headers
@@ -1,2 +1,5 @@
 /static/*
   Cache-Control: public, max-age=31536000, immutable
+
+/site.css
+  Cache-Control: no-cache

--- a/site/index.html
+++ b/site/index.html
@@ -20,7 +20,7 @@
 <link rel="preload" href="/static/fonts/bigshoulders-var.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="/static/fonts/archivo-var.woff2" as="font" type="font/woff2" crossorigin>
 <link rel="preload" href="/static/fonts/martianmono-var.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="/site.css">
+<link rel="stylesheet" href="/site.css?v=2">
 <script type="application/ld+json">
 {"@context":"https://schema.org","@type":"SoftwareApplication","name":"NullFeed","operatingSystem":"iOS, tvOS, Web, Self-hosted (Docker)","applicationCategory":"MultimediaApplication","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"},"url":"https://nullfeed.lol/","image":"https://nullfeed.lol/static/og.png?v=2","description":"Self-hosted YouTube media center: follow your channels, cache new uploads to your own server, and watch ad-free on iPhone, Apple TV, and the web — with sponsor-segment skipping and zero tracking.","license":"https://www.gnu.org/licenses/gpl-3.0.html","sameAs":["https://github.com/windoze95/nullfeed-backend"]}
 </script>


### PR DESCRIPTION
The new COLD START chip rendered at its unstyled fallback position (bottom of the hero) because `/site.css` ships with `max-age=14400` — browsers/edge colos keep pre-deploy CSS for up to 4 hours after the HTML updates. Same failure class as the og.png staleness.

- `?v=2` on the stylesheet href (index + 404) busts every currently-cached copy the moment the new HTML lands
- `_headers` now serves `/site.css` with `Cache-Control: no-cache` so future deploys revalidate instantly (etag keeps it a 304 when unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)