### PR TITLE
feat(content-type): discover Shorts + livestreams, keep them catalog-only

### DIFF
--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -13,11 +13,13 @@ from app.services.download_manager import (
     fetch_channel_images,
     fetch_channel_metadata,
     fetch_channel_rss,
+    fetch_channel_tab,
     fetch_channel_videos,
     fetch_videos_metadata,
 )
 from app.services.progress_broadcaster import publish_new_episode
 from app.services.push_gateway import send_to_users
+from app.utils.content_type import CATALOG_ONLY_TYPES, LIVE, REGULAR, SHORT
 from app.utils.time import utcnow_naive
 from app.utils.unplayable import SOFT_REASONS
 
@@ -29,6 +31,34 @@ def _as_naive_utc(value: datetime | None) -> datetime | None:
     if value is not None and value.tzinfo is not None:
         return value.astimezone(timezone.utc).replace(tzinfo=None)
     return value
+
+
+def _merge_tab_entries(*entry_lists: list[dict]) -> list[dict]:
+    """Merge video entries from several channel tabs, deduped by video id.
+
+    A video can appear in more than one tab — a past livestream is listed under
+    both /streams and /videos — so an id is kept once, in the order of the first
+    list it appeared in (the /videos feed leads, preserving its chronology). Its
+    ``content_type`` is upgraded from a later tab when that tab knows a more
+    specific kind (e.g. /streams tagging a cross-listed video ``live`` where the
+    flat /videos entry only saw ``regular``).
+    """
+    merged: dict[str, dict] = {}
+    order: list[str] = []
+    for entries in entry_lists:
+        for entry in entries:
+            vid = entry.get("youtube_video_id")
+            if not vid:
+                continue
+            existing = merged.get(vid)
+            if existing is None:
+                merged[vid] = dict(entry)
+                order.append(vid)
+            elif existing.get("content_type") in (None, REGULAR) and entry.get(
+                "content_type"
+            ) not in (None, REGULAR):
+                existing["content_type"] = entry["content_type"]
+    return [merged[vid] for vid in order]
 
 
 def _reschedule_channel(channel: Channel, *, found_new: bool) -> None:
@@ -140,13 +170,21 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
     if not had_initial_poll:
         # First-ever poll: ingest the back catalog via a full yt-dlp listing.
         # The RSS feed only exposes the ~15 newest uploads, so using it here
-        # would permanently skip older videos.
-        yt_videos = fetch_channel_videos(channel.youtube_channel_id)["videos"]
+        # would permanently skip older videos. The main /videos tab also excludes
+        # Shorts and livestreams, so scan those tabs too and merge — discovering
+        # them is the point (they're cataloged for visibility + per-channel
+        # gating, but kept catalog-only so they never flood auto-download).
+        cid = channel.youtube_channel_id
+        yt_videos = _merge_tab_entries(
+            fetch_channel_videos(cid)["videos"],
+            fetch_channel_tab(cid, "/shorts", SHORT),
+            fetch_channel_tab(cid, "/streams", LIVE),
+        )
     else:
         # Routine poll: cheap RSS conditional GET. Only genuinely-new video IDs
         # fall through to yt-dlp for full metadata.
-        yt_videos = _discover_routine(channel, db)
-        if yt_videos is None:
+        discovered = _discover_routine(channel, db)
+        if discovered is None:
             # 304 Not Modified, or the feed surfaced no unseen videos: nothing
             # to catalog. Record the poll and, since it was empty, widen the
             # cadence toward the cap. _discover_routine refreshed any validators
@@ -155,6 +193,7 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
             _reschedule_channel(channel, found_new=False)
             db.commit()
             return {"cataloged_ids": [], "auto_download_ids": []}
+        yt_videos = discovered
 
     # The routine poll updates last_checked_at and the adaptive cadence as part
     # of the catalog commit; the initial poll only catalogs (no prior schedule).
@@ -244,13 +283,16 @@ def _catalog_videos(
             except (ValueError, TypeError):
                 pass
 
-        # A video-inherent refusal known at discovery time (members-only /
-        # premium badge, unaired premiere, or a classified extraction failure).
-        # Hard reasons never auto-download (it can't succeed) and stay out of
-        # new-episode pushes (notifying about unwatchable content is noise) —
-        # the labeled row in the feed is the visibility.
+        # Cataloged for visibility but kept out of auto-download and new-episode
+        # pushes. Two reasons: a video-inherent refusal known at discovery time
+        # (members-only / premium badge, or a classified extraction failure —
+        # fetching can't succeed, and notifying about unwatchable content is
+        # noise); or a Short / livestream, discovered so the viewer can see and
+        # gate them but never auto-pulled, since every clip and multi-hour stream
+        # would flood storage. The labeled row in the feed is the visibility.
         reason = yt_vid.get("unplayable_reason")
         hard_blocked = bool(reason) and reason not in SOFT_REASONS
+        catalog_only = hard_blocked or yt_vid.get("content_type") in CATALOG_ONLY_TYPES
 
         # Create new video record as CATALOGED (not PENDING)
         video = Video(
@@ -271,10 +313,10 @@ def _catalog_videos(
         id_by_ytid[yt_video_id] = video.id
 
         video_ids_for_refs.append(video.id)
-        if not hard_blocked:
+        if not catalog_only:
             new_video_ids.append(video.id)
         cataloged_ids.append(video.id)
-        if not hard_blocked:
+        if not catalog_only:
             new_videos_for_events.append(
                 {
                     "id": video.id,

--- a/app/services/download_manager.py
+++ b/app/services/download_manager.py
@@ -14,7 +14,11 @@ from collections.abc import Callable
 import httpx
 
 from app.config import settings
-from app.utils.content_type import classify_content_type, content_type_for_reason
+from app.utils.content_type import (
+    REGULAR,
+    classify_content_type,
+    content_type_for_reason,
+)
 from app.utils.unplayable import (
     UnplayableVideoError,
     classify_entry,
@@ -780,6 +784,67 @@ def fetch_channel_videos(
         logger.warning("Failed to fetch videos for %s: %s", youtube_channel_id, e)
 
     return {"videos": videos, "channel_meta": channel_meta}
+
+
+def fetch_channel_tab(
+    youtube_channel_id: str,
+    tab: str,
+    default_type: str,
+    max_videos: int | None = None,
+) -> list[dict]:
+    """Flat-scan one of a channel's secondary tabs (``/shorts``, ``/streams``) for
+    video entries, in the shape ``_catalog_videos`` consumes.
+
+    The main /videos tab excludes Shorts and livestreams entirely, so these tabs
+    are the only way they get discovered. Each entry's ``content_type`` is the
+    per-entry classification, falling back to ``default_type`` (short for
+    /shorts, live for /streams) when a flat entry classifies as plain ``regular``
+    — the tab itself is authoritative that its videos are Shorts/livestreams even
+    though a flat entry lacks the aspect/live-status signals to prove it. Access
+    walls (members/premium/age) still win. A channel without the tab, or any
+    fetch error, just yields an empty list.
+    """
+    if max_videos is None:
+        max_videos = settings.catalog_fetch_count
+    url = _build_channel_url(youtube_channel_id, tab)
+
+    cmd = [
+        "yt-dlp",
+        "--flat-playlist",
+        "--dump-json",
+        "--playlist-items",
+        f"1:{max_videos}",
+        url,
+    ]
+
+    entries: list[dict] = []
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        if result.returncode != 0:
+            return entries
+        for line in result.stdout.strip().split("\n"):
+            if not line.strip():
+                continue
+            data = json.loads(line)
+            vid = data.get("id", "")
+            if not vid:
+                continue
+            classified = classify_content_type(data)
+            entries.append(
+                {
+                    "youtube_video_id": vid,
+                    "title": data.get("title", ""),
+                    "duration_seconds": int(data.get("duration") or 0),
+                    "upload_date": data.get("upload_date"),
+                    "unplayable_reason": classify_entry(data),
+                    "content_type": (
+                        classified if classified != REGULAR else default_type
+                    ),
+                }
+            )
+    except Exception as e:
+        logger.warning("Failed to fetch %s for %s: %s", tab, youtube_channel_id, e)
+    return entries
 
 
 def _parse_rss_entries(xml_text: str) -> list[dict]:

--- a/app/utils/content_type.py
+++ b/app/utils/content_type.py
@@ -29,6 +29,13 @@ AGE_RESTRICTED = "age_restricted"
 MEMBERS_ONLY = "members_only"
 PREMIUM = "premium"
 
+# Types cataloged for visibility but never auto-downloaded or announced as new
+# episodes by default: auto-pulling every discovered Short and multi-hour
+# livestream is exactly what would flood storage, so they stay hands-off until a
+# per-channel gate opts them in. Access-walled types already sit out downloads
+# via unplayable_reason, and premieres via their SOFT upcoming reason.
+CATALOG_ONLY_TYPES = frozenset({SHORT, LIVE})
+
 # Longest a video can be and still count as a Short by the duration fallback
 # (YouTube caps Shorts at 60s; a second of slack for rounding). Only consulted
 # when nothing already marked it a Short.

--- a/tests/test_content_type_discovery.py
+++ b/tests/test_content_type_discovery.py
@@ -1,0 +1,142 @@
+"""Discover Shorts + livestreams (the /shorts and /streams tabs the main /videos
+tab excludes), tag them by kind, and keep them catalog-only so they're visible
+and gate-able but never flood auto-download."""
+
+import json
+import uuid
+from unittest.mock import MagicMock
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.models.channel import Channel
+from app.models.video import Video
+from app.services import channel_poller, download_manager
+from app.services.channel_poller import _merge_tab_entries
+from app.services.download_manager import fetch_channel_tab
+from app.utils.content_type import LIVE, MEMBERS_ONLY, PREMIERE, REGULAR, SHORT
+from tests.helpers import fake_completed_process
+
+
+def test_fetch_channel_tab_forces_default_when_regular(monkeypatch):
+    entries = [
+        {"id": "AAA00000001", "title": "Clip", "duration": 30},
+        {
+            "id": "BBB00000002",
+            "title": "Members clip",
+            "duration": 20,
+            "availability": "subscriber_only",
+        },
+    ]
+    stdout = "\n".join(json.dumps(e) for e in entries)
+    monkeypatch.setattr(
+        download_manager.subprocess,
+        "run",
+        lambda *a, **k: fake_completed_process(stdout),
+    )
+
+    result = fetch_channel_tab("UCabc", "/shorts", SHORT)
+
+    # A flat entry can't prove it's a Short (no aspect signal) → the /shorts tab
+    # default applies; an access wall still wins.
+    assert [v["content_type"] for v in result] == [SHORT, MEMBERS_ONLY]
+
+
+def test_fetch_channel_tab_streams_default_live_but_keeps_premiere(monkeypatch):
+    entries = [
+        {"id": "AAA00000001", "title": "Past stream", "duration": 3600},
+        {"id": "CCC00000003", "title": "Scheduled", "live_status": "is_upcoming"},
+    ]
+    stdout = "\n".join(json.dumps(e) for e in entries)
+    monkeypatch.setattr(
+        download_manager.subprocess,
+        "run",
+        lambda *a, **k: fake_completed_process(stdout),
+    )
+
+    result = fetch_channel_tab("UCabc", "/streams", LIVE)
+
+    # Plain stream entries fall back to live; a scheduled premiere keeps premiere.
+    assert [v["content_type"] for v in result] == [LIVE, PREMIERE]
+
+
+def test_fetch_channel_tab_empty_on_error(monkeypatch):
+    monkeypatch.setattr(
+        download_manager.subprocess,
+        "run",
+        lambda *a, **k: fake_completed_process("", returncode=1),
+    )
+    assert fetch_channel_tab("UCabc", "/shorts", SHORT) == []
+
+
+def test_merge_tab_entries_dedups_and_upgrades_type():
+    videos = [
+        {"youtube_video_id": "V1", "title": "Regular", "content_type": REGULAR},
+        {"youtube_video_id": "S1", "title": "Past stream", "content_type": REGULAR},
+    ]
+    shorts = [{"youtube_video_id": "H1", "title": "Short", "content_type": SHORT}]
+    streams = [{"youtube_video_id": "S1", "title": "Past stream", "content_type": LIVE}]
+
+    merged = _merge_tab_entries(videos, shorts, streams)
+
+    # Order follows the first list, new ids appended; the cross-listed S1 is kept
+    # once (in its /videos position) and its type upgraded regular → live.
+    assert [e["youtube_video_id"] for e in merged] == ["V1", "S1", "H1"]
+    by_id = {e["youtube_video_id"]: e["content_type"] for e in merged}
+    assert by_id == {"V1": REGULAR, "S1": LIVE, "H1": SHORT}
+
+
+def _mem_session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_catalog_gates_shorts_and_lives_from_autodownload(monkeypatch):
+    db = _mem_session()
+    channel = Channel(
+        id=str(uuid.uuid4()),
+        youtube_channel_id="UCabc1230000000000000000",
+        name="Test",
+        slug="test",
+    )
+    db.add(channel)
+    db.commit()
+
+    emit_mock = MagicMock()
+    monkeypatch.setattr(channel_poller, "_emit_new_episode_events", emit_mock)
+    auto_mock = MagicMock(return_value=[])
+    monkeypatch.setattr(channel_poller, "_determine_auto_downloads", auto_mock)
+
+    yt_videos = [
+        {
+            "youtube_video_id": "AAA00000001",
+            "title": "Regular",
+            "content_type": REGULAR,
+        },
+        {"youtube_video_id": "BBB00000002", "title": "Clip", "content_type": SHORT},
+        {"youtube_video_id": "CCC00000003", "title": "Stream", "content_type": LIVE},
+    ]
+    result = channel_poller._catalog_videos(
+        channel, yt_videos, db, had_initial_poll=True, update_schedule=False
+    )
+
+    # All three are cataloged and typed…
+    assert len(result["cataloged_ids"]) == 3
+    types = dict(db.execute(select(Video.youtube_video_id, Video.content_type)).all())
+    assert types == {
+        "AAA00000001": REGULAR,
+        "BBB00000002": SHORT,
+        "CCC00000003": LIVE,
+    }
+
+    # …but the Short and livestream are held out of auto-download candidates and
+    # new-episode events; only the regular upload flows through.
+    candidate_ytids = {
+        db.get(Video, vid).youtube_video_id for vid in auto_mock.call_args.args[0]
+    }
+    assert candidate_ytids == {"AAA00000001"}
+    emitted_titles = {v["title"] for v in emit_mock.call_args.args[1]}
+    assert emitted_titles == {"Regular"}
+    db.close()


### PR DESCRIPTION
Phase 2 of content-type detection + per-channel gating (follows #116). Discovers the content the main feed can't see.

## The gap

A channel's `/videos` tab **excludes Shorts and livestreams entirely**, so they were never cataloged — the poller only ever scanned `/videos`. You asked to discover both.

## What this does

- The first (back-catalog) poll now also **flat-scans `/shorts` and `/streams`** and merges them with `/videos`. `_merge_tab_entries` dedupes by id and, for a past livestream cross-listed under both `/streams` and `/videos`, keeps it once (in its `/videos` position) but **upgrades its type** to `live`.
- `fetch_channel_tab(tab, default_type)` stamps each entry's `content_type`, falling back to the tab's own kind (`short`/`live`) when a flat entry classifies as plain `regular` — the tab is authoritative even though a flat entry lacks the aspect/live signals. Access walls (members/premium/age) still win.
- Discovered Shorts and livestreams are **catalog-only**: cataloged for visibility + gating, but held out of **auto-download** and **new-episode pushes** (`CATALOG_ONLY_TYPES = {short, live}`, extending the existing `hard_blocked` gate). So turning discovery on never floods storage with clips or your notifications with a channel's every Short.

## Routine polls (no added cost)

New Shorts/lives from *routine* polls are already classified by the phase-1 classifier via the existing RSS→full-extraction path (full entries carry `aspect_ratio`/`live_status`), so **no per-poll tab-scan cost is added**. The tab scans run only on the one-time back-catalog poll.

> Caveat: if a channel's RSS uploads feed omits Shorts, brand-new Shorts posted after the first poll won't be caught until we add a periodic tab re-scan (deliberately deferred to keep routine polls cheap). Back catalog + livestreams are fully covered.

## Verification

`ruff` ✓ · `ruff format` ✓ · `mypy app/` ✓ · **381 tests pass** (5 new: tab classification, cross-tab merge/upgrade, and the catalog-only auto-download gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
