### PR TITLE
feat(content-type): throttled back-catalog reconcile job

### DIFF
--- a/app/services/channel_poller.py
+++ b/app/services/channel_poller.py
@@ -19,11 +19,25 @@ from app.services.download_manager import (
 )
 from app.services.progress_broadcaster import publish_new_episode
 from app.services.push_gateway import send_to_users
-from app.utils.content_type import CATALOG_ONLY_TYPES, LIVE, REGULAR, SHORT
+from app.utils.content_type import (
+    CATALOG_ONLY_TYPES,
+    LIVE,
+    REGULAR,
+    SHORT,
+    classify_content_type,
+)
 from app.utils.time import utcnow_naive
 from app.utils.unplayable import SOFT_REASONS
 
 logger = logging.getLogger(__name__)
+
+# Content reconciliation (the back-catalog catch-up job): how many
+# content_type-NULL videos to classify per channel per pass, and how many
+# channels to sweep per beat. Bounded so the per-video yt-dlp extraction can't
+# stampede YouTube (which rate-limits / bot-checks bulk extraction) — the sweep
+# just chips away each tick and winds down to a no-op once everything is typed.
+RECONCILE_VIDEOS_PER_CHANNEL = 15
+RECONCILE_CHANNELS_PER_RUN = 8
 
 
 def _as_naive_utc(value: datetime | None) -> datetime | None:
@@ -182,7 +196,10 @@ def poll_single_channel(channel_id: str, db: Session) -> dict:
         )
     else:
         # Routine poll: cheap RSS conditional GET. Only genuinely-new video IDs
-        # fall through to yt-dlp for full metadata.
+        # fall through to yt-dlp for full metadata. (Discovery of a channel's
+        # back-catalog Shorts/livestreams — which RSS and /videos never surface —
+        # is handled off the poll path by the throttled content-reconcile job, so
+        # routine polls stay cheap.)
         discovered = _discover_routine(channel, db)
         if discovered is None:
             # 304 Not Modified, or the feed surfaced no unseen videos: nothing
@@ -350,6 +367,94 @@ def _catalog_videos(
         _emit_new_episode_events(channel_id, new_videos_for_events, db)
 
     return {"cataloged_ids": cataloged_ids, "auto_download_ids": auto_download_ids}
+
+
+def channels_needing_reconcile(db: Session, limit: int) -> list[str]:
+    """Subscribed channels that still have content_type-NULL videos to classify.
+
+    Naturally winds down: a channel drops out once its back catalog is typed
+    (videos cataloged after the content-type feature are classified at ingest),
+    so the periodic sweep converges to a no-op.
+    """
+    stmt = (
+        select(Video.channel_id)
+        .join(UserSubscription, UserSubscription.channel_id == Video.channel_id)
+        .where(Video.content_type.is_(None))
+        .distinct()
+        .limit(limit)
+    )
+    return [row[0] for row in db.execute(stmt).all()]
+
+
+def reconcile_channel_content(channel_id: str, db: Session) -> dict:
+    """Catch a channel's back catalog up to the content-type model.
+
+    Two steps, both bounded and idempotent so the periodic sweep converges
+    without hammering YouTube:
+
+    1. **Discover** the channel's Shorts + livestreams (which RSS and the
+       /videos tab never surface — the tab scan otherwise only ran on the first
+       poll). Cataloged silently and catalog-only, exactly like a poll.
+    2. **Classify** up to ``RECONCILE_VIDEOS_PER_CHANNEL`` content_type-NULL rows
+       — from the stored download ``metadata_json`` when we already have it
+       (free), else one batched yt-dlp extraction of the rest (a single call for
+       the whole batch). A row that fails extraction transiently stays NULL and
+       is retried on a later pass.
+    """
+    channel = db.get(Channel, channel_id)
+    if channel is None:
+        return {"discovered": 0, "classified": 0}
+
+    # 1) Discover back-catalog Shorts + livestreams (catalog-only; silent).
+    cid = channel.youtube_channel_id
+    tab_videos = _merge_tab_entries(
+        fetch_channel_tab(cid, "/shorts", SHORT),
+        fetch_channel_tab(cid, "/streams", LIVE),
+    )
+    discovered = 0
+    if tab_videos:
+        result = _catalog_videos(
+            channel, tab_videos, db, had_initial_poll=True, update_schedule=False
+        )
+        discovered = len(result["cataloged_ids"])
+
+    # 2) Classify content_type-NULL rows.
+    null_videos = (
+        db.execute(
+            select(Video)
+            .where(Video.channel_id == channel_id, Video.content_type.is_(None))
+            .limit(RECONCILE_VIDEOS_PER_CHANNEL)
+        )
+        .scalars()
+        .all()
+    )
+    need_fetch: list[Video] = []
+    for video in null_videos:
+        if video.metadata_json:
+            video.content_type = classify_content_type(video.metadata_json)
+        else:
+            need_fetch.append(video)
+
+    if need_fetch:
+        metas = {
+            m["youtube_video_id"]: m
+            for m in fetch_videos_metadata([v.youtube_video_id for v in need_fetch])
+        }
+        for video in need_fetch:
+            meta = metas.get(video.youtube_video_id)
+            if meta is None:
+                # Transient failure (bot-check / network) — leave NULL, retry later.
+                continue
+            # content_type_for_reason can be None (private/removed/…) — those
+            # aren't a media kind, so fall back to regular to mark them handled.
+            video.content_type = meta.get("content_type") or REGULAR
+            # Self-heal the reason too if the extraction revealed one.
+            if meta.get("unplayable_reason"):
+                video.unplayable_reason = meta["unplayable_reason"]
+
+    classified = sum(1 for v in null_videos if v.content_type is not None)
+    db.commit()
+    return {"discovered": discovered, "classified": classified}
 
 
 def ingest_pushed_videos(

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -66,6 +66,14 @@ celery_app.conf.beat_schedule = {
         "task": "app.tasks.download_tasks.enforce_video_cache_task",
         "schedule": settings.cache_retention_interval_hours * 3600,
     },
+    # Back-catalog catch-up for the content-type feature: discover each channel's
+    # Shorts/livestreams and classify content_type-NULL rows, a few channels at a
+    # time. Winds down to a no-op once caught up (an indexed "any NULL rows?"
+    # check), so a modest cadence is fine and it stays quiet thereafter.
+    "reconcile-content-types": {
+        "task": "app.tasks.download_tasks.reconcile_content_task",
+        "schedule": 900,  # every 15 minutes
+    },
 }
 
 # WebSub (PubSubHubbub) subscription upkeep — only scheduled when a public

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -15,10 +15,13 @@ from app.models.channel import Channel
 from app.models.subscription import UserSubscription
 from app.models.video import Video
 from app.services.channel_poller import (
+    RECONCILE_CHANNELS_PER_RUN,
     _backoff_failed_channel,
+    channels_needing_reconcile,
     ingest_pushed_videos,
     list_channel_ids_to_poll,
     poll_single_channel,
+    reconcile_channel_content,
     refresh_stale_channel_metadata,
 )
 from app.services.download_manager import (
@@ -129,6 +132,59 @@ def poll_channel_task(self, channel_id: str) -> dict:
         logger.exception("Error polling channel %s", channel_id)
         db.rollback()
         _backoff_failed_channel(channel_id, db)
+        return {"status": "error"}
+    finally:
+        db.close()
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.reconcile_content_task",
+    bind=True,
+    max_retries=0,
+)
+def reconcile_content_task(self) -> dict:
+    """Periodic: sweep the back catalog into the content-type model.
+
+    Enumerates a few channels that still have content_type-NULL videos and fans
+    out one isolated per-channel reconcile job each (same shape as the poll
+    fan-out). Cheap and self-limiting — it winds down to a no-op once everything
+    has been discovered + classified, and only ramps back up when a subscription
+    is added or old rows resurface.
+    """
+    db = _get_sync_db()
+    try:
+        channel_ids = channels_needing_reconcile(db, RECONCILE_CHANNELS_PER_RUN)
+    except Exception:
+        logger.exception("Error enumerating channels to reconcile")
+        return {"status": "error"}
+    finally:
+        db.close()
+
+    if not channel_ids:
+        return {"status": "ok", "dispatched": 0}
+
+    group(
+        reconcile_channel_content_task.s(channel_id) for channel_id in channel_ids
+    ).apply_async()
+    logger.info("Dispatched %d content-reconcile jobs", len(channel_ids))
+    return {"status": "ok", "dispatched": len(channel_ids)}
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.reconcile_channel_content_task",
+    bind=True,
+    max_retries=0,
+)
+def reconcile_channel_content_task(self, channel_id: str) -> dict:
+    """Discover + classify one channel's back catalog, on its own DB session so a
+    slow/stuck channel can't affect the others."""
+    db = _get_sync_db()
+    try:
+        result = reconcile_channel_content(channel_id, db)
+        return {"status": "ok", **result}
+    except Exception:
+        logger.exception("Error reconciling channel content %s", channel_id)
+        db.rollback()
         return {"status": "error"}
     finally:
         db.close()

--- a/tests/test_content_reconcile.py
+++ b/tests/test_content_reconcile.py
@@ -1,0 +1,146 @@
+"""Content reconciliation — the back-catalog catch-up job: discover a channel's
+Shorts/livestreams and classify content_type-NULL rows (from stored metadata, or
+a batched extraction), bounded and self-limiting."""
+
+import uuid
+from unittest.mock import MagicMock
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.models.channel import Channel
+from app.models.subscription import UserSubscription
+from app.models.video import Video
+from app.services import channel_poller
+from app.services.channel_poller import (
+    channels_needing_reconcile,
+    reconcile_channel_content,
+)
+from app.utils.content_type import MEMBERS_ONLY, SHORT
+
+
+def _mem_session():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def _channel(db, ytid="UCabc1230000000000000000"):
+    ch = Channel(id=str(uuid.uuid4()), youtube_channel_id=ytid, name="T", slug=ytid)
+    db.add(ch)
+    db.commit()
+    return ch
+
+
+def _video(db, channel, *, content_type=None, metadata_json=None, ytid=None):
+    video = Video(
+        id=str(uuid.uuid4()),
+        youtube_video_id=ytid or f"yt{uuid.uuid4().hex[:9]}",
+        channel_id=channel.id,
+        title="V",
+        status="CATALOGED",
+        content_type=content_type,
+        metadata_json=metadata_json,
+    )
+    db.add(video)
+    db.commit()
+    return video
+
+
+def test_channels_needing_reconcile_only_those_with_null_rows():
+    db = _mem_session()
+    done = _channel(db, "UCdone000000000000000000")
+    todo = _channel(db, "UCtodo000000000000000000")
+    for ch in (done, todo):
+        db.add(UserSubscription(user_id="u1", channel_id=ch.id))
+    db.commit()
+    _video(db, done, content_type="regular")  # fully typed → drops out
+    _video(db, todo, content_type=None)  # still needs classifying
+
+    assert channels_needing_reconcile(db, limit=10) == [todo.id]
+    db.close()
+
+
+def test_reconcile_classifies_from_stored_metadata(monkeypatch):
+    db = _mem_session()
+    monkeypatch.setattr(channel_poller, "fetch_channel_tab", lambda *a, **k: [])
+    ch = _channel(db)
+    video = _video(
+        db, ch, content_type=None, metadata_json={"availability": "subscriber_only"}
+    )
+
+    result = reconcile_channel_content(ch.id, db)
+
+    db.refresh(video)
+    assert video.content_type == MEMBERS_ONLY  # free, from stored metadata
+    assert result["classified"] == 1
+    db.close()
+
+
+def test_reconcile_fetches_when_no_stored_metadata(monkeypatch):
+    db = _mem_session()
+    monkeypatch.setattr(channel_poller, "fetch_channel_tab", lambda *a, **k: [])
+    monkeypatch.setattr(
+        channel_poller,
+        "fetch_videos_metadata",
+        lambda ids: [{"youtube_video_id": "ABC00000001", "content_type": SHORT}],
+    )
+    ch = _channel(db)
+    video = _video(db, ch, content_type=None, metadata_json=None, ytid="ABC00000001")
+
+    reconcile_channel_content(ch.id, db)
+
+    db.refresh(video)
+    assert video.content_type == SHORT
+    db.close()
+
+
+def test_reconcile_transient_fetch_failure_leaves_null(monkeypatch):
+    db = _mem_session()
+    monkeypatch.setattr(channel_poller, "fetch_channel_tab", lambda *a, **k: [])
+    # The id isn't returned (bot-check / network) → stays NULL, retried next pass.
+    monkeypatch.setattr(channel_poller, "fetch_videos_metadata", lambda ids: [])
+    ch = _channel(db)
+    video = _video(db, ch, content_type=None, metadata_json=None)
+
+    reconcile_channel_content(ch.id, db)
+
+    db.refresh(video)
+    assert video.content_type is None
+    db.close()
+
+
+def test_reconcile_discovers_shorts(monkeypatch):
+    db = _mem_session()
+    monkeypatch.setattr(channel_poller, "_emit_new_episode_events", MagicMock())
+    monkeypatch.setattr(
+        channel_poller, "_determine_auto_downloads", MagicMock(return_value=[])
+    )
+    monkeypatch.setattr(channel_poller, "fetch_videos_metadata", lambda ids: [])
+
+    def fake_tab(cid, tab, default_type, *a, **k):
+        if tab == "/shorts":
+            return [
+                {
+                    "youtube_video_id": "SHORT000001",
+                    "title": "Clip",
+                    "duration_seconds": 30,
+                    "upload_date": None,
+                    "unplayable_reason": None,
+                    "content_type": SHORT,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(channel_poller, "fetch_channel_tab", fake_tab)
+    ch = _channel(db)
+
+    result = reconcile_channel_content(ch.id, db)
+
+    assert result["discovered"] == 1
+    row = db.execute(
+        select(Video).where(Video.youtube_video_id == "SHORT000001")
+    ).scalar_one()
+    assert row.content_type == SHORT
+    db.close()


### PR DESCRIPTION
The throttled per-video reclassification you suggested — plus the back-catalog Shorts/livestream discovery existing channels never got. Runs **off the poll path** so routine polls stay cheap.

## How it works
A periodic Celery sweep (`reconcile_content_task`, every 15 min) picks a few channels that still have `content_type`-NULL videos and fans out one isolated per-channel job each. `reconcile_channel_content` then:

1. **Discovers** the channel's Shorts + livestreams by scanning `/shorts` + `/streams` (which RSS and the `/videos` tab never surface — that scan otherwise only ran on first subscribe). Cataloged silently, catalog-only.
2. **Classifies** up to 15 `content_type`-NULL rows: from the stored download `metadata_json` when we already have it (**free, no yt-dlp**), else **one batched `yt-dlp` extraction** for the rest — your "send a call per video" idea, but batched into a single call so it's one request, not N.

## Why it's safe
- **Bounded:** 15 videos/channel, 8 channels/run, every 15 min — can't stampede YouTube's rate-limit / bot-check (which the code already treats as transient).
- **Self-limiting:** a channel drops out the moment its back catalog is typed (new videos are classified at ingest), so the sweep is an indexed "any NULL rows?" check that **winds down to a no-op** and stays quiet until a new subscription or old rows resurface.
- **Retry-safe:** a video that fails extraction transiently stays NULL and is retried next pass.

Combined with the backfill (#121), your existing **members-only / age-restricted / short / live** content becomes accurately typed and filterable — no re-subscribe needed.

## Verification
`ruff` / `format` / `mypy` clean · **396 tests pass** (5 new: channel selectivity, classify-from-metadata, classify-from-fetch, transient-failure retry, shorts discovery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7
