### PR TITLE
ChatGPT-subscription rank provider for Discover (Codex OAuth)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,15 @@ OPENAI_API_KEY=
 
 # Discovery provider selection (optional). Blank = auto-pick from the keys
 # above (embeddings: gemini then openai; ranking: anthropic then gemini then
-# openai). Valid embed providers: gemini, openai. Valid rank providers:
-# anthropic, gemini, openai. NOTE: switching the embedding provider/model
-# re-embeds channel profiles from scratch (cached vectors are per-model).
+# openai, then chatgpt if signed in). Valid embed providers: gemini, openai.
+# Valid rank providers: anthropic, gemini, openai, chatgpt. NOTE: switching
+# the embedding provider/model re-embeds channel profiles from scratch
+# (cached vectors are per-model).
+#
+# "chatgpt" needs no API key: it runs Discover ranking on a ChatGPT Plus/Pro
+# subscription via the Codex sign-in (Settings -> ChatGPT sign-in in the API,
+# see README "Use your ChatGPT subscription"). Unofficial surface: it shares
+# your plan's Codex usage limits and may break if OpenAI changes it.
 NULLFEED_EMBED_PROVIDER=
 NULLFEED_RANK_PROVIDER=
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ NullFeed is a self-hosted YouTube media center that wraps **yt-dlp** with a poli
 | `GEMINI_API_KEY`         | _(none)_  | Google Gemini API key — enables the embeddings-based Discover pipeline and/or Gemini ranking |
 | `OPENAI_API_KEY`         | _(none)_  | OpenAI API key — enables the embeddings-based Discover pipeline and/or OpenAI ranking |
 | `NULLFEED_EMBED_PROVIDER`| _(auto)_  | Discover embedding provider (`gemini` / `openai`); blank auto-picks from available keys. Switching re-embeds from scratch |
-| `NULLFEED_RANK_PROVIDER` | _(auto)_  | Discover ranking provider (`anthropic` / `gemini` / `openai`); blank auto-picks from available keys |
+| `NULLFEED_RANK_PROVIDER` | _(auto)_  | Discover ranking provider (`anthropic` / `gemini` / `openai` / `chatgpt`); blank auto-picks from available keys (a ChatGPT sign-in counts, picked last) |
 | `NULLFEED_EMBED_MODEL`   | _(auto)_  | Override the embedding model (requires `NULLFEED_EMBED_PROVIDER`) |
 | `NULLFEED_RANK_MODEL`    | _(auto)_  | Override the ranking model (requires `NULLFEED_RANK_PROVIDER`) |
 | `DOWNLOAD_CONCURRENCY`   | `2`       | Max simultaneous yt-dlp downloads                        |
@@ -131,6 +131,29 @@ NullFeed is a self-hosted YouTube media center that wraps **yt-dlp** with a poli
 | `/data/thumbnails` | Cached channel art and thumbnails| `/mnt/user/appdata/nullfeed/thumbs`     |
 
 ---
+
+## Use your ChatGPT subscription for Discover ranking
+
+Instead of an OpenAI API key, the Discover reranker can run on a ChatGPT
+Plus/Pro subscription via the same "sign in with ChatGPT" flow Codex CLI
+uses. Embeddings still need a Gemini or OpenAI key (the ChatGPT surface has
+no embeddings) — `GEMINI_API_KEY` from Google AI Studio's free tier pairs
+well.
+
+1. In ChatGPT: Settings -> Security -> enable **device authorization**
+   (off by default).
+2. As the NullFeed admin profile: `POST /api/settings/chatgpt-login` — the
+   response contains a `verification_url` and a `user_code`.
+3. Open the URL, sign in, enter the code.
+4. `POST /api/settings/chatgpt-login/poll` until it returns
+   `{"status": "connected"}`. Done — the `chatgpt` rank provider is now
+   available (auto-picked when no API keys are set, or pin it with
+   `NULLFEED_RANK_PROVIDER=chatgpt`).
+
+**Caveats:** this is an unofficial surface OpenAI operates for Codex
+clients — it may change or be gated at any time, and Discover shares your
+plan's Codex usage limits (heavy refreshing eats the same quota as Codex
+code reviews). Any failure just disables the provider; nothing else breaks.
 
 ## Age-restricted videos
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,11 @@ well.
    response contains a `verification_url` and a `user_code`.
 3. Open the URL, sign in, enter the code.
 4. `POST /api/settings/chatgpt-login/poll` until it returns
-   `{"status": "connected"}`. Done — the `chatgpt` rank provider is now
-   available (auto-picked when no API keys are set, or pin it with
-   `NULLFEED_RANK_PROVIDER=chatgpt`).
+   `{"status": "connected"}`.
+5. Set **`NULLFEED_RANK_PROVIDER=chatgpt`**. This pin is required in the
+   normal setup: your embedding key (Gemini/OpenAI) would otherwise win the
+   ranking slot too, so without the pin Discover keeps ranking on that
+   metered key instead of your ChatGPT plan.
 
 **Caveats:** this is an unofficial surface OpenAI operates for Codex
 clients — it may change or be gated at any time, and Discover shares your

--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -1,8 +1,10 @@
-"""Admin settings: in-app YouTube cookie management.
+"""Admin settings: YouTube cookies + ChatGPT (Codex OAuth) sign-in.
 
 Lets an admin paste a cookies.txt from the app so age-restricted / members-only
-videos can be extracted, without hand-placing a file on the server. Stored via
-``app/utils/ytdlp`` (hot-reloaded on the next yt-dlp call).
+videos can be extracted, without hand-placing a file on the server (stored via
+``app/utils/ytdlp``, hot-reloaded on the next yt-dlp call), and manage the
+optional ChatGPT-subscription sign-in that backs the ``chatgpt`` Discover
+rank provider (``app/services/chatgpt_auth``).
 """
 
 import logging
@@ -12,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from app.api.auth import get_current_user
 from app.models.user import User
+from app.services import chatgpt_auth
 from app.utils.ytdlp import (
     clear_cookies,
     cookies_status,
@@ -78,3 +81,54 @@ async def delete_youtube_cookies(user: User = Depends(get_current_user)) -> dict
     _require_admin(user)
     clear_cookies()
     return cookies_status()
+
+
+# --- ChatGPT (Codex OAuth) sign-in for the Discover rank provider ----------
+
+
+@router.get("/chatgpt-login")
+async def get_chatgpt_login(user: User = Depends(get_current_user)) -> dict:
+    """Sign-in status: connected / pending / needs re-auth."""
+    _require_admin(user)
+    return chatgpt_auth.auth_status()
+
+
+@router.post("/chatgpt-login")
+async def start_chatgpt_login(user: User = Depends(get_current_user)) -> dict:
+    """Start the device sign-in: open the returned URL, enter the code."""
+    _require_admin(user)
+    try:
+        started = await chatgpt_auth.start_device_login()
+    except chatgpt_auth.DeviceLoginError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    except Exception as exc:  # network failure etc. — never a 500 traceback
+        logger.warning("ChatGPT sign-in start failed: %s", exc)
+        raise HTTPException(
+            status_code=502, detail="Could not reach the ChatGPT sign-in service."
+        )
+    logger.info("ChatGPT device sign-in started by admin %s", user.id)
+    return started
+
+
+@router.post("/chatgpt-login/poll")
+async def poll_chatgpt_login(user: User = Depends(get_current_user)) -> dict:
+    """One approval poll; repeat until status is no longer 'pending'."""
+    _require_admin(user)
+    try:
+        return await chatgpt_auth.poll_device_login()
+    except chatgpt_auth.DeviceLoginError as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
+    except Exception as exc:
+        logger.warning("ChatGPT sign-in poll failed: %s", exc)
+        raise HTTPException(
+            status_code=502, detail="Could not reach the ChatGPT sign-in service."
+        )
+
+
+@router.delete("/chatgpt-login")
+async def delete_chatgpt_login(user: User = Depends(get_current_user)) -> dict:
+    """Sign out (removes the stored tokens)."""
+    _require_admin(user)
+    chatgpt_auth.clear_auth()
+    logger.info("ChatGPT sign-in cleared by admin %s", user.id)
+    return chatgpt_auth.auth_status()

--- a/app/services/chatgpt_auth.py
+++ b/app/services/chatgpt_auth.py
@@ -1,0 +1,363 @@
+"""ChatGPT-subscription sign-in for the discovery rank provider (Codex OAuth).
+
+Implements the device-code "sign in with ChatGPT" flow that Codex CLI uses
+(and that agents like opencode and Hermes ride) so a self-hosted NullFeed can
+run Discover ranking against a ChatGPT Plus/Pro plan instead of API credits.
+
+This is an UNOFFICIAL surface: OpenAI operates it for Codex clients and has
+tolerated third-party use, but it is undocumented and may change or be
+gated at any time. Everything here degrades gracefully — a broken login only
+disables the ``chatgpt`` rank provider; Discover falls back like any other
+missing provider.
+
+Flow (mirrors codex-rs/login):
+
+1. ``POST /api/accounts/deviceauth/usercode`` -> ``{device_auth_id,
+   user_code, interval}``. The admin opens ``https://auth.openai.com/codex/device``
+   and enters the code. Device authorization is OFF by default — the account
+   owner must enable it in ChatGPT security settings first.
+2. Poll ``POST /api/accounts/deviceauth/token`` (403/404 = not yet approved)
+   until it returns ``{authorization_code, code_verifier}``.
+3. Exchange the code at ``/oauth/token`` (PKCE, form-encoded). Tokens are
+   persisted 0600 under ``settings.config_path``.
+
+Refresh tokens are single-use and rotated on every refresh, so refreshes are
+serialized behind a lock and the store is written atomically; a re-auth-class
+error (``invalid_grant`` / ``refresh_token_*``) marks the store
+``needs_reauth`` instead of deleting it, so the admin UI can say why.
+"""
+
+import asyncio
+import base64
+import binascii
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+AUTH_BASE = "https://auth.openai.com"
+TOKEN_URL = f"{AUTH_BASE}/oauth/token"
+VERIFICATION_URL = f"{AUTH_BASE}/codex/device"
+
+_AUTH_FILENAME = "chatgpt_codex_auth.json"
+_PENDING_FILENAME = "chatgpt_codex_pending.json"
+# Refresh proactively when the access token expires within this window.
+_REFRESH_WINDOW_SECONDS = 300
+# The device code is valid for 15 minutes (codex-rs constant).
+_DEVICE_FLOW_TTL_SECONDS = 900
+_TIMEOUT = 30.0
+
+# Token-endpoint error codes that mean the refresh token is dead and the
+# admin must sign in again (single-use rotation makes these expected when
+# another Codex client consumed the same credential).
+_REAUTH_ERROR_CODES = (
+    "invalid_grant",
+    "invalid_token",
+    "refresh_token_expired",
+    "refresh_token_reused",
+    "refresh_token_invalidated",
+)
+
+
+class DeviceLoginError(RuntimeError):
+    """The device-auth flow could not be started or completed."""
+
+
+# Serialized refresh: the lock is loop-bound, so tests reset it per loop.
+_refresh_lock: asyncio.Lock | None = None
+
+
+def _get_refresh_lock() -> asyncio.Lock:
+    global _refresh_lock
+    if _refresh_lock is None:
+        _refresh_lock = asyncio.Lock()
+    return _refresh_lock
+
+
+def _reset_state() -> None:
+    """Test hook: drop the loop-bound lock between event loops."""
+    global _refresh_lock
+    _refresh_lock = None
+
+
+def _auth_path() -> Path:
+    return Path(settings.config_path) / _AUTH_FILENAME
+
+
+def _pending_path() -> Path:
+    return Path(settings.config_path) / _PENDING_FILENAME
+
+
+def _write_private(path: Path, data: dict) -> None:
+    """Atomic 0600 write (tmp + rename), mirroring the push-key pattern."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{os.urandom(4).hex()}.tmp")
+    tmp.write_text(json.dumps(data))
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def _load(path: Path) -> dict | None:
+    try:
+        data = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _jwt_payload(token: str) -> dict:
+    """Decode a JWT payload WITHOUT signature verification.
+
+    We only read our own token's expiry and account claim locally; the
+    backend is what actually authenticates the token.
+    """
+    try:
+        segment = token.split(".")[1]
+        padded = segment + "=" * (-len(segment) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+    except (IndexError, ValueError, binascii.Error):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _jwt_exp(token: str) -> float | None:
+    exp = _jwt_payload(token).get("exp")
+    return float(exp) if isinstance(exp, (int, float)) else None
+
+
+def _account_id_from(record: dict) -> str | None:
+    for key in ("access_token", "id_token"):
+        claims = _jwt_payload(record.get(key) or "")
+        auth_claim = claims.get("https://api.openai.com/auth")
+        if isinstance(auth_claim, dict):
+            account_id = auth_claim.get("chatgpt_account_id")
+            if isinstance(account_id, str) and account_id:
+                return account_id
+    return None
+
+
+def has_auth() -> bool:
+    """True when a signed-in, non-broken credential store exists."""
+    record = _load(_auth_path())
+    return bool(
+        record and record.get("refresh_token") and not record.get("needs_reauth")
+    )
+
+
+def auth_status() -> dict:
+    record = _load(_auth_path())
+    pending = _load(_pending_path())
+    status = {
+        "connected": bool(record and record.get("refresh_token")),
+        "needs_reauth": bool(record and record.get("needs_reauth")),
+        "account_id": (record or {}).get("account_id"),
+        "pending": bool(pending),
+    }
+    if pending:
+        status["user_code"] = pending.get("user_code")
+        status["verification_url"] = VERIFICATION_URL
+    return status
+
+
+def clear_auth() -> None:
+    _auth_path().unlink(missing_ok=True)
+    _pending_path().unlink(missing_ok=True)
+
+
+async def start_device_login() -> dict:
+    """Begin the device flow; returns what the admin must do next."""
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            f"{AUTH_BASE}/api/accounts/deviceauth/usercode",
+            json={"client_id": CLIENT_ID},
+        )
+    if resp.status_code >= 400:
+        raise DeviceLoginError(
+            "Could not start the ChatGPT device sign-in "
+            f"(HTTP {resp.status_code}). Device authorization is disabled by "
+            "default — enable it in ChatGPT Settings -> Security (or your "
+            "workspace settings), then try again."
+        )
+    data = resp.json()
+    user_code = data.get("user_code") or data.get("usercode")
+    device_auth_id = data.get("device_auth_id")
+    if not (isinstance(user_code, str) and isinstance(device_auth_id, str)):
+        raise DeviceLoginError("Unexpected response starting device sign-in")
+    _write_private(
+        _pending_path(),
+        {
+            "device_auth_id": device_auth_id,
+            "user_code": user_code,
+            "interval": int(data.get("interval") or 5),
+            "started_at": time.time(),
+        },
+    )
+    return {
+        "verification_url": VERIFICATION_URL,
+        "user_code": user_code,
+        "expires_in_minutes": _DEVICE_FLOW_TTL_SECONDS // 60,
+    }
+
+
+async def poll_device_login() -> dict:
+    """One poll attempt; the caller (admin UI) repeats until terminal."""
+    pending = _load(_pending_path())
+    if not pending:
+        return {"status": "idle"}
+    if time.time() - float(pending.get("started_at") or 0) > _DEVICE_FLOW_TTL_SECONDS:
+        _pending_path().unlink(missing_ok=True)
+        return {"status": "expired", "detail": "The device code expired; start again."}
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        resp = await client.post(
+            f"{AUTH_BASE}/api/accounts/deviceauth/token",
+            json={
+                "device_auth_id": pending["device_auth_id"],
+                "user_code": pending["user_code"],
+            },
+        )
+        # 403/404 mean "not approved yet" in this (non-RFC-8628) flow.
+        if resp.status_code in (403, 404):
+            return {
+                "status": "pending",
+                "user_code": pending["user_code"],
+                "verification_url": VERIFICATION_URL,
+            }
+        if resp.status_code >= 400:
+            _pending_path().unlink(missing_ok=True)
+            return {
+                "status": "error",
+                "detail": f"Device sign-in failed (HTTP {resp.status_code}).",
+            }
+        approval = resp.json()
+        token_resp = await _exchange_code(
+            client,
+            approval.get("authorization_code") or "",
+            approval.get("code_verifier") or "",
+        )
+
+    _persist_tokens(token_resp)
+    _pending_path().unlink(missing_ok=True)
+    record = _load(_auth_path()) or {}
+    logger.info("ChatGPT sign-in completed (account %s)", record.get("account_id"))
+    return {"status": "connected", "account_id": record.get("account_id")}
+
+
+async def _exchange_code(client: httpx.AsyncClient, code: str, verifier: str) -> dict:
+    resp = await client.post(
+        TOKEN_URL,
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": f"{AUTH_BASE}/deviceauth/callback",
+            "client_id": CLIENT_ID,
+            "code_verifier": verifier,
+        },
+    )
+    if resp.status_code >= 400:
+        raise DeviceLoginError(
+            f"Token exchange failed (HTTP {resp.status_code}): {resp.text[:200]}"
+        )
+    data = resp.json()
+    if not isinstance(data, dict) or not data.get("access_token"):
+        raise DeviceLoginError("Token exchange returned no access token")
+    return data
+
+
+def _persist_tokens(token_resp: dict, existing: dict | None = None) -> None:
+    existing = existing or _load(_auth_path()) or {}
+    record = {
+        "access_token": token_resp.get("access_token") or existing.get("access_token"),
+        "refresh_token": token_resp.get("refresh_token")
+        or existing.get("refresh_token"),
+        "id_token": token_resp.get("id_token") or existing.get("id_token"),
+        "last_refresh": time.time(),
+        "needs_reauth": False,
+    }
+    record["account_id"] = _account_id_from(record) or existing.get("account_id")
+    _write_private(_auth_path(), record)
+
+
+def _credentials_from(record: dict) -> tuple[str, str] | None:
+    access = record.get("access_token")
+    account = record.get("account_id") or _account_id_from(record)
+    if isinstance(access, str) and access and isinstance(account, str) and account:
+        return access, account
+    return None
+
+
+def _is_fresh(record: dict) -> bool:
+    exp = _jwt_exp(record.get("access_token") or "")
+    return exp is not None and exp - time.time() > _REFRESH_WINDOW_SECONDS
+
+
+async def get_access_credentials(
+    force_refresh: bool = False,
+) -> tuple[str, str] | None:
+    """Return (access_token, chatgpt_account_id), refreshing when needed.
+
+    None means signed out or re-auth required — callers treat the provider
+    as unavailable.
+    """
+    record = _load(_auth_path())
+    if not record or not record.get("refresh_token") or record.get("needs_reauth"):
+        return None
+    if not force_refresh and _is_fresh(record):
+        return _credentials_from(record)
+
+    async with _get_refresh_lock():
+        # Another coroutine may have refreshed while we waited.
+        record = _load(_auth_path())
+        if not record or not record.get("refresh_token") or record.get("needs_reauth"):
+            return None
+        if not force_refresh and _is_fresh(record):
+            return _credentials_from(record)
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            # JSON body, not form-encoded — matches codex-rs exactly.
+            resp = await client.post(
+                TOKEN_URL,
+                json={
+                    "client_id": CLIENT_ID,
+                    "grant_type": "refresh_token",
+                    "refresh_token": record["refresh_token"],
+                },
+            )
+        if resp.status_code >= 400:
+            detail = ""
+            try:
+                detail = (resp.json() or {}).get("error") or ""
+            except (json.JSONDecodeError, ValueError):
+                detail = resp.text[:100]
+            if resp.status_code in (400, 401, 403) and (
+                not detail or any(code in str(detail) for code in _REAUTH_ERROR_CODES)
+            ):
+                logger.warning(
+                    "ChatGPT token refresh requires re-auth (%s %s)",
+                    resp.status_code,
+                    detail,
+                )
+                record["needs_reauth"] = True
+                _write_private(_auth_path(), record)
+            else:
+                logger.warning(
+                    "ChatGPT token refresh failed transiently (%s %s)",
+                    resp.status_code,
+                    detail,
+                )
+            return None
+
+        _persist_tokens(resp.json(), existing=record)
+        refreshed = _load(_auth_path()) or {}
+        return _credentials_from(refreshed)

--- a/app/services/chatgpt_auth.py
+++ b/app/services/chatgpt_auth.py
@@ -71,8 +71,11 @@ class DeviceLoginError(RuntimeError):
     """The device-auth flow could not be started or completed."""
 
 
-# Serialized refresh: the lock is loop-bound, so tests reset it per loop.
+# Serialized refresh + serialized device-poll exchange. Locks are loop-bound,
+# so tests reset them per loop. These serialize WITHIN a process; cross-worker
+# safety comes from re-reading the shared store before every write.
 _refresh_lock: asyncio.Lock | None = None
+_poll_lock: asyncio.Lock | None = None
 
 
 def _get_refresh_lock() -> asyncio.Lock:
@@ -82,10 +85,18 @@ def _get_refresh_lock() -> asyncio.Lock:
     return _refresh_lock
 
 
+def _get_poll_lock() -> asyncio.Lock:
+    global _poll_lock
+    if _poll_lock is None:
+        _poll_lock = asyncio.Lock()
+    return _poll_lock
+
+
 def _reset_state() -> None:
-    """Test hook: drop the loop-bound lock between event loops."""
-    global _refresh_lock
+    """Test hook: drop the loop-bound locks between event loops."""
+    global _refresh_lock, _poll_lock
     _refresh_lock = None
+    _poll_lock = None
 
 
 def _auth_path() -> Path:
@@ -210,45 +221,81 @@ async def start_device_login() -> dict:
     }
 
 
-async def poll_device_login() -> dict:
-    """One poll attempt; the caller (admin UI) repeats until terminal."""
-    pending = _load(_pending_path())
-    if not pending:
-        return {"status": "idle"}
-    if time.time() - float(pending.get("started_at") or 0) > _DEVICE_FLOW_TTL_SECONDS:
-        _pending_path().unlink(missing_ok=True)
-        return {"status": "expired", "detail": "The device code expired; start again."}
+def _pending_response(pending: dict) -> dict:
+    return {
+        "status": "pending",
+        "user_code": pending["user_code"],
+        "verification_url": VERIFICATION_URL,
+    }
 
-    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
-        resp = await client.post(
-            f"{AUTH_BASE}/api/accounts/deviceauth/token",
-            json={
-                "device_auth_id": pending["device_auth_id"],
-                "user_code": pending["user_code"],
-            },
-        )
-        # 403/404 mean "not approved yet" in this (non-RFC-8628) flow.
-        if resp.status_code in (403, 404):
-            return {
-                "status": "pending",
-                "user_code": pending["user_code"],
-                "verification_url": VERIFICATION_URL,
-            }
-        if resp.status_code >= 400:
+
+async def poll_device_login() -> dict:
+    """One poll attempt; the caller (admin UI) repeats until terminal.
+
+    Serialized in-process so two admin tabs can't both exchange the
+    single-use authorization code; across workers the exchange is guarded by
+    an atomic claim-rename of the pending file.
+    """
+    async with _get_poll_lock():
+        pending = _load(_pending_path())
+        if not pending:
+            return {"status": "idle"}
+        if (
+            time.time() - float(pending.get("started_at") or 0)
+            > _DEVICE_FLOW_TTL_SECONDS
+        ):
             _pending_path().unlink(missing_ok=True)
             return {
-                "status": "error",
-                "detail": f"Device sign-in failed (HTTP {resp.status_code}).",
+                "status": "expired",
+                "detail": "The device code expired; start again.",
             }
-        approval = resp.json()
-        token_resp = await _exchange_code(
-            client,
-            approval.get("authorization_code") or "",
-            approval.get("code_verifier") or "",
-        )
+
+        async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+            resp = await client.post(
+                f"{AUTH_BASE}/api/accounts/deviceauth/token",
+                json={
+                    "device_auth_id": pending["device_auth_id"],
+                    "user_code": pending["user_code"],
+                },
+            )
+            # 403/404 mean "not approved yet" in this (non-RFC-8628) flow.
+            if resp.status_code in (403, 404):
+                return _pending_response(pending)
+            # 429 / 5xx are transient — keep polling rather than killing the
+            # flow on a single blip.
+            if resp.status_code == 429 or resp.status_code >= 500:
+                logger.info(
+                    "ChatGPT device poll transient error %s; still pending",
+                    resp.status_code,
+                )
+                return _pending_response(pending)
+            if resp.status_code >= 400:
+                _pending_path().unlink(missing_ok=True)
+                return {
+                    "status": "error",
+                    "detail": f"Device sign-in failed (HTTP {resp.status_code}).",
+                }
+            approval = resp.json()
+
+            # Claim the pending flow atomically before exchanging: whoever
+            # wins the rename does the single-use code exchange; a racing
+            # worker finds no pending file and reports still-pending.
+            claim = _pending_path().with_name(f"{_PENDING_FILENAME}.claimed")
+            try:
+                os.replace(_pending_path(), claim)
+            except FileNotFoundError:
+                return _pending_response(pending)
+
+            try:
+                token_resp = await _exchange_code(
+                    client,
+                    approval.get("authorization_code") or "",
+                    approval.get("code_verifier") or "",
+                )
+            finally:
+                claim.unlink(missing_ok=True)
 
     _persist_tokens(token_resp)
-    _pending_path().unlink(missing_ok=True)
     record = _load(_auth_path()) or {}
     logger.info("ChatGPT sign-in completed (account %s)", record.get("account_id"))
     return {"status": "connected", "account_id": record.get("account_id")}
@@ -315,15 +362,22 @@ async def get_access_credentials(
         return None
     if not force_refresh and _is_fresh(record):
         return _credentials_from(record)
+    # The token the caller's 401 was on; used to detect a concurrent refresh.
+    seen_access = record.get("access_token")
 
     async with _get_refresh_lock():
-        # Another coroutine may have refreshed while we waited.
+        # Another coroutine (or worker) may have refreshed while we waited.
         record = _load(_auth_path())
         if not record or not record.get("refresh_token") or record.get("needs_reauth"):
             return None
-        if not force_refresh and _is_fresh(record):
+        if _is_fresh(record) and (
+            not force_refresh or record.get("access_token") != seen_access
+        ):
+            # Fresh AND (not forced, or someone rotated since our 401) — use it
+            # instead of burning another single-use refresh token.
             return _credentials_from(record)
 
+        attempted_rt = record["refresh_token"]
         async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
             # JSON body, not form-encoded — matches codex-rs exactly.
             resp = await client.post(
@@ -331,7 +385,7 @@ async def get_access_credentials(
                 json={
                     "client_id": CLIENT_ID,
                     "grant_type": "refresh_token",
-                    "refresh_token": record["refresh_token"],
+                    "refresh_token": attempted_rt,
                 },
             )
         if resp.status_code >= 400:
@@ -340,16 +394,30 @@ async def get_access_credentials(
                 detail = (resp.json() or {}).get("error") or ""
             except (json.JSONDecodeError, ValueError):
                 detail = resp.text[:100]
-            if resp.status_code in (400, 401, 403) and (
-                not detail or any(code in str(detail) for code in _REAUTH_ERROR_CODES)
-            ):
+            # Only an EXPLICIT dead-token code means re-auth. An empty or
+            # error-less 4xx (a WAF/CDN/LB blip) is transient — do not brick
+            # a valid credential over it.
+            dead_token = resp.status_code in (400, 401, 403) and any(
+                code in str(detail) for code in _REAUTH_ERROR_CODES
+            )
+            if dead_token:
+                # Re-read before writing: another worker may have rotated this
+                # credential (making OUR attempt fail with a stale token) or
+                # the admin may have signed out mid-flight. Either way, don't
+                # clobber the shared store with our stale record.
+                current = _load(_auth_path())
+                if not current or current.get("refresh_token") != attempted_rt:
+                    logger.info(
+                        "ChatGPT refresh lost a rotation race; using current store"
+                    )
+                    return _credentials_from(current) if current else None
                 logger.warning(
                     "ChatGPT token refresh requires re-auth (%s %s)",
                     resp.status_code,
                     detail,
                 )
-                record["needs_reauth"] = True
-                _write_private(_auth_path(), record)
+                current["needs_reauth"] = True
+                _write_private(_auth_path(), current)
             else:
                 logger.warning(
                     "ChatGPT token refresh failed transiently (%s %s)",
@@ -358,6 +426,12 @@ async def get_access_credentials(
                 )
             return None
 
-        _persist_tokens(resp.json(), existing=record)
+        # Re-read before persisting: if the admin cleared the store during the
+        # network round-trip, don't resurrect it.
+        current = _load(_auth_path())
+        if not current or current.get("refresh_token") != attempted_rt:
+            logger.info("ChatGPT store changed during refresh; not overwriting")
+            return _credentials_from(current) if current else None
+        _persist_tokens(resp.json(), existing=current)
         refreshed = _load(_auth_path()) or {}
         return _credentials_from(refreshed)

--- a/app/services/codex_instructions.py
+++ b/app/services/codex_instructions.py
@@ -1,0 +1,83 @@
+"""Codex CLI's base prompt, vendored verbatim (do not edit by hand).
+
+The ChatGPT-plan Codex backend validates the ``instructions`` field of every
+request and rejects arbitrary text ("Instructions are not valid"), so the
+chatgpt rank provider sends Codex's own base prompt here and injects
+NullFeed's actual prompt as a user input item instead — the same approach
+the opencode and Hermes agents use.
+
+Source: https://github.com/openai/codex (Apache-2.0),
+codex-rs/core/gpt_5_codex_prompt.md @ main, fetched 2026-07-11.
+Re-vendor if the default chatgpt rank model moves to a new family.
+"""
+
+CODEX_BASE_INSTRUCTIONS = """\
+You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.
+
+## General
+
+- When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
+
+## Editing constraints
+
+- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
+- Add succinct code comments that explain what is going on if code is not self-explanatory. You should not add comments like "Assigns the value to the variable", but a brief comment might be useful ahead of a complex code block that the user would otherwise have to spend time parsing out. Usage of these comments should be rare.
+- Try to use apply_patch for single file edits, but it is fine to explore other options to make the edit if it does not work well. Do not use apply_patch for changes that are auto-generated (i.e. generating package.json or running a lint or format command like gofmt) or when scripting is more efficient (such as search and replacing a string across a codebase).
+- You may be in a dirty git worktree.
+    * NEVER revert existing changes you did not make unless explicitly requested, since these changes were made by the user.
+    * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.
+    * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
+    * If the changes are in unrelated files, just ignore them and don't revert them.
+- Do not amend a commit unless explicitly requested to do so.
+- While you are working, you might notice unexpected changes that you didn't make. If this happens, STOP IMMEDIATELY and ask the user how they would like to proceed.
+- **NEVER** use destructive commands like `git reset --hard` or `git checkout --` unless specifically requested or approved by the user.
+
+## Plan tool
+
+When using the planning tool:
+- Skip using the planning tool for straightforward tasks (roughly the easiest 25%).
+- Do not make single-step plans.
+- When you made a plan, update it after having performed one of the sub-tasks that you shared on the plan.
+
+## Special user requests
+
+- If the user makes a simple request (such as asking for the time) which you can fulfill by running a terminal command (such as `date`), you should do so.
+- If the user asks for a "review", default to a code review mindset: prioritise identifying bugs, risks, behavioural regressions, and missing tests. Findings must be the primary focus of the response - keep summaries or overviews brief and only after enumerating the issues. Present findings first (ordered by severity with file/line references), follow with open questions or assumptions, and offer a change-summary only as a secondary detail. If no findings are discovered, state that explicitly and mention any residual risks or testing gaps.
+
+## Presenting your work and final message
+
+You are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.
+
+- Default: be very concise; friendly coding teammate tone.
+- Ask only when needed; suggest ideas; mirror the user's style.
+- For substantial work, summarize clearly; follow final‑answer formatting.
+- Skip heavy formatting for simple confirmations.
+- Don't dump large files you've written; reference paths only.
+- No "save/copy this file" - User is on the same machine.
+- Offer logical next steps (tests, commits, build) briefly; add verify steps if you couldn't do something.
+- For code changes:
+  * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
+  * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
+  * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
+- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+
+### Final answer structure and style guidelines
+
+- Plain text; CLI handles styling. Use structure only when it helps scanability.
+- Headers: optional; short Title Case (1-3 words) wrapped in **…**; no blank line before the first bullet; add only if they truly help.
+- Bullets: use - ; merge related points; keep to one line when possible; 4–6 per list ordered by importance; keep phrasing consistent.
+- Monospace: backticks for commands/paths/env vars/code ids and inline examples; use for literal keyword bullets; never combine with **.
+- Code samples or multi-line snippets should be wrapped in fenced code blocks; include an info string as often as possible.
+- Structure: group related bullets; order sections general → specific → supporting; for subsections, start with a bolded keyword bullet, then items; match complexity to the task.
+- Tone: collaborative, concise, factual; present tense, active voice; self‑contained; no "above/below"; parallel wording.
+- Don'ts: no nested bullets/hierarchies; no ANSI codes; don't cram unrelated keywords; keep keyword lists short—wrap/reformat if long; avoid naming formatting styles in answers.
+- Adaptation: code explanations → precise, structured with code refs; simple tasks → lead with outcome; big changes → logical walkthrough + rationale + next actions; casual one-offs → plain sentences, no headers/bullets.
+- File References: When referencing files in your response, make sure to include the relevant start line and always follow the below rules:
+  * Use inline code to make file paths clickable.
+  * Each reference should have a stand alone path. Even if it's the same file.
+  * Accepted: absolute, workspace‑relative, a/ or b/ diff prefixes, or bare filename/suffix.
+  * Line/column (1‑based, optional): :line[:column] or #Lline[Ccolumn] (column defaults to 1).
+  * Do not use URIs like file://, vscode://, or https://.
+  * Do not provide range of lines
+  * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\\repo\\project\\main.rs:12:5
+"""

--- a/app/services/llm_providers.py
+++ b/app/services/llm_providers.py
@@ -16,6 +16,7 @@ Every network call lives behind a small module-level function so tests can
 monkeypatch the seam instead of mocking SDKs or HTTP.
 """
 
+import asyncio
 import json
 import logging
 
@@ -259,7 +260,16 @@ async def _complete_chatgpt(prompt: str, model: str) -> str:
         creds = await chatgpt_auth.get_access_credentials(force_refresh=True)
         if not creds:
             raise RuntimeError("chatgpt provider re-auth required") from None
-        return await _codex_responses(creds, prompt, model)
+        try:
+            return await _codex_responses(creds, prompt, model)
+        except _CodexUnauthorized:
+            # A freshly refreshed token still 401s — the Codex backend is
+            # rejecting the account (e.g. Codex access revoked), not a stale
+            # token. Surface a real message instead of the bare sentinel.
+            raise RuntimeError(
+                "Codex backend rejected a freshly refreshed token (401); "
+                "the ChatGPT account may lack Codex access"
+            ) from None
 
 
 async def _codex_responses(creds: tuple[str, str], prompt: str, model: str) -> str:
@@ -298,36 +308,54 @@ async def _codex_responses(creds: tuple[str, str], prompt: str, model: str) -> s
         "accept": "text/event-stream",
     }
     parts: list[str] = []
-    async with httpx.AsyncClient(timeout=_CHATGPT_TIMEOUT) as client:
-        async with client.stream(
-            "POST", _CHATGPT_RESPONSES_URL, headers=headers, json=payload
-        ) as resp:
-            if resp.status_code == 401:
-                raise _CodexUnauthorized()
-            if resp.status_code >= 400:
-                body = (await resp.aread()).decode("utf-8", "replace")[:300]
-                raise RuntimeError(f"Codex backend {resp.status_code}: {body}")
-            async for line in resp.aiter_lines():
-                if not line.startswith("data:"):
-                    continue
-                data = line[5:].strip()
-                if data == "[DONE]":
-                    break
-                try:
-                    event = json.loads(data)
-                except json.JSONDecodeError:
-                    continue
-                event_type = event.get("type")
-                if event_type == "response.output_text.delta":
-                    delta = event.get("delta")
-                    if isinstance(delta, str):
-                        parts.append(delta)
-                elif event_type in ("response.completed", "response.done"):
-                    break
-                elif event_type == "response.failed":
-                    error = (event.get("response") or {}).get("error") or {}
-                    raise RuntimeError(
-                        "Codex response failed: "
-                        f"{error.get('code')} {error.get('message')}"
-                    )
+    done = False
+    # httpx's scalar timeout is per-read (it resets on every chunk / SSE
+    # keep-alive comment), so a wedged-but-alive stream could hang forever
+    # while holding the per-user discovery lock. Bound the whole exchange.
+    async with asyncio.timeout(_CHATGPT_TIMEOUT):
+        async with httpx.AsyncClient(timeout=_CHATGPT_TIMEOUT) as client:
+            async with client.stream(
+                "POST", _CHATGPT_RESPONSES_URL, headers=headers, json=payload
+            ) as resp:
+                if resp.status_code == 401:
+                    raise _CodexUnauthorized()
+                if resp.status_code >= 400:
+                    body = (await resp.aread()).decode("utf-8", "replace")[:300]
+                    raise RuntimeError(f"Codex backend {resp.status_code}: {body}")
+                async for line in resp.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == "[DONE]":
+                        done = True
+                        break
+                    try:
+                        event = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+                    event_type = event.get("type")
+                    if event_type == "response.output_text.delta":
+                        delta = event.get("delta")
+                        if isinstance(delta, str):
+                            parts.append(delta)
+                    elif event_type in ("response.completed", "response.done"):
+                        done = True
+                        break
+                    elif event_type in ("response.failed", "error"):
+                        error = (event.get("response") or {}).get("error") or event
+                        raise RuntimeError(
+                            "Codex response failed: "
+                            f"{error.get('code')} {error.get('message')}"
+                        )
+                    elif event_type == "response.incomplete":
+                        reason = (event.get("response") or {}).get(
+                            "incomplete_details"
+                        ) or {}
+                        raise RuntimeError(
+                            f"Codex response incomplete: {reason.get('reason')}"
+                        )
+    if not done:
+        # Stream ended with no terminal event — don't pass a truncated answer
+        # off as complete.
+        raise RuntimeError("Codex stream ended without a completion event")
     return "".join(parts)

--- a/app/services/llm_providers.py
+++ b/app/services/llm_providers.py
@@ -1,21 +1,28 @@
 """Provider seams for the discovery pipeline (embeddings + ranking).
 
 Two providers can supply embeddings (gemini, openai — Anthropic has no
-embeddings API) and three can supply the ranking LLM (anthropic, gemini,
-openai); the two choices are independent and mix-and-match freely. Gemini
-and OpenAI are called over plain REST via httpx so the base image needs no
-extra SDKs; Anthropic reuses the already-installed ``anthropic`` package
-(imported lazily, like the other consumers).
+embeddings API) and four can supply the ranking LLM (anthropic, gemini,
+openai, chatgpt); the two choices are independent and mix-and-match freely.
+Gemini and OpenAI are called over plain REST via httpx so the base image
+needs no extra SDKs; Anthropic reuses the already-installed ``anthropic``
+package (imported lazily, like the other consumers).
+
+The ``chatgpt`` rank provider is special: instead of an API key it uses a
+ChatGPT Plus/Pro subscription via the Codex OAuth sign-in (see
+``app/services/chatgpt_auth``) and calls the ChatGPT Codex backend — an
+unofficial, best-effort surface that shares the plan's Codex usage limits.
 
 Every network call lives behind a small module-level function so tests can
 monkeypatch the seam instead of mocking SDKs or HTTP.
 """
 
+import json
 import logging
 
 import httpx
 
 from app.config import settings
+from app.services import chatgpt_auth
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +36,16 @@ RANK_MODELS = {
     "anthropic": "claude-haiku-4-5",
     "gemini": "gemini-3.5-flash",
     "openai": "gpt-5.6-luna",
+    # ChatGPT-subscription (Codex OAuth) — models the Codex backend accepts,
+    # not api.openai.com ids.
+    "chatgpt": "gpt-5.1-codex",
 }
 
-# Auto-detect order when no provider is configured explicitly.
+# Auto-detect order when no provider is configured explicitly. chatgpt is
+# last: a completed sign-in is deliberate, but metered API keys are the more
+# predictable default when both are present.
 _EMBED_ORDER = ("gemini", "openai")
-_RANK_ORDER = ("anthropic", "gemini", "openai")
+_RANK_ORDER = ("anthropic", "gemini", "openai", "chatgpt")
 
 _TIMEOUT = 60.0
 # Roomy for 10 picks with reasons, plus headroom for override models that
@@ -44,9 +56,17 @@ _GEMINI_EMBED_BATCH = 100
 
 _GEMINI_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
 _OPENAI_BASE = "https://api.openai.com/v1"
+# The ChatGPT-plan Codex backend. OAuth tokens do NOT work against
+# api.openai.com — the subscription path is only this endpoint.
+_CHATGPT_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
+# Streaming with reasoning can take a while; more generous than _TIMEOUT.
+_CHATGPT_TIMEOUT = 120.0
 
 
 def _provider_key(provider: str) -> str:
+    if provider == "chatgpt":
+        # No API key: "configured" means a completed ChatGPT sign-in.
+        return "oauth" if chatgpt_auth.has_auth() else ""
     return {
         "anthropic": settings.anthropic_api_key,
         "gemini": settings.gemini_api_key,
@@ -137,6 +157,8 @@ async def rank_complete(prompt: str) -> str:
         return await _complete_anthropic(prompt, model)
     if provider == "gemini":
         return await _complete_gemini(prompt, model)
+    if provider == "chatgpt":
+        return await _complete_chatgpt(prompt, model)
     return await _complete_openai(prompt, model)
 
 
@@ -221,3 +243,91 @@ async def _complete_openai(prompt: str, model: str) -> str:
         resp.raise_for_status()
         data = resp.json()
     return data["choices"][0]["message"]["content"]
+
+
+class _CodexUnauthorized(RuntimeError):
+    """401 from the Codex backend — refresh once and retry."""
+
+
+async def _complete_chatgpt(prompt: str, model: str) -> str:
+    creds = await chatgpt_auth.get_access_credentials()
+    if not creds:
+        raise RuntimeError("chatgpt provider is not signed in (or needs re-auth)")
+    try:
+        return await _codex_responses(creds, prompt, model)
+    except _CodexUnauthorized:
+        creds = await chatgpt_auth.get_access_credentials(force_refresh=True)
+        if not creds:
+            raise RuntimeError("chatgpt provider re-auth required") from None
+        return await _codex_responses(creds, prompt, model)
+
+
+async def _codex_responses(creds: tuple[str, str], prompt: str, model: str) -> str:
+    """One streamed call to the ChatGPT Codex backend; returns final text.
+
+    The backend hard-requires ``store: false`` + ``stream: true`` and
+    VALIDATES ``instructions`` — arbitrary text is rejected, so we send
+    Codex's own base prompt and carry our real prompt as the user message
+    (the same approach opencode and Hermes use).
+    """
+    from app.services.codex_instructions import CODEX_BASE_INSTRUCTIONS
+
+    access_token, account_id = creds
+    payload = {
+        "model": model,
+        "instructions": CODEX_BASE_INSTRUCTIONS,
+        "input": [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": prompt}],
+            }
+        ],
+        "store": False,
+        "stream": True,
+        "include": ["reasoning.encrypted_content"],
+        # Ranking is easy; keep reasoning cheap so Discover barely dents the
+        # plan's Codex quota. Codex models reject "none", so "low" it is.
+        "reasoning": {"effort": "low", "summary": "auto"},
+    }
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "chatgpt-account-id": account_id,
+        "OpenAI-Beta": "responses=experimental",
+        "originator": "codex_cli_rs",
+        "accept": "text/event-stream",
+    }
+    parts: list[str] = []
+    async with httpx.AsyncClient(timeout=_CHATGPT_TIMEOUT) as client:
+        async with client.stream(
+            "POST", _CHATGPT_RESPONSES_URL, headers=headers, json=payload
+        ) as resp:
+            if resp.status_code == 401:
+                raise _CodexUnauthorized()
+            if resp.status_code >= 400:
+                body = (await resp.aread()).decode("utf-8", "replace")[:300]
+                raise RuntimeError(f"Codex backend {resp.status_code}: {body}")
+            async for line in resp.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+                try:
+                    event = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                event_type = event.get("type")
+                if event_type == "response.output_text.delta":
+                    delta = event.get("delta")
+                    if isinstance(delta, str):
+                        parts.append(delta)
+                elif event_type in ("response.completed", "response.done"):
+                    break
+                elif event_type == "response.failed":
+                    error = (event.get("response") or {}).get("error") or {}
+                    raise RuntimeError(
+                        "Codex response failed: "
+                        f"{error.get('code')} {error.get('message')}"
+                    )
+    return "".join(parts)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from httpx import ASGITransport, AsyncClient
 
 import app.api.auth as auth_api
 import app.api.websocket as websocket_api
+import app.services.chatgpt_auth as chatgpt_auth
 import app.services.discovery as discovery_service
 import app.services.instant_stream as instant_stream
 import app.services.push_gateway as push_gateway
@@ -44,6 +45,8 @@ def _reset_in_memory_state():
     # Locks are bound to the event loop that created them; each test gets a
     # fresh loop, so a leaked lock would raise 'attached to a different loop'.
     discovery_service._generation_locks.clear()
+    chatgpt_auth._reset_state()
+    chatgpt_auth.clear_auth()
     youtube_import._resolve_cache.clear()
     youtube_import._suggestions_cache.clear()
     instant_stream._resolve_cache.clear()

--- a/tests/test_chatgpt_auth.py
+++ b/tests/test_chatgpt_auth.py
@@ -1,0 +1,440 @@
+"""ChatGPT (Codex OAuth) sign-in + the chatgpt rank provider."""
+
+import base64
+import json
+import stat
+import time
+
+import httpx
+import pytest
+
+import app.services.chatgpt_auth as chatgpt_auth
+import app.services.llm_providers as llm_providers
+from app.config import settings
+
+pytestmark = pytest.mark.asyncio
+
+
+def _jwt(claims: dict) -> str:
+    """Unsigned JWT-shaped token: header.payload.signature."""
+
+    def seg(data: dict) -> str:
+        raw = base64.urlsafe_b64encode(json.dumps(data).encode()).decode()
+        return raw.rstrip("=")
+
+    return f"{seg({'alg': 'none'})}.{seg(claims)}.sig"
+
+
+def _access_token(expires_in: float = 3600, account_id: str = "acct-123") -> str:
+    return _jwt(
+        {
+            "exp": time.time() + expires_in,
+            "https://api.openai.com/auth": {"chatgpt_account_id": account_id},
+        }
+    )
+
+
+def _seed_auth(expires_in: float = 3600, refresh_token: str = "rt-1") -> None:
+    chatgpt_auth._persist_tokens(
+        {
+            "access_token": _access_token(expires_in),
+            "refresh_token": refresh_token,
+            "id_token": _jwt({}),
+        }
+    )
+
+
+def _mock_http(monkeypatch, module, handler):
+    real_client = httpx.AsyncClient
+
+    def factory(*_args, **_kwargs):
+        return real_client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", factory)
+
+
+def _set_no_keys(monkeypatch):
+    monkeypatch.setattr(settings, "anthropic_api_key", "")
+    monkeypatch.setattr(settings, "gemini_api_key", "")
+    monkeypatch.setattr(settings, "openai_api_key", "")
+    monkeypatch.setattr(settings, "discovery_embed_provider", "")
+    monkeypatch.setattr(settings, "discovery_rank_provider", "")
+    monkeypatch.setattr(settings, "discovery_embed_model", "")
+    monkeypatch.setattr(settings, "discovery_rank_model", "")
+
+
+# --- device flow -------------------------------------------------------------
+
+
+async def test_device_flow_end_to_end(monkeypatch):
+    polls = {"n": 0}
+
+    def handler(request):
+        url = str(request.url)
+        if url.endswith("/api/accounts/deviceauth/usercode"):
+            assert json.loads(request.content) == {"client_id": chatgpt_auth.CLIENT_ID}
+            return httpx.Response(
+                200,
+                json={
+                    "device_auth_id": "dev-1",
+                    "usercode": "ABCD-1234",  # serde alias form
+                    "interval": 3,
+                },
+            )
+        if url.endswith("/api/accounts/deviceauth/token"):
+            polls["n"] += 1
+            if polls["n"] == 1:
+                return httpx.Response(403)  # not approved yet
+            return httpx.Response(
+                200,
+                json={"authorization_code": "code-1", "code_verifier": "ver-1"},
+            )
+        if url.endswith("/oauth/token"):
+            body = dict(
+                pair.split("=", 1)
+                for pair in request.content.decode().split("&")
+                if "=" in pair
+            )
+            assert body["grant_type"] == "authorization_code"
+            assert body["code"] == "code-1"
+            assert body["code_verifier"] == "ver-1"
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": _access_token(),
+                    "refresh_token": "rt-fresh",
+                    "id_token": _jwt({}),
+                },
+            )
+        raise AssertionError(f"unexpected URL {url}")
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+
+    started = await chatgpt_auth.start_device_login()
+    assert started["user_code"] == "ABCD-1234"
+    assert started["verification_url"].endswith("/codex/device")
+    assert chatgpt_auth.auth_status()["pending"] is True
+
+    first = await chatgpt_auth.poll_device_login()
+    assert first["status"] == "pending"
+
+    second = await chatgpt_auth.poll_device_login()
+    assert second["status"] == "connected"
+    assert second["account_id"] == "acct-123"
+
+    status = chatgpt_auth.auth_status()
+    assert status["connected"] is True
+    assert status["pending"] is False
+    assert chatgpt_auth.has_auth() is True
+
+    mode = stat.S_IMODE(chatgpt_auth._auth_path().stat().st_mode)
+    assert mode == 0o600
+
+
+async def test_start_device_login_surfaces_disabled_device_auth(monkeypatch):
+    def handler(request):
+        return httpx.Response(403, json={"error": "forbidden"})
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+    with pytest.raises(chatgpt_auth.DeviceLoginError) as excinfo:
+        await chatgpt_auth.start_device_login()
+    assert "enable it in ChatGPT Settings" in str(excinfo.value)
+
+
+async def test_poll_without_pending_flow_is_idle():
+    assert (await chatgpt_auth.poll_device_login()) == {"status": "idle"}
+
+
+# --- refresh -----------------------------------------------------------------
+
+
+async def test_refresh_rotates_token_when_expired(monkeypatch):
+    _seed_auth(expires_in=-10, refresh_token="rt-old")
+    calls = {"n": 0}
+
+    def handler(request):
+        assert str(request.url).endswith("/oauth/token")
+        body = json.loads(request.content)  # JSON body, matching codex-rs
+        assert body == {
+            "client_id": chatgpt_auth.CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": "rt-old",
+        }
+        calls["n"] += 1
+        return httpx.Response(
+            200,
+            json={
+                "access_token": _access_token(account_id="acct-123"),
+                "refresh_token": "rt-rotated",
+            },
+        )
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+    creds = await chatgpt_auth.get_access_credentials()
+    assert creds is not None
+    _token, account_id = creds
+    assert account_id == "acct-123"
+    assert calls["n"] == 1
+
+    # The rotated (single-use) refresh token must be persisted.
+    record = chatgpt_auth._load(chatgpt_auth._auth_path())
+    assert record["refresh_token"] == "rt-rotated"
+
+    # A fresh token skips the network entirely.
+    creds = await chatgpt_auth.get_access_credentials()
+    assert creds is not None
+    assert calls["n"] == 1
+
+
+async def test_refresh_invalid_grant_marks_needs_reauth(monkeypatch):
+    _seed_auth(expires_in=-10)
+
+    def handler(request):
+        return httpx.Response(400, json={"error": "invalid_grant"})
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+    assert (await chatgpt_auth.get_access_credentials()) is None
+    status = chatgpt_auth.auth_status()
+    assert status["needs_reauth"] is True
+    # A broken credential no longer counts as a configured provider.
+    assert chatgpt_auth.has_auth() is False
+
+
+async def test_transient_refresh_failure_does_not_require_reauth(monkeypatch):
+    _seed_auth(expires_in=-10)
+
+    def handler(request):
+        return httpx.Response(500)
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+    assert (await chatgpt_auth.get_access_credentials()) is None
+    assert chatgpt_auth.auth_status()["needs_reauth"] is False
+    assert chatgpt_auth.has_auth() is True
+
+
+# --- provider resolution -----------------------------------------------------
+
+
+async def test_chatgpt_resolves_last_in_auto_order(monkeypatch):
+    _set_no_keys(monkeypatch)
+    assert llm_providers.resolve_rank_provider() is None
+
+    _seed_auth()
+    assert llm_providers.resolve_rank_provider() == ("chatgpt", "gpt-5.1-codex")
+    # Embeddings can never come from the ChatGPT surface.
+    assert llm_providers.resolve_embed_provider() is None
+
+    # A metered key outranks the subscription in auto mode.
+    monkeypatch.setattr(settings, "anthropic_api_key", "a-x")
+    assert llm_providers.resolve_rank_provider() == ("anthropic", "claude-haiku-4-5")
+
+    # ...but an explicit selection pins it.
+    monkeypatch.setattr(settings, "discovery_rank_provider", "chatgpt")
+    assert llm_providers.resolve_rank_provider() == ("chatgpt", "gpt-5.1-codex")
+
+    # Explicit chatgpt for EMBEDDINGS is invalid.
+    monkeypatch.setattr(settings, "discovery_embed_provider", "chatgpt")
+    assert llm_providers.resolve_embed_provider() is None
+
+
+# --- the completion call -----------------------------------------------------
+
+
+def _sse(events: list[dict | str]) -> bytes:
+    lines = []
+    for event in events:
+        data = event if isinstance(event, str) else json.dumps(event)
+        lines.append(f"data: {data}\n\n")
+    return "".join(lines).encode()
+
+
+async def test_complete_chatgpt_accumulates_deltas(monkeypatch):
+    _seed_auth()
+    seen = {}
+
+    def handler(request):
+        seen["url"] = str(request.url)
+        seen["headers"] = dict(request.headers)
+        seen["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            content=_sse(
+                [
+                    {"type": "response.created"},
+                    {"type": "response.output_text.delta", "delta": '["a"'},
+                    {"type": "response.reasoning_text.delta", "delta": "hmm"},
+                    {"type": "response.output_text.delta", "delta": ", 2]"},
+                    {"type": "response.completed", "response": {"id": "r1"}},
+                    "[DONE]",
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _mock_http(monkeypatch, llm_providers, handler)
+    text = await llm_providers._complete_chatgpt("rank these", "gpt-5.1-codex")
+    assert text == '["a", 2]'
+
+    assert seen["url"] == "https://chatgpt.com/backend-api/codex/responses"
+    assert seen["headers"]["chatgpt-account-id"] == "acct-123"
+    assert seen["headers"]["originator"] == "codex_cli_rs"
+    assert seen["headers"]["openai-beta"] == "responses=experimental"
+
+    payload = seen["payload"]
+    assert payload["store"] is False
+    assert payload["stream"] is True
+    assert payload["model"] == "gpt-5.1-codex"
+    # The validated instructions are Codex's own base prompt; ours rides as
+    # the user input item.
+    assert payload["instructions"].startswith("You are Codex")
+    assert payload["input"][0]["content"][0]["text"] == "rank these"
+
+
+async def test_complete_chatgpt_retries_once_after_401(monkeypatch):
+    _seed_auth(refresh_token="rt-old")
+    calls = {"responses": 0, "refresh": 0}
+
+    def handler(request):
+        url = str(request.url)
+        if url.endswith("/oauth/token"):
+            calls["refresh"] += 1
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": _access_token(),
+                    "refresh_token": "rt-new",
+                },
+            )
+        calls["responses"] += 1
+        if calls["responses"] == 1:
+            return httpx.Response(401)
+        return httpx.Response(
+            200,
+            content=_sse(
+                [
+                    {"type": "response.output_text.delta", "delta": "ok"},
+                    {"type": "response.done"},
+                    "[DONE]",
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    # Both modules share the global httpx module, so one patch covers the
+    # responses call AND the refresh call.
+    _mock_http(monkeypatch, llm_providers, handler)
+    text = await llm_providers._complete_chatgpt("prompt", "gpt-5.1-codex")
+    assert text == "ok"
+    assert calls == {"responses": 2, "refresh": 1}
+
+
+async def test_complete_chatgpt_surfaces_usage_limit(monkeypatch):
+    _seed_auth()
+
+    def handler(request):
+        return httpx.Response(
+            429,
+            json={"error": {"type": "usage_limit_reached", "resets_at": 1234}},
+        )
+
+    _mock_http(monkeypatch, llm_providers, handler)
+    with pytest.raises(RuntimeError) as excinfo:
+        await llm_providers._complete_chatgpt("prompt", "gpt-5.1-codex")
+    assert "429" in str(excinfo.value)
+    assert "usage_limit_reached" in str(excinfo.value)
+
+
+async def test_complete_chatgpt_response_failed_event(monkeypatch):
+    _seed_auth()
+
+    def handler(request):
+        return httpx.Response(
+            200,
+            content=_sse(
+                [
+                    {
+                        "type": "response.failed",
+                        "response": {
+                            "error": {"code": "usage_not_included", "message": "nope"}
+                        },
+                    },
+                ]
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _mock_http(monkeypatch, llm_providers, handler)
+    with pytest.raises(RuntimeError) as excinfo:
+        await llm_providers._complete_chatgpt("prompt", "gpt-5.1-codex")
+    assert "usage_not_included" in str(excinfo.value)
+
+
+# --- admin endpoints ---------------------------------------------------------
+
+
+async def test_chatgpt_login_endpoints_admin_flow(monkeypatch, client, make_user):
+    _, admin_headers = await make_user("Admin")
+    _, other_headers = await make_user("Someone")
+
+    # Non-admin is rejected everywhere.
+    for method, path in (
+        ("GET", "/api/settings/chatgpt-login"),
+        ("POST", "/api/settings/chatgpt-login"),
+        ("POST", "/api/settings/chatgpt-login/poll"),
+        ("DELETE", "/api/settings/chatgpt-login"),
+    ):
+        resp = await client.request(method, path, headers=other_headers)
+        assert resp.status_code == 403, (method, path, resp.text)
+
+    def handler(request):
+        url = str(request.url)
+        if url.endswith("/usercode"):
+            return httpx.Response(
+                200,
+                json={"device_auth_id": "dev-1", "user_code": "WXYZ-9876"},
+            )
+        if url.endswith("/deviceauth/token"):
+            return httpx.Response(
+                200,
+                json={"authorization_code": "c", "code_verifier": "v"},
+            )
+        return httpx.Response(
+            200,
+            json={"access_token": _access_token(), "refresh_token": "rt"},
+        )
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+
+    resp = await client.get("/api/settings/chatgpt-login", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["connected"] is False
+
+    resp = await client.post("/api/settings/chatgpt-login", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["user_code"] == "WXYZ-9876"
+
+    resp = await client.post("/api/settings/chatgpt-login/poll", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["status"] == "connected"
+
+    resp = await client.get("/api/settings/chatgpt-login", headers=admin_headers)
+    assert resp.json()["connected"] is True
+
+    resp = await client.delete("/api/settings/chatgpt-login", headers=admin_headers)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["connected"] is False
+    assert chatgpt_auth.has_auth() is False
+
+
+async def test_chatgpt_login_start_maps_device_error_to_502(
+    monkeypatch, client, make_user
+):
+    _, admin_headers = await make_user("Admin")
+
+    def handler(request):
+        return httpx.Response(403)
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+    resp = await client.post("/api/settings/chatgpt-login", headers=admin_headers)
+    assert resp.status_code == 502, resp.text
+    assert "enable it in ChatGPT Settings" in resp.json()["detail"]

--- a/tests/test_chatgpt_auth.py
+++ b/tests/test_chatgpt_auth.py
@@ -237,6 +237,69 @@ async def test_chatgpt_resolves_last_in_auto_order(monkeypatch):
     assert llm_providers.resolve_embed_provider() is None
 
 
+async def test_rank_complete_dispatches_to_chatgpt(monkeypatch):
+    """The resolution -> dispatch wiring, not just the two pieces alone."""
+    _set_no_keys(monkeypatch)
+    _seed_auth()
+    monkeypatch.setattr(settings, "discovery_rank_provider", "chatgpt")
+
+    captured = {}
+
+    async def fake_complete(prompt, model):
+        captured["prompt"] = prompt
+        captured["model"] = model
+        return "dispatched"
+
+    monkeypatch.setattr(llm_providers, "_complete_chatgpt", fake_complete)
+    result = await llm_providers.rank_complete("rank this")
+    assert result == "dispatched"
+    assert captured == {"prompt": "rank this", "model": "gpt-5.1-codex"}
+
+
+async def test_refresh_ignores_concurrent_rotation(monkeypatch):
+    """A refresh whose token was rotated by another worker mid-call must not
+    clobber the store with its stale record."""
+    _seed_auth(expires_in=-10, refresh_token="rt-old")
+
+    async def fake_post(*_args, **kwargs):
+        # Simulate a peer worker rotating the credential while our POST is in
+        # flight: the on-disk store now holds a fresh token under rt-new.
+        chatgpt_auth._persist_tokens(
+            {
+                "access_token": _access_token(),
+                "refresh_token": "rt-new",
+            }
+        )
+        return httpx.Response(400, json={"error": "invalid_grant"})
+
+    async def fake_aenter(self):
+        return self
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    monkeypatch.setattr(httpx.AsyncClient, "__aenter__", fake_aenter)
+
+    creds = await chatgpt_auth.get_access_credentials()
+    # We used the peer's fresh credentials instead of marking needs_reauth.
+    assert creds is not None
+    record = chatgpt_auth._load(chatgpt_auth._auth_path())
+    assert record["refresh_token"] == "rt-new"
+    assert record.get("needs_reauth") is not True
+    assert chatgpt_auth.has_auth() is True
+
+
+async def test_refresh_empty_body_is_transient_not_reauth(monkeypatch):
+    """A 403 with no error code (WAF/CDN blip) must NOT brick the sign-in."""
+    _seed_auth(expires_in=-10)
+
+    def handler(request):
+        return httpx.Response(403, text="")
+
+    _mock_http(monkeypatch, chatgpt_auth, handler)
+    assert (await chatgpt_auth.get_access_credentials()) is None
+    assert chatgpt_auth.auth_status()["needs_reauth"] is False
+    assert chatgpt_auth.has_auth() is True
+
+
 # --- the completion call -----------------------------------------------------
 
 
@@ -342,6 +405,41 @@ async def test_complete_chatgpt_surfaces_usage_limit(monkeypatch):
         await llm_providers._complete_chatgpt("prompt", "gpt-5.1-codex")
     assert "429" in str(excinfo.value)
     assert "usage_limit_reached" in str(excinfo.value)
+
+
+async def test_complete_chatgpt_stream_without_terminal_event(monkeypatch):
+    _seed_auth()
+
+    def handler(request):
+        # Deltas but no completed/done/[DONE] — a truncated stream.
+        return httpx.Response(
+            200,
+            content=_sse([{"type": "response.output_text.delta", "delta": "partial"}]),
+            headers={"content-type": "text/event-stream"},
+        )
+
+    _mock_http(monkeypatch, llm_providers, handler)
+    with pytest.raises(RuntimeError) as excinfo:
+        await llm_providers._complete_chatgpt("prompt", "gpt-5.1-codex")
+    assert "without a completion event" in str(excinfo.value)
+
+
+async def test_complete_chatgpt_persistent_401_raises_descriptive(monkeypatch):
+    _seed_auth(refresh_token="rt-old")
+
+    def handler(request):
+        if str(request.url).endswith("/oauth/token"):
+            return httpx.Response(
+                200,
+                json={"access_token": _access_token(), "refresh_token": "rt-new"},
+            )
+        return httpx.Response(401)  # both response calls 401
+
+    _mock_http(monkeypatch, llm_providers, handler)
+    with pytest.raises(RuntimeError) as excinfo:
+        await llm_providers._complete_chatgpt("prompt", "gpt-5.1-codex")
+    # A real message, not the empty bare-sentinel str.
+    assert "Codex" in str(excinfo.value) and str(excinfo.value)
 
 
 async def test_complete_chatgpt_response_failed_event(monkeypatch):


### PR DESCRIPTION
## Summary

Adds **`chatgpt`** as a fourth Discover rank provider: instead of an OpenAI API key, the reranker can run on a **ChatGPT Plus/Pro subscription** via the same device-code "sign in with ChatGPT" flow Codex CLI uses (and that opencode/Hermes ride). This is the "use what you already pay for" option — no metered API account needed for ranking.

Rank slot only: the ChatGPT/Codex surface has no embeddings, so the zero-extra-cost pairing is **Gemini free-tier embeddings + `chatgpt` ranking** (`NULLFEED_RANK_PROVIDER=chatgpt`).

## How it works
- **`app/services/chatgpt_auth.py`** — device-code sign-in (usercode → approval poll → PKCE code exchange), tokens persisted `0600` under `config_path` with atomic writes; single-use refresh-token rotation handled with a serialized refresh, and a re-auth-class error (`invalid_grant`/`refresh_token_*`) marks `needs_reauth` rather than deleting the store.
- **`app/services/llm_providers.py`** — `chatgpt` rank provider (default `gpt-5.1-codex`), streamed POST to `chatgpt.com/backend-api/codex/responses` with the mandatory `store:false` / `stream:true` / validated-`instructions` contract: Codex's own base prompt rides in `instructions` (vendored verbatim, Apache-2.0 attribution) and NullFeed's prompt is the user input item. SSE deltas accumulated; 401 → one refresh-and-retry.
- **`app/api/settings.py`** — admin-gated `GET/POST/DELETE /api/settings/chatgpt-login` + `POST .../poll`.

Every endpoint/header/body shape was corroborated against **openai/codex source** (`codex-rs/login`, `codex-rs/codex-api/src/sse/responses.rs`) plus two independent implementations before writing a line.

## Compatibility & safety
- Purely additive: existing anthropic/gemini/openai rank users are unchanged (`chatgpt` is auto-detected **last**, and in practice you pin it). Embeddings can never resolve to `chatgpt`.
- Any failure (signed out, re-auth needed, usage limit, backend error) degrades Discover to `[]` like every other provider — nothing else breaks.
- **Unofficial surface**, documented as such: OpenAI operates it for Codex clients and has tolerated third-party use, but it may change/gate, and Discover shares your plan's Codex usage limits. README spells this out.

## Hardening (second commit)
Adversarially reviewed (28-agent multi-dimension pass, 12 confirmed findings fixed). Highlights: a real **cross-worker token-clobber** race (a worker losing a single-use rotation race would overwrite the winner's valid token — now guarded by re-read-and-compare-before-write), empty-body 4xx no longer bricks a sign-in, an overall stream deadline (httpx's is per-read), and truncated streams raise instead of returning partial output as success.

## Test plan
- 18 new tests (device flow incl. 0600 perms + usercode alias, refresh rotation/persistence, concurrent-rotation guard, empty-body-transient classification, needs_reauth vs transient, provider resolution + dispatch wiring, SSE accumulation, 401-refresh-retry, persistent-401, stream-without-terminal, usage-limit surfacing, admin gate + endpoint flow).
- Full suite: 440 passed locally; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)