### PR TITLE
docs: correct ChatGPT-provider quota caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ well.
    metered key instead of your ChatGPT plan.
 
 **Caveats:** this is an unofficial surface OpenAI operates for Codex
-clients — it may change or be gated at any time, and Discover shares your
-plan's Codex usage limits (heavy refreshing eats the same quota as Codex
-code reviews). Any failure just disables the provider; nothing else breaks.
+clients — it may change or be gated at any time, and Discover draws on your
+plan's Codex usage allowance, so heavy refreshing can hit that limit. Any
+failure just disables the provider; nothing else breaks.
 
 ## Age-restricted videos
 


### PR DESCRIPTION
The README caveat for the `chatgpt` rank provider claimed heavy Discover refreshing "eats the same quota as Codex code reviews." That's wrong — the Codex code-review meter is separate from the Codex CLI/API usage the sign-in token draws against. Reworded to just say it draws on the plan's Codex usage allowance. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)