### PR TITLE
feat(content-type): also hide premium by default

### DIFF
--- a/app/utils/content_type.py
+++ b/app/utils/content_type.py
@@ -45,18 +45,18 @@ CATALOG_ONLY_TYPES = frozenset({SHORT, LIVE})
 
 # Content types hidden for a channel *by default* — applied only when the viewer
 # hasn't explicitly configured that channel's filter (its stored hidden set is
-# NULL). Members-only content can't be played here anyway, so it stays out of the
-# way until the viewer opts to show it per channel. Any explicitly stored set
-# (even an empty one — "show everything") overrides this; see
-# effective_hidden_content_types.
-DEFAULT_HIDDEN_CONTENT_TYPES = (MEMBERS_ONLY,)
+# NULL). The access walls the server can't fetch anyway (members-only = channel
+# membership, premium = YouTube Premium / paid-rental) stay out of the way until
+# the viewer opts to show them per channel. Any explicitly stored set (even an
+# empty one — "show everything") overrides this; see effective_hidden_content_types.
+DEFAULT_HIDDEN_CONTENT_TYPES = (MEMBERS_ONLY, PREMIUM)
 
 
 def effective_hidden_content_types(stored: list | None) -> list[str]:
     """The content types actually hidden for a channel. A stored value is used
     as-is — including an empty list, i.e. the viewer explicitly showing
     everything; NULL means the channel was never configured, so the global
-    default (members-only) applies."""
+    default (members-only + premium) applies."""
     return list(DEFAULT_HIDDEN_CONTENT_TYPES) if stored is None else stored
 
 

--- a/tests/test_content_filter.py
+++ b/tests/test_content_filter.py
@@ -132,7 +132,7 @@ async def test_empty_filter_clears(client, make_user):
     assert len(resp.json()["items"]) == 3
 
 
-async def test_members_only_hidden_by_default(client, make_user):
+async def test_access_walls_hidden_by_default(client, make_user):
     user, headers = await make_user()
     async with async_session_factory() as db:
         channel = await seed_channel(db)
@@ -141,20 +141,25 @@ async def test_members_only_hidden_by_default(client, make_user):
         await seed_subscription(db, user["id"], cid)
         await seed_video(db, channel, title="Regular", content_type="regular")
         await seed_video(db, channel, title="Members", content_type="members_only")
+        await seed_video(db, channel, title="Premium", content_type="premium")
 
-    # Members-only is hidden without the viewer configuring anything.
+    # Members-only and premium are hidden without the viewer configuring anything.
     resp = await client.get(f"/api/channels/{cid}/videos", headers=headers)
     assert {v["title"] for v in resp.json()["items"]} == {"Regular"}
 
-    # The channel detail surfaces the default so the menu shows it unchecked.
+    # The channel detail surfaces the default so the menu shows them unchecked.
     resp = await client.get(f"/api/channels/{cid}", headers=headers)
-    assert resp.json()["hidden_content_types"] == ["members_only"]
+    assert resp.json()["hidden_content_types"] == ["members_only", "premium"]
 
     # The reveal override still shows everything.
     resp = await client.get(
         f"/api/channels/{cid}/videos?include_hidden=true", headers=headers
     )
-    assert {v["title"] for v in resp.json()["items"]} == {"Regular", "Members"}
+    assert {v["title"] for v in resp.json()["items"]} == {
+        "Regular",
+        "Members",
+        "Premium",
+    }
 
 
 async def test_explicit_show_all_overrides_members_only_default(client, make_user):

--- a/tests/test_content_type.py
+++ b/tests/test_content_type.py
@@ -109,9 +109,9 @@ def test_content_type_for_reason_ignores_non_media_reasons():
         assert content_type_for_reason(reason) is None
 
 
-def test_effective_hidden_content_types_applies_members_only_default():
-    # Unconfigured (NULL) → the members-only default.
-    assert effective_hidden_content_types(None) == [MEMBERS_ONLY]
+def test_effective_hidden_content_types_applies_default():
+    # Unconfigured (NULL) → the default access walls (members-only + premium).
+    assert effective_hidden_content_types(None) == [MEMBERS_ONLY, PREMIUM]
     # An explicit set is used as-is, including empty ("show everything").
     assert effective_hidden_content_types([]) == []
     assert effective_hidden_content_types([SHORT]) == [SHORT]


### PR DESCRIPTION
Follow-up to #123. Adds `premium` to `DEFAULT_HIDDEN_CONTENT_TYPES` alongside `members_only`.

Both are access walls NullFeed can't fetch — **members-only** = a channel's own membership, **premium** = YouTube Premium / paid-rental — so an unconfigured channel now hides both by default, revealable per channel via the filter menu. Same three-way semantics (NULL → default; explicit set incl. empty → as-is).

ruff / format / mypy clean · **399 tests pass** (updated the default-hidden tests to cover premium too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016CnajrBHSomu3GHTWhRkn7