### PR TITLE
feat(content-type): backfill content_type from existing unplayable_reason

### DIFF
--- a/alembic/versions/018_backfill_content_type_from_reason.py
+++ b/alembic/versions/018_backfill_content_type_from_reason.py
@@ -1,0 +1,51 @@
+"""Backfill videos.content_type from the unplayable_reason already stored
+
+Videos cataloged before the content_type column existed have content_type NULL,
+so they read as "regular" and can't be filtered by kind. But members-only /
+premium / age-restricted / premiere videos already carry an unplayable_reason
+label (set at catalog time from YouTube's availability/live badges). This is a
+pure data backfill — no yt-dlp — that copies that label into content_type so
+existing content is immediately filterable. Types with no such label (Shorts,
+livestreams, plain videos) are left NULL and picked up by discovery /
+reclassification.
+
+Revision ID: 018_backfill_content_type_from_reason
+Revises: 017_subscription_hidden_content_types
+Create Date: 2026-07-08
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "018_backfill_content_type_from_reason"
+down_revision: Union[str, None] = "017_subscription_hidden_content_types"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    # members_only / premium / age_restricted map to the same content_type name.
+    conn.execute(
+        sa.text(
+            "UPDATE videos SET content_type = unplayable_reason "
+            "WHERE content_type IS NULL AND unplayable_reason IN "
+            "('members_only', 'premium', 'age_restricted')"
+        )
+    )
+    # An unaired premiere is labeled 'upcoming' but is content type 'premiere'.
+    conn.execute(
+        sa.text(
+            "UPDATE videos SET content_type = 'premiere' "
+            "WHERE content_type IS NULL AND unplayable_reason = 'upcoming'"
+        )
+    )
+
+
+def downgrade() -> None:
+    # Data backfill: no-op. The content_type column (added in 016) and every
+    # value remain; there's no reliable way to tell a backfilled value from one
+    # a later catalog/reclassify pass set to the same kind, so we don't guess.
+    pass


### PR DESCRIPTION
Immediate answer to *"is there a filter for members-only content"* for **existing** content.

Videos cataloged before the `content_type` column have it NULL → they read as `regular` → not filterable by kind. But members-only / premium / age-restricted / premiere videos already carry an `unplayable_reason` label (set at catalog time from YouTube's availability/live badges). Migration **018** copies that into `content_type` (`upcoming → premiere`). Pure data backfill — no yt-dlp. Types with no label (Shorts, livestreams, plain videos) stay NULL for discovery / reclassification (following PRs) to fill in.

**Effect:** your existing members-only (and premium / age-restricted / premiere) back catalog becomes filterable the moment this deploys — a "Members only" toggle shows up in those channels' filter menus.

Verified on a scratch DB: seeded rows with `unplayable_reason` → after 018, `members_only→members_only`, `upcoming→premiere`, `removed→NULL`, no-reason→NULL. ruff/format clean; single migration head.

Next: routine `/shorts`+`/streams` re-scan + classify-on-touch, then the throttled per-video reclassify job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7