### PR TITLE
Runtime admin-controlled AI provider config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,12 @@ TUBEVAULT_PORT=8484
 # Gemini or OpenAI key additionally enables the embeddings-based discovery
 # pipeline (candidate search + similarity matching). With only an Anthropic
 # key, Discover uses the simpler prompt-only engine. All optional.
+#
+# These (and the provider selection below) are now BOOTSTRAP DEFAULTS: an
+# admin can set/override keys and the embed/rank provider from the app
+# (Settings -> AI providers), stored securely server-side. A value set in the
+# app overrides the matching env var here; clearing it reverts to the env
+# value. You can leave all of these blank and configure everything in-app.
 ANTHROPIC_API_KEY=
 GEMINI_API_KEY=
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ NullFeed is a self-hosted YouTube media center that wraps **yt-dlp** with a poli
 
 ---
 
+## Managing AI providers from the app
+
+You don't have to set the AI keys or provider selection via env vars. An admin
+can manage them in **Settings → AI providers**: paste/clear the Anthropic,
+Gemini, and OpenAI keys, pick the embedding and ranking provider (and model),
+and connect a ChatGPT subscription — all stored securely on the server (0600
+files under the config volume, never returned to the client once set). The env
+vars above act as bootstrap defaults; anything set in the app overrides them,
+and clearing an in-app value reverts to the env default. No redeploy needed.
+
 ## Use your ChatGPT subscription for Discover ranking
 
 Instead of an OpenAI API key, the Discover reranker can run on a ChatGPT

--- a/app/api/settings.py
+++ b/app/api/settings.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel, Field
 
 from app.api.auth import get_current_user
 from app.models.user import User
-from app.services import chatgpt_auth
+from app.services import ai_config, chatgpt_auth, llm_providers
 from app.utils.ytdlp import (
     clear_cookies,
     cookies_status,
@@ -36,6 +36,15 @@ def _require_admin(user: User) -> None:
 
 class YoutubeCookiesIn(BaseModel):
     cookies: str = Field(..., min_length=1, max_length=1_000_000)
+
+
+class AiKeyIn(BaseModel):
+    key: str = Field(..., min_length=1, max_length=500)
+
+
+class AiSelectionIn(BaseModel):
+    provider: str = Field("", max_length=40)
+    model: str = Field("", max_length=120)
 
 
 @router.get("/youtube-cookies")
@@ -81,6 +90,101 @@ async def delete_youtube_cookies(user: User = Depends(get_current_user)) -> dict
     _require_admin(user)
     clear_cookies()
     return cookies_status()
+
+
+# --- AI providers: runtime keys + provider/model selection -----------------
+
+
+def _ai_status() -> dict:
+    """Full AI-config view for the admin panel. Never includes a raw key."""
+    embed_eff = llm_providers.resolve_embed_provider()
+    rank_eff = llm_providers.resolve_rank_provider()
+    return {
+        "keys": {p: ai_config.key_status(p) for p in ai_config.KEY_PROVIDERS},
+        "embed": {
+            **ai_config.selection_status("embed"),
+            "effective": {"provider": embed_eff[0], "model": embed_eff[1]}
+            if embed_eff
+            else None,
+            "options": list(llm_providers.EMBED_MODELS),
+        },
+        "rank": {
+            **ai_config.selection_status("rank"),
+            "effective": {"provider": rank_eff[0], "model": rank_eff[1]}
+            if rank_eff
+            else None,
+            "options": list(llm_providers.RANK_MODELS),
+        },
+        "availability": {
+            "anthropic": bool(ai_config.get_key("anthropic")),
+            "gemini": bool(ai_config.get_key("gemini")),
+            "openai": bool(ai_config.get_key("openai")),
+            "chatgpt": chatgpt_auth.has_auth(),
+        },
+    }
+
+
+@router.get("/ai-providers")
+async def get_ai_providers(user: User = Depends(get_current_user)) -> dict:
+    """Which keys are set (masked), the embed/rank selection, and what's live."""
+    _require_admin(user)
+    return _ai_status()
+
+
+@router.put("/ai-providers/keys/{provider}")
+async def put_ai_key(
+    provider: str, body: AiKeyIn, user: User = Depends(get_current_user)
+) -> dict:
+    """Set a provider API key at runtime (overrides the env value)."""
+    _require_admin(user)
+    if provider not in ai_config.KEY_PROVIDERS:
+        raise HTTPException(status_code=404, detail="Unknown provider")
+    ai_config.set_key(provider, body.key.strip())
+    # Name + admin id only — never the key value.
+    logger.info("AI %s key set by admin %s", provider, user.id)
+    return _ai_status()
+
+
+@router.delete("/ai-providers/keys/{provider}")
+async def delete_ai_key(provider: str, user: User = Depends(get_current_user)) -> dict:
+    """Clear a runtime key, reverting that provider to its env value (if any)."""
+    _require_admin(user)
+    if provider not in ai_config.KEY_PROVIDERS:
+        raise HTTPException(status_code=404, detail="Unknown provider")
+    ai_config.clear_key(provider)
+    logger.info("AI %s key cleared by admin %s", provider, user.id)
+    return _ai_status()
+
+
+@router.put("/ai-providers/selection/{role}")
+async def put_ai_selection(
+    role: str, body: AiSelectionIn, user: User = Depends(get_current_user)
+) -> dict:
+    """Pin the embed/rank provider (+ optional model), or "" to auto-detect."""
+    _require_admin(user)
+    if role not in ai_config.SELECTION_ROLES:
+        raise HTTPException(status_code=404, detail="Unknown selection role")
+    provider = body.provider.strip().lower()
+    model = body.model.strip()
+    allowed = (
+        llm_providers.EMBED_MODELS if role == "embed" else llm_providers.RANK_MODELS
+    )
+    if provider and provider not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Provider {provider!r} is not valid for {role} "
+            f"(choose from {', '.join(allowed)} or leave blank to auto-detect)",
+        )
+    if model and not provider:
+        raise HTTPException(
+            status_code=400,
+            detail="Set the provider explicitly to use a model override",
+        )
+    ai_config.set_selection(role, provider, model)
+    logger.info(
+        "Discovery %s provider set to %r by admin %s", role, provider or "auto", user.id
+    )
+    return _ai_status()
 
 
 # --- ChatGPT (Codex OAuth) sign-in for the Discover rank provider ----------

--- a/app/services/ad_segments.py
+++ b/app/services/ad_segments.py
@@ -17,7 +17,7 @@ import logging
 
 import httpx
 
-from app.config import settings
+from app.services import ai_config
 from app.services.download_manager import fetch_transcript
 
 logger = logging.getLogger(__name__)
@@ -99,7 +99,7 @@ def _claude_complete(prompt: str) -> str:
     """Run one synchronous Claude completion and return the response text."""
     import anthropic
 
-    client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    client = anthropic.Anthropic(api_key=ai_config.get_key("anthropic"))
     message = client.messages.create(
         model=_AI_MODEL,
         max_tokens=_AI_MAX_TOKENS,
@@ -161,6 +161,6 @@ def resolve_ad_segments(youtube_video_id: str) -> list[dict]:
     sponsorblock = fetch_sponsorblock_segments(youtube_video_id)
     if sponsorblock:
         return sponsorblock
-    if settings.anthropic_api_key:
+    if ai_config.get_key("anthropic"):
         return detect_ad_segments_with_ai(youtube_video_id)
     return []

--- a/app/services/ai_config.py
+++ b/app/services/ai_config.py
@@ -62,13 +62,23 @@ def _str(value: object) -> str:
     return value if isinstance(value, str) else ""
 
 
+def _dict(value: object) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _keys(store: dict) -> dict:
+    """The store's ``keys`` sub-dict, coerced — a hand-edited file whose
+    ``keys`` is a non-dict must degrade to env, not crash the read path."""
+    return _dict(store.get("keys"))
+
+
 def _env_key(provider: str) -> str:
     attr = _ENV_KEY_ATTR.get(provider)
     return getattr(settings, attr, "") if attr else ""
 
 
 def _runtime_key(provider: str) -> str:
-    return _str((_load().get("keys") or {}).get(provider))
+    return _str(_keys(_load()).get(provider))
 
 
 # --- reads (used by llm_providers / recommendation / ad_segments) -----------
@@ -110,7 +120,7 @@ def _selection(role: str) -> tuple[str, str]:
 
 def set_key(provider: str, key: str) -> None:
     store = _load()
-    keys = dict(store.get("keys") or {})
+    keys = _keys(store)
     keys[provider] = key
     store["keys"] = keys
     _write_private(_config_path(), store)
@@ -119,7 +129,7 @@ def set_key(provider: str, key: str) -> None:
 def clear_key(provider: str) -> None:
     """Remove a runtime key, reverting that provider to its env value."""
     store = _load()
-    keys = dict(store.get("keys") or {})
+    keys = _keys(store)
     if keys.pop(provider, None) is not None:
         store["keys"] = keys
         _write_private(_config_path(), store)

--- a/app/services/ai_config.py
+++ b/app/services/ai_config.py
@@ -1,0 +1,165 @@
+"""Runtime, admin-controlled AI configuration for the discovery pipeline.
+
+Lets an admin manage the discovery providers from the app instead of only via
+container env vars: the anthropic/gemini/openai API keys and the embed/rank
+provider+model selection. (The ChatGPT sign-in — the fourth rank provider —
+is stored separately in ``chatgpt_auth``.)
+
+Storage mirrors the established runtime-secret pattern (``chatgpt_auth`` tokens,
+YouTube cookies): a single 0600 JSON file under ``settings.config_path``,
+written atomically, read fresh on every call so every uvicorn/Celery worker on
+the shared config volume sees an edit immediately.
+
+Precedence is runtime-over-env: a value set here overrides the env/``settings``
+default, and clearing it reverts to the env value — so existing env-based
+deployments keep working untouched, and an operator can override live without a
+redeploy. Keys are write-only: they are never returned by any read here (only
+``key_status`` — configured/source/masked last 4) and never logged.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from app.config import settings
+
+KEY_PROVIDERS = ("anthropic", "gemini", "openai")
+SELECTION_ROLES = ("embed", "rank")
+
+_ENV_KEY_ATTR = {
+    "anthropic": "anthropic_api_key",
+    "gemini": "gemini_api_key",
+    "openai": "openai_api_key",
+}
+_FILENAME = "ai_config.json"
+
+
+def _config_path() -> Path:
+    return Path(settings.config_path) / _FILENAME
+
+
+def _write_private(path: Path, data: dict) -> None:
+    """Atomic 0600 write (tmp + rename); mirrors chatgpt_auth._write_private."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.{os.urandom(4).hex()}.tmp")
+    tmp.write_text(json.dumps(data))
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, path)
+
+
+def _load() -> dict:
+    try:
+        data = json.loads(_config_path().read_text())
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _str(value: object) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _env_key(provider: str) -> str:
+    attr = _ENV_KEY_ATTR.get(provider)
+    return getattr(settings, attr, "") if attr else ""
+
+
+def _runtime_key(provider: str) -> str:
+    return _str((_load().get("keys") or {}).get(provider))
+
+
+# --- reads (used by llm_providers / recommendation / ad_segments) -----------
+
+
+def get_key(provider: str) -> str:
+    """The effective key: runtime override if set, else the env value.
+
+    Returns "" when neither is set, and always "" for "chatgpt" (which has no
+    key — it authenticates via the ChatGPT sign-in).
+    """
+    return _runtime_key(provider) or _env_key(provider)
+
+
+def get_embed_selection() -> tuple[str, str]:
+    return _selection("embed")
+
+
+def get_rank_selection() -> tuple[str, str]:
+    return _selection("rank")
+
+
+def _selection(role: str) -> tuple[str, str]:
+    store = _load()
+    provider = _str(store.get(f"{role}_provider"))
+    model = _str(store.get(f"{role}_model"))
+    # Return the runtime (provider, model) as a UNIT whenever either is set —
+    # never pair a runtime provider with an env model (or vice versa), which
+    # would mismatch vendor and model.
+    if provider or model:
+        return provider, model
+    if role == "embed":
+        return settings.discovery_embed_provider, settings.discovery_embed_model
+    return settings.discovery_rank_provider, settings.discovery_rank_model
+
+
+# --- writes (admin endpoints only) ------------------------------------------
+
+
+def set_key(provider: str, key: str) -> None:
+    store = _load()
+    keys = dict(store.get("keys") or {})
+    keys[provider] = key
+    store["keys"] = keys
+    _write_private(_config_path(), store)
+
+
+def clear_key(provider: str) -> None:
+    """Remove a runtime key, reverting that provider to its env value."""
+    store = _load()
+    keys = dict(store.get("keys") or {})
+    if keys.pop(provider, None) is not None:
+        store["keys"] = keys
+        _write_private(_config_path(), store)
+
+
+def set_selection(role: str, provider: str, model: str) -> None:
+    store = _load()
+    store[f"{role}_provider"] = provider
+    store[f"{role}_model"] = model
+    _write_private(_config_path(), store)
+
+
+# --- status (write-only: never returns a raw key) ---------------------------
+
+
+def key_status(provider: str) -> dict:
+    runtime = _runtime_key(provider)
+    env = _env_key(provider)
+    effective = runtime or env
+    return {
+        "configured": bool(effective),
+        "source": "runtime" if runtime else ("env" if env else None),
+        # Masked hint; short/secret-like values are hidden entirely.
+        "last4": effective[-4:] if len(effective) >= 8 else None,
+    }
+
+
+def selection_status(role: str) -> dict:
+    provider, model = _selection(role)
+    store = _load()
+    runtime_set = bool(
+        _str(store.get(f"{role}_provider")) or _str(store.get(f"{role}_model"))
+    )
+    return {
+        "provider": provider,
+        "model": model,
+        "source": "runtime" if runtime_set else "env",
+    }
+
+
+def clear() -> None:
+    """Test hook: drop the whole runtime store."""
+    _config_path().unlink(missing_ok=True)

--- a/app/services/llm_providers.py
+++ b/app/services/llm_providers.py
@@ -22,8 +22,7 @@ import logging
 
 import httpx
 
-from app.config import settings
-from app.services import chatgpt_auth
+from app.services import ai_config, chatgpt_auth
 
 logger = logging.getLogger(__name__)
 
@@ -68,11 +67,7 @@ def _provider_key(provider: str) -> str:
     if provider == "chatgpt":
         # No API key: "configured" means a completed ChatGPT sign-in.
         return "oauth" if chatgpt_auth.has_auth() else ""
-    return {
-        "anthropic": settings.anthropic_api_key,
-        "gemini": settings.gemini_api_key,
-        "openai": settings.openai_api_key,
-    }.get(provider, "")
+    return ai_config.get_key(provider)
 
 
 def _resolve(
@@ -107,22 +102,14 @@ def _resolve(
 
 def resolve_embed_provider() -> tuple[str, str] | None:
     """Return (provider, model) for embeddings, or None when unavailable."""
-    return _resolve(
-        settings.discovery_embed_provider,
-        settings.discovery_embed_model,
-        EMBED_MODELS,
-        _EMBED_ORDER,
-    )
+    provider, model = ai_config.get_embed_selection()
+    return _resolve(provider, model, EMBED_MODELS, _EMBED_ORDER)
 
 
 def resolve_rank_provider() -> tuple[str, str] | None:
     """Return (provider, model) for ranking, or None when unavailable."""
-    return _resolve(
-        settings.discovery_rank_provider,
-        settings.discovery_rank_model,
-        RANK_MODELS,
-        _RANK_ORDER,
-    )
+    provider, model = ai_config.get_rank_selection()
+    return _resolve(provider, model, RANK_MODELS, _RANK_ORDER)
 
 
 def embed_model_key() -> str | None:
@@ -172,7 +159,7 @@ async def _embed_gemini(texts: list[str], model: str) -> list[list[float]]:
                 f"{_GEMINI_BASE}/{model}:batchEmbedContents",
                 # Header, NOT a ?key= query param: httpx logs full request
                 # URLs at INFO, which would leak the key into app logs.
-                headers={"x-goog-api-key": settings.gemini_api_key},
+                headers={"x-goog-api-key": ai_config.get_key("gemini")},
                 json={
                     "requests": [
                         {
@@ -192,7 +179,7 @@ async def _embed_openai(texts: list[str], model: str) -> list[list[float]]:
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
         resp = await client.post(
             f"{_OPENAI_BASE}/embeddings",
-            headers={"Authorization": f"Bearer {settings.openai_api_key}"},
+            headers={"Authorization": f"Bearer {ai_config.get_key('openai')}"},
             json={"model": model, "input": texts},
         )
         resp.raise_for_status()
@@ -204,7 +191,7 @@ async def _embed_openai(texts: list[str], model: str) -> list[list[float]]:
 async def _complete_anthropic(prompt: str, model: str) -> str:
     import anthropic  # lazy: keep the dependency optional at runtime
 
-    client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+    client = anthropic.AsyncAnthropic(api_key=ai_config.get_key("anthropic"))
     message = await client.messages.create(
         model=model,
         max_tokens=_MAX_RANK_TOKENS,
@@ -222,7 +209,7 @@ async def _complete_gemini(prompt: str, model: str) -> str:
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
         resp = await client.post(
             f"{_GEMINI_BASE}/{model}:generateContent",
-            headers={"x-goog-api-key": settings.gemini_api_key},
+            headers={"x-goog-api-key": ai_config.get_key("gemini")},
             json={"contents": [{"parts": [{"text": prompt}]}]},
         )
         resp.raise_for_status()
@@ -235,7 +222,7 @@ async def _complete_openai(prompt: str, model: str) -> str:
     async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
         resp = await client.post(
             f"{_OPENAI_BASE}/chat/completions",
-            headers={"Authorization": f"Bearer {settings.openai_api_key}"},
+            headers={"Authorization": f"Bearer {ai_config.get_key('openai')}"},
             json={
                 "model": model,
                 "messages": [{"role": "user", "content": prompt}],

--- a/app/services/recommendation.py
+++ b/app/services/recommendation.py
@@ -5,7 +5,7 @@ import uuid
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
+from app.services import ai_config
 from app.models.channel import Channel
 from app.models.recommendation import Recommendation
 from app.models.subscription import UserSubscription
@@ -44,7 +44,8 @@ async def generate_recommendations(
     db: AsyncSession,
 ) -> list[Recommendation]:
     """Generate AI-powered channel recommendations for a user."""
-    if not settings.anthropic_api_key:
+    anthropic_key = ai_config.get_key("anthropic")
+    if not anthropic_key:
         logger.info("No Anthropic API key configured; skipping recommendations.")
         return []
 
@@ -70,7 +71,7 @@ async def generate_recommendations(
     )
 
     try:
-        client = anthropic.AsyncAnthropic(api_key=settings.anthropic_api_key)
+        client = anthropic.AsyncAnthropic(api_key=anthropic_key)
         message = await client.messages.create(
             model="claude-sonnet-4-6",
             max_tokens=1024,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from httpx import ASGITransport, AsyncClient
 
 import app.api.auth as auth_api
 import app.api.websocket as websocket_api
+import app.services.ai_config as ai_config
 import app.services.chatgpt_auth as chatgpt_auth
 import app.services.discovery as discovery_service
 import app.services.instant_stream as instant_stream
@@ -47,6 +48,7 @@ def _reset_in_memory_state():
     discovery_service._generation_locks.clear()
     chatgpt_auth._reset_state()
     chatgpt_auth.clear_auth()
+    ai_config.clear()
     youtube_import._resolve_cache.clear()
     youtube_import._suggestions_cache.clear()
     instant_stream._resolve_cache.clear()

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -43,6 +43,20 @@ async def test_corrupt_store_falls_back_to_env(monkeypatch):
     )
 
 
+async def test_malformed_keys_field_degrades_and_is_repairable(monkeypatch):
+    # Valid JSON, but 'keys' is hand-edited to a non-dict. Reads must degrade
+    # to env, not crash, and a write must repair the store.
+    monkeypatch.setattr(settings, "gemini_api_key", "env-gemini")
+    for bad in ('{"keys": "sk-x"}', '{"keys": ["openai"]}', '{"keys": 5}'):
+        ai_config._config_path().write_text(bad)
+        assert ai_config.get_key("gemini") == "env-gemini"
+        assert ai_config.key_status("gemini")["source"] == "env"
+        # Writing repairs the malformed store rather than raising.
+        ai_config.set_key("openai", "sk-repaired")
+        assert ai_config.get_key("openai") == "sk-repaired"
+        ai_config.clear()
+
+
 async def test_selection_returned_as_a_unit(monkeypatch):
     # Env has a rank model but no provider; a runtime provider must NOT be
     # paired with the env model.

--- a/tests/test_ai_config.py
+++ b/tests/test_ai_config.py
@@ -1,0 +1,204 @@
+"""Runtime AI-config store: getters, env fallback, masking, and endpoints."""
+
+import json
+
+import pytest
+
+import app.services.ai_config as ai_config
+from app.config import settings
+
+pytestmark = pytest.mark.asyncio
+
+
+# --- getters + precedence ----------------------------------------------------
+
+
+async def test_get_key_runtime_overrides_env(monkeypatch):
+    monkeypatch.setattr(settings, "gemini_api_key", "env-key")
+    # No runtime store yet -> env value.
+    assert ai_config.get_key("gemini") == "env-key"
+
+    ai_config.set_key("gemini", "runtime-key")
+    assert ai_config.get_key("gemini") == "runtime-key"
+
+    # Clearing reverts to env.
+    ai_config.clear_key("gemini")
+    assert ai_config.get_key("gemini") == "env-key"
+
+
+async def test_get_key_empty_when_neither_set(monkeypatch):
+    monkeypatch.setattr(settings, "openai_api_key", "")
+    assert ai_config.get_key("openai") == ""
+    # chatgpt never has a key here.
+    assert ai_config.get_key("chatgpt") == ""
+
+
+async def test_corrupt_store_falls_back_to_env(monkeypatch):
+    monkeypatch.setattr(settings, "anthropic_api_key", "env-anthropic")
+    ai_config._config_path().write_text("{ not valid json")
+    assert ai_config.get_key("anthropic") == "env-anthropic"
+    assert ai_config.get_embed_selection() == (
+        settings.discovery_embed_provider,
+        settings.discovery_embed_model,
+    )
+
+
+async def test_selection_returned_as_a_unit(monkeypatch):
+    # Env has a rank model but no provider; a runtime provider must NOT be
+    # paired with the env model.
+    monkeypatch.setattr(settings, "discovery_rank_provider", "")
+    monkeypatch.setattr(settings, "discovery_rank_model", "env-model")
+
+    # Nothing runtime -> env pair.
+    assert ai_config.get_rank_selection() == ("", "env-model")
+
+    # Runtime provider set (no runtime model) -> the runtime pair as a unit,
+    # env model dropped.
+    ai_config.set_selection("rank", "gemini", "")
+    assert ai_config.get_rank_selection() == ("gemini", "")
+
+
+async def test_key_status_masks_and_reports_source(monkeypatch):
+    monkeypatch.setattr(settings, "gemini_api_key", "")
+    assert ai_config.key_status("gemini") == {
+        "configured": False,
+        "source": None,
+        "last4": None,
+    }
+
+    ai_config.set_key("gemini", "abcdef1234")
+    status = ai_config.key_status("gemini")
+    assert status["configured"] is True
+    assert status["source"] == "runtime"
+    assert status["last4"] == "1234"
+
+    # A short secret is fully masked.
+    ai_config.set_key("openai", "short")
+    assert ai_config.key_status("openai")["last4"] is None
+
+
+async def test_store_file_is_0600(monkeypatch):
+    import stat
+
+    ai_config.set_key("openai", "sk-secret")
+    mode = stat.S_IMODE(ai_config._config_path().stat().st_mode)
+    assert mode == 0o600
+    # The raw key lives in the file but is never returned by a getter/status.
+    on_disk = json.loads(ai_config._config_path().read_text())
+    assert on_disk["keys"]["openai"] == "sk-secret"
+    assert "sk-secret" not in json.dumps(ai_config.key_status("openai"))
+
+
+# --- resolver integration ----------------------------------------------------
+
+
+async def test_runtime_key_enables_resolution(monkeypatch):
+    import app.services.llm_providers as llm_providers
+
+    monkeypatch.setattr(settings, "anthropic_api_key", "")
+    monkeypatch.setattr(settings, "gemini_api_key", "")
+    monkeypatch.setattr(settings, "openai_api_key", "")
+    monkeypatch.setattr(settings, "discovery_embed_provider", "")
+    monkeypatch.setattr(settings, "discovery_rank_provider", "")
+    monkeypatch.setattr(settings, "discovery_embed_model", "")
+    monkeypatch.setattr(settings, "discovery_rank_model", "")
+
+    assert llm_providers.resolve_embed_provider() is None
+
+    ai_config.set_key("gemini", "runtime-gemini")
+    assert llm_providers.resolve_embed_provider() == ("gemini", "gemini-embedding-2")
+    assert llm_providers.resolve_rank_provider() == ("gemini", "gemini-3.5-flash")
+
+    # A runtime selection pins the rank provider.
+    ai_config.set_key("openai", "runtime-openai")
+    ai_config.set_selection("rank", "openai", "")
+    assert llm_providers.resolve_rank_provider() == ("openai", "gpt-5.6-luna")
+
+
+# --- admin endpoints ---------------------------------------------------------
+
+
+async def test_ai_provider_endpoints_flow(monkeypatch, client, make_user):
+    _, admin_headers = await make_user("Admin")
+    _, other_headers = await make_user("Someone")
+    monkeypatch.setattr(settings, "gemini_api_key", "")
+
+    # Non-admin is refused.
+    for method, path in (
+        ("GET", "/api/settings/ai-providers"),
+        ("PUT", "/api/settings/ai-providers/keys/gemini"),
+        ("DELETE", "/api/settings/ai-providers/keys/gemini"),
+        ("PUT", "/api/settings/ai-providers/selection/rank"),
+    ):
+        kwargs = {"headers": other_headers}
+        if method == "PUT":
+            kwargs["json"] = {"key": "x"} if "keys" in path else {"provider": ""}
+        resp = await client.request(method, path, **kwargs)
+        assert resp.status_code == 403, (method, path, resp.text)
+
+    # Set a key; it's reported configured but never echoed.
+    resp = await client.put(
+        "/api/settings/ai-providers/keys/gemini",
+        headers=admin_headers,
+        json={"key": "sk-gemini-secret"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["keys"]["gemini"]["configured"] is True
+    assert body["keys"]["gemini"]["source"] == "runtime"
+    assert body["availability"]["gemini"] is True
+    assert "sk-gemini-secret" not in resp.text
+
+    # Pin the rank provider.
+    resp = await client.put(
+        "/api/settings/ai-providers/selection/rank",
+        headers=admin_headers,
+        json={"provider": "gemini", "model": ""},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["rank"]["effective"] == {
+        "provider": "gemini",
+        "model": "gemini-3.5-flash",
+    }
+
+    # Clear the key -> reverts to env (empty here).
+    resp = await client.delete(
+        "/api/settings/ai-providers/keys/gemini", headers=admin_headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["keys"]["gemini"]["configured"] is False
+
+
+async def test_ai_provider_endpoint_validation(monkeypatch, client, make_user):
+    _, admin_headers = await make_user("Admin")
+
+    # Unknown provider / role -> 404.
+    resp = await client.put(
+        "/api/settings/ai-providers/keys/cohere",
+        headers=admin_headers,
+        json={"key": "x"},
+    )
+    assert resp.status_code == 404, resp.text
+
+    resp = await client.put(
+        "/api/settings/ai-providers/selection/sideways",
+        headers=admin_headers,
+        json={"provider": "gemini"},
+    )
+    assert resp.status_code == 404, resp.text
+
+    # chatgpt/anthropic are not valid EMBED providers -> 400.
+    resp = await client.put(
+        "/api/settings/ai-providers/selection/embed",
+        headers=admin_headers,
+        json={"provider": "chatgpt"},
+    )
+    assert resp.status_code == 400, resp.text
+
+    # A model override without a provider -> 400.
+    resp = await client.put(
+        "/api/settings/ai-providers/selection/rank",
+        headers=admin_headers,
+        json={"provider": "", "model": "some-model"},
+    )
+    assert resp.status_code == 400, resp.text


### PR DESCRIPTION
## Summary

Moves discovery AI configuration out of boot-time env vars into a **runtime, admin-controlled store**, so the API keys and the embed/rank provider+model selection can be managed from the app (an admin Settings panel) instead of only at container setup. Follows up #128 — the ChatGPT sign-in already worked this way; this brings the rest of the AI config to the same model.

## How it works
- **`app/services/ai_config.py`** — a single 0600 JSON file under `config_path` (same pattern as the ChatGPT tokens and YouTube cookies), atomic writes, read-fresh so every uvicorn/Celery worker on the shared volume sees an edit immediately.
- **Precedence is runtime-over-env**: a value set in the app overrides the matching env var; clearing it reverts to the env value. So **existing env-based deployments keep working untouched**, and an operator can override live with no redeploy.
- **Keys are write-only**: never returned by any read (status is `configured` / `source` / masked last-4 only) and never logged. Selection is returned as a `(provider, model)` unit so a runtime provider is never mismatched with an env model.
- **16 call sites rerouted** through `ai_config`: `llm_providers` (`_provider_key`, `resolve_embed`/`resolve_rank`, the 5 API-call key reads), the legacy `recommendation` engine, and `ad_segments` (Celery sync — a plain file read).

## API (admin-gated, on the settings router)
- `GET /api/settings/ai-providers` — masked key status, embed/rank selection, effective provider, availability
- `PUT` / `DELETE /api/settings/ai-providers/keys/{provider}` — set / clear a runtime key
- `PUT /api/settings/ai-providers/selection/{role}` — pin the embed/rank provider (+ optional model), with validation (unknown provider/role → 404, embed-incapable/unknown provider → 400, model-without-provider → 400)

## Compatibility
- Non-breaking: with no store file, the getters fall straight through to the env/`settings.*` values, so all **440 pre-existing tests pass unchanged**. Env vars are now documented as bootstrap defaults.

## Hardening
Adversarially reviewed (14-agent pass across key-confidentiality / reroute-correctness / store-integrity / test-isolation). Security and reroute dimensions came back clean (keys never leak; the reroute preserves exact env-fallback behavior). One confirmed bug fixed: a hand-edited file with a non-dict `keys` field crashed the read path instead of degrading to env — now coerced so a malformed store degrades and a write repairs it.

## Test plan
- 10 new tests (runtime-over-env precedence, empty=fallback, corrupt-file + malformed-`keys` degrade/repair, paired-selection unit rule, key masking/source, 0600 perms + no-echo, resolver integration, admin endpoint flow + validation).
- Full suite: 450 passed; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)