### PR TITLE
feat(content-type): report a channel's available content types on ChannelDetail

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -475,6 +475,12 @@ async def get_channel(
     if sub:
         detail.tracking_mode = sub.tracking_mode
         detail.hidden_content_types = sub.hidden_content_types or []
+    types_result = await db.execute(
+        select(func.coalesce(Video.content_type, REGULAR))
+        .where(Video.channel_id == channel_id)
+        .distinct()
+    )
+    detail.available_content_types = sorted(t for (t,) in types_result.all())
     return detail
 
 

--- a/app/schemas/channel.py
+++ b/app/schemas/channel.py
@@ -32,6 +32,9 @@ class ChannelDetail(ChannelOut):
     # Content types this user has hidden for this channel (empty when nothing is
     # hidden or the user isn't subscribed). Backs the per-channel filter menu.
     hidden_content_types: list[str] = Field(default_factory=list)
+    # The distinct content types this channel actually has cataloged, so the
+    # filter menu only offers toggles for types that exist here (NULL → regular).
+    available_content_types: list[str] = Field(default_factory=list)
 
 
 class ContentFilterUpdate(BaseModel):

--- a/tests/test_content_filter.py
+++ b/tests/test_content_filter.py
@@ -130,3 +130,15 @@ async def test_empty_filter_clears(client, make_user):
     assert resp.json()["hidden_content_types"] == []
     resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
     assert len(resp.json()["items"]) == 3
+
+
+async def test_channel_detail_reports_available_content_types(client, make_user):
+    user, headers = await make_user()
+    cid = await _seed_channel_with_videos(user["id"])  # regular, short, live
+    resp = await client.get(f"/api/channels/{cid}", headers=headers)
+    # Only the types this channel actually has — the filter menu offers just these.
+    assert sorted(resp.json()["available_content_types"]) == [
+        "live",
+        "regular",
+        "short",
+    ]


### PR DESCRIPTION
Small follow-up so the client's per-channel filter menu only offers toggles for types the channel actually has (the UX the user picked).

`ChannelDetail.available_content_types` = the distinct `coalesce(content_type, 'regular')` for the channel, computed in `get_channel`. Empty until a channel has videos.

Verified: ruff / format / mypy clean, 7 content-filter tests pass (1 new: available types reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7