### PR TITLE
feat(content-type): apply the per-channel gate to the home feed

### DIFF
--- a/app/api/feed.py
+++ b/app/api/feed.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.api.auth import get_current_user
 from app.database import get_db
@@ -12,8 +13,34 @@ from app.models.video import Video
 from app.schemas.channel import ChannelOut
 from app.schemas.feed import FeedItem, HomeFeed
 from app.schemas.video import VideoOut
+from app.utils.content_type import REGULAR
 
 router = APIRouter(prefix="/api/feed", tags=["feed"])
+
+
+async def _subscriptions(user: User, db: AsyncSession) -> list[tuple[str, list | None]]:
+    """This user's (channel_id, hidden_content_types) subscription rows."""
+    result = await db.execute(
+        select(
+            UserSubscription.channel_id, UserSubscription.hidden_content_types
+        ).where(UserSubscription.user_id == user.id)
+    )
+    return [(channel_id, hidden) for channel_id, hidden in result.all()]
+
+
+def _content_gate(subs: list[tuple[str, list | None]]) -> ColumnElement | None:
+    """A WHERE condition dropping videos whose content_type is hidden for their
+    channel (the per-channel gate applied to feeds). None when nothing is hidden.
+    A NULL content_type counts as ``regular``, matching the channel-list gate."""
+    hidden_conds = [
+        and_(
+            Video.channel_id == channel_id,
+            func.coalesce(Video.content_type, REGULAR).in_(hidden),
+        )
+        for channel_id, hidden in subs
+        if hidden
+    ]
+    return not_(or_(*hidden_conds)) if hidden_conds else None
 
 
 def _channel_out(channel: Channel) -> ChannelOut:
@@ -84,12 +111,11 @@ async def _new_episodes_items(
 ) -> list[FeedItem]:
     """Newest unwatched download per subscribed channel for this user."""
     # Get user's subscribed channel IDs
-    sub_result = await db.execute(
-        select(UserSubscription.channel_id).where(UserSubscription.user_id == user.id)
-    )
-    subscribed_ids = [row[0] for row in sub_result.all()]
+    subs = await _subscriptions(user, db)
+    subscribed_ids = [cid for cid, _ in subs]
     if not subscribed_ids:
         return []
+    gate = _content_gate(subs)
 
     # Rank each unwatched, completed video within its channel so the dedup-to-
     # newest-per-channel happens in SQL. The window function runs over the
@@ -98,6 +124,15 @@ async def _new_episodes_items(
     # Pushing this into the DB keeps latency tied to ``limit`` rather than the
     # size of the subscribed library (the old code loaded every such row and
     # deduped in Python).
+    ranked_where = [
+        UserVideoRef.user_id == user.id,
+        UserVideoRef.removed_at.is_(None),
+        UserVideoRef.is_watched == False,  # noqa: E712
+        Video.channel_id.in_(subscribed_ids),
+    ]
+    if gate is not None:
+        # Rank over the gated set so rank 1 is the newest *non-hidden* episode.
+        ranked_where.append(gate)
     ranked = (
         select(
             Video.id.label("video_id"),
@@ -109,12 +144,7 @@ async def _new_episodes_items(
             .label("rn"),
         )
         .join(UserVideoRef, UserVideoRef.video_id == Video.id)
-        .where(
-            UserVideoRef.user_id == user.id,
-            UserVideoRef.removed_at.is_(None),
-            UserVideoRef.is_watched == False,  # noqa: E712
-            Video.channel_id.in_(subscribed_ids),
-        )
+        .where(*ranked_where)
         .subquery()
     )
 
@@ -148,22 +178,24 @@ async def _recently_added_items(
     Episode-based and cache-agnostic: a new upload shows here as soon as it's
     cataloged, whether or not it has been cached yet.
     """
-    sub_result = await db.execute(
-        select(UserSubscription.channel_id).where(UserSubscription.user_id == user.id)
-    )
-    subscribed_ids = [row[0] for row in sub_result.all()]
+    subs = await _subscriptions(user, db)
+    subscribed_ids = [cid for cid, _ in subs]
     if not subscribed_ids:
         return []
+    gate = _content_gate(subs)
 
+    recent_where = [
+        UserVideoRef.user_id == user.id,
+        UserVideoRef.removed_at.is_(None),
+        Video.channel_id.in_(subscribed_ids),
+    ]
+    if gate is not None:
+        recent_where.append(gate)
     result = await db.execute(
         select(UserVideoRef, Video, Channel)
         .join(Video, UserVideoRef.video_id == Video.id)
         .join(Channel, Video.channel_id == Channel.id)
-        .where(
-            UserVideoRef.user_id == user.id,
-            UserVideoRef.removed_at.is_(None),
-            Video.channel_id.in_(subscribed_ids),
-        )
+        .where(*recent_where)
         .order_by(
             func.coalesce(Video.uploaded_at, Video.created_at).desc(),
             Video.id.desc(),

--- a/tests/test_content_feed_gate.py
+++ b/tests/test_content_feed_gate.py
@@ -1,0 +1,47 @@
+"""The per-channel content gate also applies to the home feed: hidden types drop
+out of new-episodes and recently-added (continue-watching is deliberately left
+alone — you started those on purpose)."""
+
+import pytest
+
+from app.database import async_session_factory
+from tests.helpers import seed_channel, seed_ref, seed_subscription, seed_video
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _seed(user_id: str, hidden: list[str] | None) -> str:
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cid = channel.id
+        await seed_subscription(db, user_id, cid, hidden_content_types=hidden)
+        reg = await seed_video(db, channel, title="Regular", content_type="regular")
+        clip = await seed_video(db, channel, title="Clip", content_type="short")
+        await seed_ref(db, user_id, reg.id)
+        await seed_ref(db, user_id, clip.id)
+    return cid
+
+
+async def test_recently_added_drops_hidden_types(client, make_user):
+    user, headers = await make_user()
+    await _seed(user["id"], ["short"])
+    resp = await client.get("/api/feed/recently-added", headers=headers)
+    assert resp.status_code == 200
+    assert {i["video"]["title"] for i in resp.json()} == {"Regular"}
+
+
+async def test_new_episodes_drops_hidden_types(client, make_user):
+    user, headers = await make_user()
+    await _seed(user["id"], ["short"])
+    resp = await client.get("/api/feed/new-episodes", headers=headers)
+    assert resp.status_code == 200
+    # The gate ranks over non-hidden videos, so the channel's episode is Regular
+    # (never the hidden Clip).
+    assert {i["video"]["title"] for i in resp.json()} == {"Regular"}
+
+
+async def test_feed_unfiltered_when_nothing_hidden(client, make_user):
+    user, headers = await make_user()
+    await _seed(user["id"], None)
+    resp = await client.get("/api/feed/recently-added", headers=headers)
+    assert {i["video"]["title"] for i in resp.json()} == {"Regular", "Clip"}


### PR DESCRIPTION
Phase 3b — extends the per-channel gate (#118) to the **home feed**, completing the "gate everywhere" scope.

## What this does

`new-episodes` and `recently-added` now drop videos whose `content_type` is hidden for their channel:

- `_content_gate()` builds a WHERE condition from each subscription's `hidden_content_types` (a `NULL` type counts as `regular`, matching the channel-list gate).
- **new-episodes** ranks over the *gated* set, so the episode surfaced per channel is never a hidden type (not just filtered after ranking).
- **continue-watching is intentionally left alone** — you started those on purpose; hiding a type shouldn't yank an in-progress video.

This is what actually removes a channel's Shorts from your feed views. (Shorts/livestreams already stay out of auto-download and new-episode *pushes* via the phase-2 catalog-only gate — but they still surfaced in the recently-added/new-episodes *feed* until now, since those query cataloged videos directly.)

## Verification

`ruff` ✓ · `ruff format` ✓ · `mypy app/` ✓ · **390 tests pass** (3 new: recently-added + new-episodes drop hidden types; unfiltered when nothing hidden).

---

**Backend is now feature-complete** for content-type detection + gating (#116 detect · #117 discover · #118 channel gate · this feed gate). Next: the Flutter + tvOS clients (badge + per-channel filter menu) — I'll check the UX with you before building those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
