### PR TITLE
feat(content-type): per-channel gate — hide content types on the channel screen

### DIFF
--- a/alembic/versions/017_subscription_hidden_content_types.py
+++ b/alembic/versions/017_subscription_hidden_content_types.py
@@ -1,0 +1,27 @@
+"""Per-channel content-type gate: user_subscriptions.hidden_content_types
+
+Revision ID: 017_subscription_hidden_content_types
+Revises: 016_video_content_type
+Create Date: 2026-07-08
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "017_subscription_hidden_content_types"
+down_revision: Union[str, None] = "016_video_content_type"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_subscriptions",
+        sa.Column("hidden_content_types", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_subscriptions", "hidden_content_types")

--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -22,10 +22,12 @@ from app.schemas.channel import (
     ChannelDetail,
     ChannelOut,
     ChannelSubscribe,
+    ContentFilterUpdate,
 )
 from app.schemas.video import VideoOut, VideoPagination
 from app.services.channel_poller import poll_single_channel
 from app.services.download_manager import fetch_channel_images, fetch_channel_metadata
+from app.utils.content_type import ALL_CONTENT_TYPES, REGULAR
 from app.tasks.download_tasks import (
     _get_sync_db,
     download_video_task,
@@ -411,6 +413,7 @@ async def refresh_channel_images(
     detail.is_subscribed = sub is not None
     if sub:
         detail.tracking_mode = sub.tracking_mode
+        detail.hidden_content_types = sub.hidden_content_types or []
     return detail
 
 
@@ -471,7 +474,56 @@ async def get_channel(
     detail.is_subscribed = sub is not None
     if sub:
         detail.tracking_mode = sub.tracking_mode
+        detail.hidden_content_types = sub.hidden_content_types or []
     return detail
+
+
+@router.put("/{channel_id}/content-filter", response_model=ChannelDetail)
+async def set_content_filter(
+    channel_id: str,
+    body: ContentFilterUpdate,
+    user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> ChannelDetail:
+    """Replace the content types this user has hidden for a channel — the
+    per-channel filter the client's type menu drives. An empty list clears it.
+    """
+    # Reject unknown types so a client typo can't create a filter that silently
+    # hides nothing (or, mishandled elsewhere, everything).
+    unknown = [t for t in body.hidden_content_types if t not in ALL_CONTENT_TYPES]
+    if unknown:
+        raise HTTPException(
+            status_code=422, detail=f"Unknown content types: {', '.join(unknown)}"
+        )
+
+    sub_result = await db.execute(
+        select(UserSubscription).where(
+            UserSubscription.user_id == user.id,
+            UserSubscription.channel_id == channel_id,
+        )
+    )
+    sub = sub_result.scalar_one_or_none()
+    if sub is None:
+        raise HTTPException(status_code=404, detail="Not subscribed to this channel")
+
+    # Dedup and store None when empty so "nothing hidden" is a clean NULL.
+    hidden = list(dict.fromkeys(body.hidden_content_types))
+    sub.hidden_content_types = hidden or None
+    await db.commit()
+
+    return await get_channel(channel_id, user=user, db=db)
+
+
+async def _hidden_types_for(channel_id: str, user: User, db: AsyncSession) -> list[str]:
+    """The content types this user has hidden for a channel (empty if none / not
+    subscribed) — the gate applied to the channel's video list and feeds."""
+    result = await db.execute(
+        select(UserSubscription.hidden_content_types).where(
+            UserSubscription.user_id == user.id,
+            UserSubscription.channel_id == channel_id,
+        )
+    )
+    return result.scalar_one_or_none() or []
 
 
 @router.get("/{channel_id}/videos", response_model=VideoPagination)
@@ -479,12 +531,25 @@ async def list_channel_videos(
     channel_id: str,
     page: int = Query(1, ge=1),
     per_page: int = Query(20, ge=1, le=100),
+    include_hidden: bool = Query(
+        False,
+        description="Include content types the user has hidden for this channel "
+        "(the 'show hidden' reveal). Off by default so the gate applies.",
+    ),
     user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> VideoPagination:
+    # The per-channel content gate: omit hidden types unless the caller is
+    # explicitly revealing them. NULL content_type (rows cataloged before the
+    # field existed) counts as "regular", so it's hidden only if regular is.
+    hidden = [] if include_hidden else await _hidden_types_for(channel_id, user, db)
+    filters = [Video.channel_id == channel_id]
+    if hidden:
+        filters.append(func.coalesce(Video.content_type, REGULAR).notin_(hidden))
+
     # Total count
     total_result = await db.execute(
-        select(func.count()).select_from(Video).where(Video.channel_id == channel_id)
+        select(func.count()).select_from(Video).where(*filters)
     )
     total = total_result.scalar() or 0
 
@@ -494,7 +559,7 @@ async def list_channel_videos(
     # episodes sort to the top instead of the bottom.
     result = await db.execute(
         select(Video)
-        .where(Video.channel_id == channel_id)
+        .where(*filters)
         .order_by(func.coalesce(Video.uploaded_at, Video.created_at).desc())
         .offset(offset)
         .limit(per_page)

--- a/app/models/subscription.py
+++ b/app/models/subscription.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models import Base
@@ -21,6 +21,11 @@ class UserSubscription(Base):
     retention_policy: Mapped[str] = mapped_column(String(20), default="KEEP_ALL")
     retention_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
     tracking_mode: Mapped[str] = mapped_column(String(20), default="FUTURE_ONLY")
+    # Content types this user has hidden for this channel (see
+    # app/utils/content_type.py) — a JSON list like ["short", "live"]. The
+    # channel's video list and feeds omit these unless explicitly revealed. NULL
+    # or [] means nothing is hidden (show everything).
+    hidden_content_types: Mapped[list | None] = mapped_column(JSON, nullable=True)
 
     user = relationship("User", back_populates="subscriptions")
     channel = relationship("Channel", back_populates="subscriptions")

--- a/app/schemas/channel.py
+++ b/app/schemas/channel.py
@@ -29,6 +29,16 @@ class ChannelSubscribe(BaseModel):
 class ChannelDetail(ChannelOut):
     subscriber_count: int = 0
     tracking_mode: str | None = None
+    # Content types this user has hidden for this channel (empty when nothing is
+    # hidden or the user isn't subscribed). Backs the per-channel filter menu.
+    hidden_content_types: list[str] = Field(default_factory=list)
+
+
+class ContentFilterUpdate(BaseModel):
+    """Replace the set of content types hidden for a channel. An empty list
+    clears the filter (show everything)."""
+
+    hidden_content_types: list[str] = Field(default_factory=list)
 
 
 class BulkSubscribeItem(BaseModel):

--- a/app/utils/content_type.py
+++ b/app/utils/content_type.py
@@ -29,6 +29,13 @@ AGE_RESTRICTED = "age_restricted"
 MEMBERS_ONLY = "members_only"
 PREMIUM = "premium"
 
+# The full vocabulary, for validating a per-channel content filter's requested
+# hidden types (reject anything outside this so a typo can't silently hide
+# nothing or everything).
+ALL_CONTENT_TYPES = frozenset(
+    {REGULAR, SHORT, LIVE, PREMIERE, AGE_RESTRICTED, MEMBERS_ONLY, PREMIUM}
+)
+
 # Types cataloged for visibility but never auto-downloaded or announced as new
 # episodes by default: auto-pulling every discovered Short and multi-hour
 # livestream is exactly what would flood storage, so they stay hands-off until a

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -75,6 +75,7 @@ async def seed_video(
     preview_file_path: str | None = None,
     preview_status: str | None = None,
     unplayable_reason: str | None = None,
+    content_type: str | None = None,
 ) -> Video:
     video = Video(
         id=str(uuid.uuid4()),
@@ -88,6 +89,7 @@ async def seed_video(
         preview_file_path=preview_file_path,
         preview_status=preview_status,
         unplayable_reason=unplayable_reason,
+        content_type=content_type,
     )
     db.add(video)
     await db.commit()

--- a/tests/test_content_filter.py
+++ b/tests/test_content_filter.py
@@ -1,0 +1,132 @@
+"""Per-channel content-type gate: set/clear which types are hidden for a channel,
+and filter the channel's video list accordingly (with a reveal override)."""
+
+import pytest
+
+from app.database import async_session_factory
+from tests.helpers import seed_channel, seed_subscription, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed_channel_with_videos(user_id: str) -> str:
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cid = channel.id
+        await seed_subscription(db, user_id, cid)
+        await seed_video(db, channel, title="Regular", content_type="regular")
+        await seed_video(db, channel, title="Clip", content_type="short")
+        await seed_video(db, channel, title="Stream", content_type="live")
+    return cid
+
+
+async def test_set_and_get_content_filter(client, make_user):
+    user, headers = await make_user()
+    cid = await _seed_channel_with_videos(user["id"])
+
+    resp = await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": ["short", "live"]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert sorted(resp.json()["hidden_content_types"]) == ["live", "short"]
+
+    # Persisted: the channel detail reflects it.
+    resp = await client.get(f"/api/channels/{cid}", headers=headers)
+    assert sorted(resp.json()["hidden_content_types"]) == ["live", "short"]
+
+
+async def test_content_filter_rejects_unknown_type(client, make_user):
+    user, headers = await make_user()
+    cid = await _seed_channel_with_videos(user["id"])
+    resp = await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": ["short", "bogus"]},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+async def test_content_filter_requires_subscription(client, make_user):
+    await make_user()  # a different, unsubscribed viewer
+    _, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cid = channel.id
+    resp = await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": ["short"]},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+async def test_channel_videos_hides_and_reveals(client, make_user):
+    user, headers = await make_user()
+    cid = await _seed_channel_with_videos(user["id"])
+
+    await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": ["short", "live"]},
+        headers=headers,
+    )
+
+    resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
+    body = resp.json()
+    assert {v["title"] for v in body["items"]} == {"Regular"}
+    assert body["total"] == 1
+
+    # The reveal override brings the hidden ones back.
+    resp = await client.get(
+        f"/api/channels/{cid}/videos?include_hidden=true", headers=headers
+    )
+    body = resp.json()
+    assert {v["title"] for v in body["items"]} == {"Regular", "Clip", "Stream"}
+    assert body["total"] == 3
+
+
+async def test_null_content_type_treated_as_regular(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cid = channel.id
+        await seed_subscription(db, user["id"], cid)
+        # A pre-existing row with no content_type (cataloged before the field).
+        await seed_video(db, channel, title="Legacy", content_type=None)
+
+    # Hiding shorts leaves the untyped (regular) row visible…
+    await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": ["short"]},
+        headers=headers,
+    )
+    resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
+    assert {v["title"] for v in resp.json()["items"]} == {"Legacy"}
+
+    # …but hiding regular hides it too (NULL counts as regular).
+    await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": ["regular"]},
+        headers=headers,
+    )
+    resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
+    assert resp.json()["items"] == []
+
+
+async def test_empty_filter_clears(client, make_user):
+    user, headers = await make_user()
+    cid = await _seed_channel_with_videos(user["id"])
+    await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": ["short"]},
+        headers=headers,
+    )
+    resp = await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": []},
+        headers=headers,
+    )
+    assert resp.json()["hidden_content_types"] == []
+    resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
+    assert len(resp.json()["items"]) == 3


### PR DESCRIPTION
Phase 3 of content-type gating (follows #116, #117). The per-channel gate on the channel screen.

## What this does

Adds `user_subscriptions.hidden_content_types` (a JSON list) — the per-channel filter your type menu will drive:

- **`PUT /channels/{id}/content-filter`** `{hidden_content_types: [...]}` — set or clear the hidden types. Validates against the known vocabulary (422 on a bogus type), 404 when you're not subscribed, and an empty list clears the filter to NULL.
- **`GET /channels/{id}/videos`** now omits hidden types by default; **`?include_hidden=true`** is the "show hidden" reveal. `NULL` content_type (rows cataloged before the field) counts as **regular**, so it's hidden only if `regular` is.
- **`ChannelDetail.hidden_content_types`** exposes the current setting (on both `GET /channels/{id}` and refresh-images) so the client can render the menu with the right toggles checked.

Default is **hide nothing** — the gate does nothing until you choose types to hide.

## Scope

This gates the **channel screen**. Extending the same per-channel gate to the **home feed** (new-episodes + recently-added) is the immediately-following PR (phase 3b) — the feed queries join per-channel, so it's a focused follow-up. Note Shorts/livestreams already sit out feed *alerts* and auto-download via the phase-2 catalog-only gate, so the feed extension mainly affects "recently added".

## Verification

`ruff` ✓ · `ruff format` ✓ · `mypy app/` ✓ · **387 tests pass** (6 new: set/get/clear, unknown-type 422, not-subscribed 404, hide + reveal, NULL-as-regular) · `alembic upgrade head` applies (column verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
