### PR TITLE
feat(content-type): hide members-only content by default

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -27,7 +27,11 @@ from app.schemas.channel import (
 from app.schemas.video import VideoOut, VideoPagination
 from app.services.channel_poller import poll_single_channel
 from app.services.download_manager import fetch_channel_images, fetch_channel_metadata
-from app.utils.content_type import ALL_CONTENT_TYPES, REGULAR
+from app.utils.content_type import (
+    ALL_CONTENT_TYPES,
+    REGULAR,
+    effective_hidden_content_types,
+)
 from app.tasks.download_tasks import (
     _get_sync_db,
     download_video_task,
@@ -413,7 +417,9 @@ async def refresh_channel_images(
     detail.is_subscribed = sub is not None
     if sub:
         detail.tracking_mode = sub.tracking_mode
-        detail.hidden_content_types = sub.hidden_content_types or []
+        detail.hidden_content_types = effective_hidden_content_types(
+            sub.hidden_content_types
+        )
     return detail
 
 
@@ -474,7 +480,9 @@ async def get_channel(
     detail.is_subscribed = sub is not None
     if sub:
         detail.tracking_mode = sub.tracking_mode
-        detail.hidden_content_types = sub.hidden_content_types or []
+        detail.hidden_content_types = effective_hidden_content_types(
+            sub.hidden_content_types
+        )
     types_result = await db.execute(
         select(func.coalesce(Video.content_type, REGULAR))
         .where(Video.channel_id == channel_id)
@@ -512,24 +520,27 @@ async def set_content_filter(
     if sub is None:
         raise HTTPException(status_code=404, detail="Not subscribed to this channel")
 
-    # Dedup and store None when empty so "nothing hidden" is a clean NULL.
-    hidden = list(dict.fromkeys(body.hidden_content_types))
-    sub.hidden_content_types = hidden or None
+    # Store the explicit set as given (deduped) — including an empty list, which
+    # means "show everything" and must override the members-only default, so it's
+    # kept distinct from NULL ("never configured", where the default applies).
+    sub.hidden_content_types = list(dict.fromkeys(body.hidden_content_types))
     await db.commit()
 
     return await get_channel(channel_id, user=user, db=db)
 
 
 async def _hidden_types_for(channel_id: str, user: User, db: AsyncSession) -> list[str]:
-    """The content types this user has hidden for a channel (empty if none / not
-    subscribed) — the gate applied to the channel's video list and feeds."""
+    """The content types effectively hidden for a channel — the gate applied to
+    its video list. An unconfigured channel (no stored set / not subscribed)
+    falls back to the members-only default; an explicit set (even empty) is used
+    as-is. See effective_hidden_content_types."""
     result = await db.execute(
         select(UserSubscription.hidden_content_types).where(
             UserSubscription.user_id == user.id,
             UserSubscription.channel_id == channel_id,
         )
     )
-    return result.scalar_one_or_none() or []
+    return effective_hidden_content_types(result.scalar_one_or_none())
 
 
 @router.get("/{channel_id}/videos", response_model=VideoPagination)

--- a/app/api/feed.py
+++ b/app/api/feed.py
@@ -13,7 +13,7 @@ from app.models.video import Video
 from app.schemas.channel import ChannelOut
 from app.schemas.feed import FeedItem, HomeFeed
 from app.schemas.video import VideoOut
-from app.utils.content_type import REGULAR
+from app.utils.content_type import REGULAR, effective_hidden_content_types
 
 router = APIRouter(prefix="/api/feed", tags=["feed"])
 
@@ -31,15 +31,19 @@ async def _subscriptions(user: User, db: AsyncSession) -> list[tuple[str, list |
 def _content_gate(subs: list[tuple[str, list | None]]) -> ColumnElement | None:
     """A WHERE condition dropping videos whose content_type is hidden for their
     channel (the per-channel gate applied to feeds). None when nothing is hidden.
-    A NULL content_type counts as ``regular``, matching the channel-list gate."""
-    hidden_conds = [
-        and_(
-            Video.channel_id == channel_id,
-            func.coalesce(Video.content_type, REGULAR).in_(hidden),
-        )
-        for channel_id, hidden in subs
-        if hidden
-    ]
+    A NULL content_type counts as ``regular``, matching the channel-list gate; a
+    NULL stored set means the channel is unconfigured, so the members-only
+    default applies (see effective_hidden_content_types)."""
+    hidden_conds = []
+    for channel_id, stored in subs:
+        hidden = effective_hidden_content_types(stored)
+        if hidden:
+            hidden_conds.append(
+                and_(
+                    Video.channel_id == channel_id,
+                    func.coalesce(Video.content_type, REGULAR).in_(hidden),
+                )
+            )
     return not_(or_(*hidden_conds)) if hidden_conds else None
 
 

--- a/app/utils/content_type.py
+++ b/app/utils/content_type.py
@@ -43,6 +43,23 @@ ALL_CONTENT_TYPES = frozenset(
 # via unplayable_reason, and premieres via their SOFT upcoming reason.
 CATALOG_ONLY_TYPES = frozenset({SHORT, LIVE})
 
+# Content types hidden for a channel *by default* — applied only when the viewer
+# hasn't explicitly configured that channel's filter (its stored hidden set is
+# NULL). Members-only content can't be played here anyway, so it stays out of the
+# way until the viewer opts to show it per channel. Any explicitly stored set
+# (even an empty one — "show everything") overrides this; see
+# effective_hidden_content_types.
+DEFAULT_HIDDEN_CONTENT_TYPES = (MEMBERS_ONLY,)
+
+
+def effective_hidden_content_types(stored: list | None) -> list[str]:
+    """The content types actually hidden for a channel. A stored value is used
+    as-is — including an empty list, i.e. the viewer explicitly showing
+    everything; NULL means the channel was never configured, so the global
+    default (members-only) applies."""
+    return list(DEFAULT_HIDDEN_CONTENT_TYPES) if stored is None else stored
+
+
 # Longest a video can be and still count as a Short by the duration fallback
 # (YouTube caps Shorts at 60s; a second of slack for rounding). Only consulted
 # when nothing already marked it a Short.

--- a/tests/test_content_filter.py
+++ b/tests/test_content_filter.py
@@ -132,6 +132,52 @@ async def test_empty_filter_clears(client, make_user):
     assert len(resp.json()["items"]) == 3
 
 
+async def test_members_only_hidden_by_default(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cid = channel.id
+        # Subscribed but the filter is never configured (NULL) → default applies.
+        await seed_subscription(db, user["id"], cid)
+        await seed_video(db, channel, title="Regular", content_type="regular")
+        await seed_video(db, channel, title="Members", content_type="members_only")
+
+    # Members-only is hidden without the viewer configuring anything.
+    resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
+    assert {v["title"] for v in resp.json()["items"]} == {"Regular"}
+
+    # The channel detail surfaces the default so the menu shows it unchecked.
+    resp = await client.get(f"/api/channels/{cid}", headers=headers)
+    assert resp.json()["hidden_content_types"] == ["members_only"]
+
+    # The reveal override still shows everything.
+    resp = await client.get(
+        f"/api/channels/{cid}/videos?include_hidden=true", headers=headers
+    )
+    assert {v["title"] for v in resp.json()["items"]} == {"Regular", "Members"}
+
+
+async def test_explicit_show_all_overrides_members_only_default(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        cid = channel.id
+        await seed_subscription(db, user["id"], cid)
+        await seed_video(db, channel, title="Members", content_type="members_only")
+
+    # Explicitly showing everything (empty set) overrides the default.
+    resp = await client.put(
+        f"/api/channels/{cid}/content-filter",
+        json={"hidden_content_types": []},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["hidden_content_types"] == []
+
+    resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
+    assert {v["title"] for v in resp.json()["items"]} == {"Members"}
+
+
 async def test_channel_detail_reports_available_content_types(client, make_user):
     user, headers = await make_user()
     cid = await _seed_channel_with_videos(user["id"])  # regular, short, live

--- a/tests/test_content_type.py
+++ b/tests/test_content_type.py
@@ -12,6 +12,7 @@ from app.utils.content_type import (
     SHORT,
     classify_content_type,
     content_type_for_reason,
+    effective_hidden_content_types,
 )
 
 
@@ -106,3 +107,11 @@ def test_content_type_for_reason_maps_known_reasons():
 def test_content_type_for_reason_ignores_non_media_reasons():
     for reason in ("private", "removed", "geo_blocked", "drm", "unavailable", None):
         assert content_type_for_reason(reason) is None
+
+
+def test_effective_hidden_content_types_applies_members_only_default():
+    # Unconfigured (NULL) → the members-only default.
+    assert effective_hidden_content_types(None) == [MEMBERS_ONLY]
+    # An explicit set is used as-is, including empty ("show everything").
+    assert effective_hidden_content_types([]) == []
+    assert effective_hidden_content_types([SHORT]) == [SHORT]


### PR DESCRIPTION
Members-only videos can't be played here anyway, so a channel's filter now **hides them by default** — unless you opt to show them per channel.

## Semantics
A channel's stored hidden set becomes three-way:
- **NULL** (never configured) → the members-only default applies.
- **an explicit list** (e.g. `[short]`) → used as-is.
- **empty `[]`** (you unchecked everything / explicitly show all) → overrides the default, shows everything.

`effective_hidden_content_types()` centralizes this, applied in the channel-list gate, the feed gate, and the channel-detail / content-filter responses. Because the detail response returns the *effective* set, the client menu shows **Members only unchecked** by default and preserves it through edits — **no client change needed**. The PUT now stores the explicit set as-is (empty stays `[]`) so "show everything" is distinguishable from "unconfigured".

**Retroactive:** existing subscriptions (NULL hidden set) get the default too — members-only drops out of their channel lists and feeds immediately, and the filter menu lets you turn it back on any channel.

## Verification
ruff / format / mypy clean · **399 tests pass** (3 new: default hides members-only + reveal override, explicit show-all overrides the default, `effective_hidden_content_types` unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7