### PR TITLE
Fix Accept-Ranges on instant-stream proxy when upstream ignores Range

### DIFF
--- a/app/services/instant_stream.py
+++ b/app/services/instant_stream.py
@@ -62,8 +62,14 @@ _UPSTREAM_USER_AGENT = (
 )
 
 # Response headers worth forwarding from the source so the client gets correct
-# length/range/type metadata for seeking.
-_FORWARDED_HEADERS = ("content-length", "content-range", "content-type")
+# length/range/type metadata for seeking. accept-ranges is only trusted as-is
+# on a plain (no client Range) request — see stream_proxy.
+_FORWARDED_HEADERS = (
+    "accept-ranges",
+    "content-length",
+    "content-range",
+    "content-type",
+)
 
 # video_id -> (url, expiry_epoch). Per-process; each worker resolves once and
 # reuses. Cleared between tests via conftest's reset fixture.
@@ -178,8 +184,12 @@ async def stream_proxy(url: str, range_header: str | None) -> StreamingResponse:
 
     The source's status (200/206), Content-Length, Content-Range and
     Content-Type are passed through so the client's player can seek normally.
-    The client and upstream response are closed when the body is fully streamed
-    (or the client disconnects and the generator is torn down).
+    Accept-Ranges is only advertised as ``bytes`` when the upstream actually
+    honored the Range request (206); if the client sent a Range and got a full
+    200 body back, ``Accept-Ranges: none`` is sent so the player doesn't stall
+    a seek waiting for the sequential download to catch up. The client and
+    upstream response are closed when the body is fully streamed (or the
+    client disconnects and the generator is torn down).
     """
     req_headers = {"User-Agent": _UPSTREAM_USER_AGENT}
     if range_header:
@@ -201,7 +211,23 @@ async def stream_proxy(url: str, range_header: str | None) -> StreamingResponse:
         for key in _FORWARDED_HEADERS
         if key in upstream.headers
     }
-    out_headers["Accept-Ranges"] = "bytes"
+    if upstream.status_code == 206:
+        # Upstream honored the Range request, so seeking works through this
+        # path; Content-Range was forwarded above.
+        out_headers["accept-ranges"] = "bytes"
+    else:
+        # Not a range response; a stray Content-Range would be malformed here.
+        out_headers.pop("content-range", None)
+        if range_header:
+            # The client asked for a range and the upstream sent the full body
+            # instead. Advertising range support anyway makes the player treat
+            # a seek as satisfiable and stall until the sequential download
+            # catches up — declare "none" so it doesn't try. Upstream's own
+            # accept-ranges claim (forwarded above) is overridden: demonstrated
+            # behavior wins.
+            out_headers["accept-ranges"] = "none"
+        # Without a client Range a 200 proves nothing either way, so upstream's
+        # own accept-ranges advertisement (if any) is left as forwarded.
     media_type = upstream.headers.get("content-type", "video/mp4")
 
     async def body():

--- a/tests/test_instant_stream.py
+++ b/tests/test_instant_stream.py
@@ -86,6 +86,101 @@ async def test_resolve_failure_raises(monkeypatch):
         instant_stream.resolve_progressive_url("vid-2")
 
 
+# --- stream_proxy Accept-Ranges semantics ----------------------------------
+
+
+async def _drain(resp) -> bytes:
+    """Consume a StreamingResponse body (also tears down the proxy's client)."""
+    return b"".join([chunk async for chunk in resp.body_iterator])
+
+
+async def test_stream_proxy_206_advertises_ranges(monkeypatch):
+    body = bytes(i % 256 for i in range(1000))
+    monkeypatch.setattr(instant_stream, "_make_client", _mock_client_factory(body))
+
+    resp = await instant_stream.stream_proxy(
+        "https://upstream.test/v.mp4", "bytes=0-99"
+    )
+
+    assert resp.status_code == 206
+    assert resp.headers["accept-ranges"] == "bytes"
+    assert resp.headers["content-range"] == "bytes 0-99/1000"
+    assert await _drain(resp) == body[:100]
+
+
+async def test_stream_proxy_200_fallback_does_not_advertise_ranges(monkeypatch):
+    """An upstream that ignores Range and sends the full body must not leave
+    the player believing seeks work — Accept-Ranges flips to ``none`` and no
+    Content-Range leaks through."""
+    body = b"x" * 512
+
+    def ignores_range(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("range") == "bytes=0-99"  # forwarded, ignored
+
+        async def full_stream():
+            yield body
+
+        return httpx.Response(
+            200,
+            headers={
+                "Content-Length": str(len(body)),
+                "Content-Type": "video/mp4",
+                # Upstream *claims* range support while ignoring the request;
+                # the demonstrated behavior must win over the claim.
+                "Accept-Ranges": "bytes",
+            },
+            content=full_stream(),
+        )
+
+    monkeypatch.setattr(
+        instant_stream,
+        "_make_client",
+        lambda: httpx.AsyncClient(transport=httpx.MockTransport(ignores_range)),
+    )
+
+    resp = await instant_stream.stream_proxy(
+        "https://upstream.test/v.mp4", "bytes=0-99"
+    )
+
+    assert resp.status_code == 200
+    assert resp.headers["accept-ranges"] == "none"
+    assert "content-range" not in resp.headers
+    assert await _drain(resp) == body
+
+
+async def test_stream_proxy_plain_get_forwards_upstream_accept_ranges(monkeypatch):
+    """No client Range: a 200 proves nothing, so upstream's own Accept-Ranges
+    passes through when present and stays absent when it isn't."""
+    body = b"y" * 64
+
+    def with_claim(request: httpx.Request) -> httpx.Response:
+        async def full_stream():
+            yield body
+
+        return httpx.Response(
+            200,
+            headers={"Content-Type": "video/mp4", "Accept-Ranges": "bytes"},
+            content=full_stream(),
+        )
+
+    monkeypatch.setattr(
+        instant_stream,
+        "_make_client",
+        lambda: httpx.AsyncClient(transport=httpx.MockTransport(with_claim)),
+    )
+    resp = await instant_stream.stream_proxy("https://upstream.test/v.mp4", None)
+    assert resp.status_code == 200
+    assert resp.headers["accept-ranges"] == "bytes"
+    await _drain(resp)
+
+    # _mock_client_factory's plain-200 handler sends no Accept-Ranges at all.
+    monkeypatch.setattr(instant_stream, "_make_client", _mock_client_factory(body))
+    resp = await instant_stream.stream_proxy("https://upstream.test/v.mp4", None)
+    assert resp.status_code == 200
+    assert "accept-ranges" not in resp.headers
+    await _drain(resp)
+
+
 # --- endpoint -------------------------------------------------------------
 
 
@@ -130,6 +225,7 @@ async def test_instant_stream_proxies_source(client, make_user, monkeypatch):
     )
     assert resp.status_code == 206
     assert resp.headers["Content-Range"] == "bytes 0-99/1000"
+    assert resp.headers["Accept-Ranges"] == "bytes"
     assert resp.content == body[:100]
 
 


### PR DESCRIPTION
## Problem

`stream_proxy` in `app/services/instant_stream.py` set `Accept-Ranges: bytes` unconditionally on proxied instant-stream responses. When the upstream source ignored the client's `Range` header and returned `200` with the full body (no `Content-Range`), iOS AVPlayer was told ranges are supported while receiving a non-range response — a seek would stall until the sequential download caught up to the target position.

## Fix

- `Accept-Ranges: bytes` is only advertised when the upstream actually returned `206` (i.e. honored the Range request). `Content-Range` passes through as before.
- If the client sent a `Range` and the upstream answered `200`, the proxy now sends `Accept-Ranges: none` — demonstrated behavior overrides any upstream `Accept-Ranges` claim — and drops any stray `Content-Range`.
- On a plain no-Range GET, a `200` proves nothing either way, so the upstream's own `Accept-Ranges` advertisement (now in the forwarded-headers list) passes through untouched. This keeps seek working for clients (e.g. the web player) whose first request has no Range header.

## Tests

New unit tests on `stream_proxy` directly:
- 206 passthrough → `Accept-Ranges: bytes` + `Content-Range` forwarded
- 200 fallback (Range sent, upstream ignores it and even claims `Accept-Ranges: bytes`) → `Accept-Ranges: none`, no `Content-Range`
- plain GET → upstream's own `Accept-Ranges` forwarded when present, absent when not

Plus an `Accept-Ranges: bytes` assertion on the existing endpoint-level 206 test. Full suite: 402 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)