### PR TITLE
Keep Discover recommendations fresh (invalidate on sub change + staleness sweep)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,15 @@ POLL_INTERVAL_FLOOR_MINUTES=15
 POLL_INTERVAL_CAP_MINUTES=240
 POLL_INTERVAL_BACKOFF_FACTOR=2.0
 
+# Discover recommendation freshness (optional).
+# Recommendations are a snapshot from the last generation. A daily sweep clears
+# each user's live recommendations older than this many days so they regenerate
+# from current subscriptions on the next Discover open (regeneration is lazy —
+# inactive users cost nothing). 0 or negative disables the sweep. Following /
+# unfollowing channels invalidates that user's recommendations immediately
+# regardless of this. Default 7 (weekly); set to 1 for daily freshness.
+NULLFEED_RECOMMENDATION_STALE_DAYS=7
+
 # User/group ID for file permissions (Unraid standard)
 PUID=1000
 PGID=1000

--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -211,8 +211,12 @@ async def subscribe(
     await db.commit()
     await db.refresh(channel)
 
-    # Trigger an immediate poll for this channel
-    poll_channel_task.delay(channel.id)
+    # Trigger an immediate poll (best-effort — the subscription is already
+    # committed, so a broker hiccup here must not fail the request).
+    try:
+        poll_channel_task.delay(channel.id)
+    except Exception:
+        logger.exception("Could not enqueue poll for channel %s", channel.id)
 
     out = ChannelOut.model_validate(channel)
     out.is_subscribed = True
@@ -242,9 +246,16 @@ async def subscribe_bulk(
             )
     # If anything actually subscribed, invalidate once so the next Discover open
     # regenerates from the new follow set (per-item commits already landed).
+    # Best-effort — this must never discard the batch's committed results.
     if any(r.status == "subscribed" for r in results):
-        await invalidate_recommendations(user.id, db)
-        await db.commit()
+        try:
+            await invalidate_recommendations(user.id, db)
+            await db.commit()
+        except Exception:
+            logger.exception(
+                "Could not invalidate recommendations after bulk subscribe"
+            )
+            await db.rollback()
     return BulkSubscribeResponse(results=results)
 
 
@@ -316,7 +327,12 @@ async def _subscribe_bulk_item(
     await db.commit()
 
     if created:
-        poll_channel_task.delay(channel.id)
+        # Best-effort — the subscription is committed; don't turn a broker
+        # hiccup into an "error" result for a follow that actually landed.
+        try:
+            poll_channel_task.delay(channel.id)
+        except Exception:
+            logger.exception("Could not enqueue poll for channel %s", channel.id)
 
     return BulkSubscribeItemResult(
         youtube_channel_id=item.youtube_channel_id,

--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -14,6 +14,7 @@ from app.models.subscription import UserSubscription
 from app.models.user import User
 from app.models.user_video_ref import REF_KIND_CACHE, UserVideoRef
 from app.models.video import Video
+from app.services.recommendation import invalidate_recommendations
 from app.schemas.channel import (
     BulkSubscribeItem,
     BulkSubscribeItemResult,
@@ -203,6 +204,10 @@ async def subscribe(
     # Create/reactivate user video refs for ALL existing videos in this channel
     await _ensure_refs_for_channel(user.id, channel.id, db)
 
+    # Follows changed the taste profile — drop stale recs so the next Discover
+    # open regenerates (and this newly-followed channel stops being suggested).
+    await invalidate_recommendations(user.id, db)
+
     await db.commit()
     await db.refresh(channel)
 
@@ -235,6 +240,11 @@ async def subscribe_bulk(
                     detail="Subscription failed",
                 )
             )
+    # If anything actually subscribed, invalidate once so the next Discover open
+    # regenerates from the new follow set (per-item commits already landed).
+    if any(r.status == "subscribed" for r in results):
+        await invalidate_recommendations(user.id, db)
+        await db.commit()
     return BulkSubscribeResponse(results=results)
 
 
@@ -439,6 +449,9 @@ async def unsubscribe(
     if not sub:
         raise HTTPException(status_code=404, detail="Subscription not found")
     await db.delete(sub)
+    # Unfollowing changed the taste profile — drop stale recs so the next
+    # Discover open regenerates without this channel shaping the results.
+    await invalidate_recommendations(user.id, db)
     await db.commit()
     return {"detail": "Unsubscribed"}
 

--- a/app/config.py
+++ b/app/config.py
@@ -61,6 +61,17 @@ class Settings(BaseSettings):
     poll_interval_cap_minutes: int = 240
     poll_interval_backoff_factor: float = 2.0
 
+    # Discover recommendation freshness
+    # Recommendations are a snapshot from the last generation. A daily sweep
+    # deletes each user's live (non-dismissed) recommendations older than this
+    # many days so they regenerate from current subscriptions on the next
+    # Discover open (regeneration is lazy — inactive users cost nothing). A
+    # value <= 0 disables the sweep. Subscription changes invalidate a user's
+    # recommendations immediately regardless of this.
+    recommendation_stale_days: int = Field(
+        default=7, validation_alias="NULLFEED_RECOMMENDATION_STALE_DAYS"
+    )
+
     # Retention enforcement
     # How often the retention sweep runs (Celery beat, in hours). Each run
     # applies every subscription's retention_policy: e.g. KEEP_LAST_N keeps the

--- a/app/services/recommendation.py
+++ b/app/services/recommendation.py
@@ -2,7 +2,7 @@ import json
 import logging
 import uuid
 
-from sqlalchemy import func, select
+from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services import ai_config
@@ -177,3 +177,19 @@ async def _get_dismissed_names(user_id: str, db: AsyncSession) -> list[str]:
         )
     )
     return [row[0] for row in result.all()]
+
+
+async def invalidate_recommendations(user_id: str, db: AsyncSession) -> None:
+    """Drop the user's live (non-dismissed) recommendations so the next Discover
+    open regenerates them from current subscriptions.
+
+    Dismissed rows (the do-not-recommend list) are preserved. Does NOT commit —
+    the caller's transaction does — and does NOT run the generation pipeline
+    (regeneration is lazy, on the next GET /api/discover with no live recs).
+    """
+    await db.execute(
+        delete(Recommendation).where(
+            Recommendation.user_id == user_id,
+            Recommendation.dismissed == False,  # noqa: E712
+        )
+    )

--- a/app/services/recommendation_reaper.py
+++ b/app/services/recommendation_reaper.py
@@ -1,0 +1,35 @@
+"""Delete stale Discover recommendations so they regenerate on next view.
+
+Recommendations are a snapshot from the last generation; as channels post new
+uploads and the candidate catalogue grows, they drift. This sweep deletes each
+user's live (non-dismissed) recommendations older than a staleness window so
+the next Discover open rebuilds them from current subscriptions — inactive
+users cost nothing, since regeneration is lazy. Dismissed rows (the
+do-not-recommend list) are always kept.
+"""
+
+from datetime import timedelta
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from app.models.recommendation import Recommendation
+from app.utils.time import utcnow_naive
+
+
+def sweep_stale_recommendations(db: Session, stale_days: int) -> int:
+    """Delete non-dismissed recommendations older than ``stale_days``.
+
+    Returns the number deleted. A non-positive ``stale_days`` is a no-op.
+    """
+    if stale_days <= 0:
+        return 0
+    cutoff = utcnow_naive() - timedelta(days=stale_days)
+    result = db.execute(
+        delete(Recommendation).where(
+            Recommendation.dismissed == False,  # noqa: E712
+            Recommendation.created_at < cutoff,
+        )
+    )
+    db.commit()
+    return result.rowcount or 0

--- a/app/tasks/celery_app.py
+++ b/app/tasks/celery_app.py
@@ -87,3 +87,14 @@ if settings.websub_callback_url:
         "task": "app.tasks.download_tasks.sync_websub_subscriptions_task",
         "schedule": 6 * 3600,
     }
+
+# Keep Discover recommendations fresh: delete each user's live (non-dismissed)
+# recommendations older than the staleness window so they regenerate from
+# current subscriptions on the next Discover open. Cheap (a single indexed
+# DELETE); a daily wake with a multi-day window is plenty. Off when the window
+# is <= 0.
+if settings.recommendation_stale_days > 0:
+    celery_app.conf.beat_schedule["sweep-stale-recommendations"] = {
+        "task": "app.tasks.download_tasks.sweep_stale_recommendations_task",
+        "schedule": 24 * 3600,
+    }

--- a/app/tasks/download_tasks.py
+++ b/app/tasks/download_tasks.py
@@ -33,6 +33,7 @@ from app.services.download_manager import (
 from app.services.ad_segments import resolve_ad_segments
 from app.services.cache_retention import enforce_cache_retention
 from app.services.download_reaper import reap_stuck_downloads
+from app.services.recommendation_reaper import sweep_stale_recommendations
 from app.services.retention import enforce_retention
 from app.services.session_reaper import reap_expired_sessions
 from app.services.websub import sync_subscriptions
@@ -715,6 +716,26 @@ def reap_expired_sessions_task(self) -> dict:
         return {"status": "ok", "deleted": deleted}
     except Exception:
         logger.exception("Error in reap_expired_sessions_task")
+        return {"status": "error"}
+    finally:
+        db.close()
+
+
+@celery_app.task(
+    name="app.tasks.download_tasks.sweep_stale_recommendations_task",
+    bind=True,
+    max_retries=0,
+)
+def sweep_stale_recommendations_task(self) -> dict:
+    """Periodic task: delete stale Discover recommendations so they regenerate
+    from current subscriptions on the next Discover open."""
+    db = _get_sync_db()
+    try:
+        deleted = sweep_stale_recommendations(db, settings.recommendation_stale_days)
+        return {"status": "ok", "deleted": deleted}
+    except Exception:
+        logger.exception("Error in sweep_stale_recommendations_task")
+        db.rollback()
         return {"status": "error"}
     finally:
         db.close()

--- a/tests/test_recommendation_freshness.py
+++ b/tests/test_recommendation_freshness.py
@@ -100,8 +100,38 @@ async def test_unsubscribe_invalidates_recommendations(client, make_user):
         await seed_subscription(db, user["id"], channel.id)
     await _seed_recs(user["id"])
 
+    # A second user's recommendations must be untouched.
+    other, _ = await make_user("Other")
+    await _seed_recs(other["id"])
+
     resp = await client.delete(
         f"/api/channels/{channel.id}/unsubscribe", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert await _live_names(user["id"]) == []
+    assert await _all_names(user["id"]) == ["Dismissed"]
+    # Isolation: the other user's live recs survive.
+    assert await _live_names(other["id"]) == ["Live One", "Live Two"]
+
+
+async def test_subscribe_invalidates_recommendations(
+    client, make_user, poll_delay, monkeypatch
+):
+    monkeypatch.setattr(
+        "app.api.channels.fetch_channel_metadata",
+        lambda cid: {"channel_id": "UCsub", "name": "Sub Channel", "handle": "@sub"},
+    )
+    monkeypatch.setattr(
+        "app.api.channels.fetch_channel_images",
+        lambda cid: {"avatar_url": None, "banner_url": None},
+    )
+    user, headers = await make_user()
+    await _seed_recs(user["id"])
+
+    resp = await client.post(
+        "/api/channels/subscribe",
+        json={"youtube_channel_id": "UCsub"},
+        headers=headers,
     )
     assert resp.status_code == 200, resp.text
     assert await _live_names(user["id"]) == []

--- a/tests/test_recommendation_freshness.py
+++ b/tests/test_recommendation_freshness.py
@@ -1,0 +1,147 @@
+"""Recommendation freshness: invalidate-on-subscription-change + staleness sweep."""
+
+import pytest
+from sqlalchemy import select
+
+from app.database import async_session_factory
+from app.models.recommendation import Recommendation
+from app.services.recommendation import invalidate_recommendations
+from tests.helpers import seed_channel, seed_subscription
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+def poll_delay(monkeypatch):
+    from unittest.mock import MagicMock
+
+    mock = MagicMock()
+    monkeypatch.setattr("app.api.channels.poll_channel_task.delay", mock)
+    return mock
+
+
+async def _seed_recs(user_id: str) -> None:
+    async with async_session_factory() as db:
+        db.add_all(
+            [
+                Recommendation(
+                    user_id=user_id, channel_name="Live One", youtube_channel_id="@a"
+                ),
+                Recommendation(
+                    user_id=user_id, channel_name="Live Two", youtube_channel_id="@b"
+                ),
+                Recommendation(
+                    user_id=user_id,
+                    channel_name="Dismissed",
+                    youtube_channel_id="@c",
+                    dismissed=True,
+                ),
+            ]
+        )
+        await db.commit()
+
+
+async def _live_names(user_id: str) -> list[str]:
+    async with async_session_factory() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(Recommendation.channel_name).where(
+                        Recommendation.user_id == user_id,
+                        Recommendation.dismissed == False,  # noqa: E712
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return sorted(rows)
+
+
+async def _all_names(user_id: str) -> list[str]:
+    async with async_session_factory() as db:
+        rows = (
+            (
+                await db.execute(
+                    select(Recommendation.channel_name).where(
+                        Recommendation.user_id == user_id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+    return sorted(rows)
+
+
+# --- the invalidate helper ---------------------------------------------------
+
+
+async def test_invalidate_drops_live_keeps_dismissed(client, make_user):
+    user, _ = await make_user()
+    await _seed_recs(user["id"])
+
+    async with async_session_factory() as db:
+        await invalidate_recommendations(user["id"], db)
+        await db.commit()
+
+    assert await _live_names(user["id"]) == []
+    # The dismissed row (do-not-recommend list) survives.
+    assert await _all_names(user["id"]) == ["Dismissed"]
+
+
+# --- API endpoints invalidate ------------------------------------------------
+
+
+async def test_unsubscribe_invalidates_recommendations(client, make_user):
+    user, headers = await make_user()
+    async with async_session_factory() as db:
+        channel = await seed_channel(db)
+        await seed_subscription(db, user["id"], channel.id)
+    await _seed_recs(user["id"])
+
+    resp = await client.delete(
+        f"/api/channels/{channel.id}/unsubscribe", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+    assert await _live_names(user["id"]) == []
+    assert await _all_names(user["id"]) == ["Dismissed"]
+
+
+async def test_bulk_subscribe_invalidates_recommendations(
+    client, make_user, poll_delay
+):
+    user, headers = await make_user()
+    await _seed_recs(user["id"])
+
+    resp = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={"items": [{"youtube_channel_id": "UCnew1", "name": "Cool Channel"}]},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["results"][0]["status"] == "subscribed"
+    assert await _live_names(user["id"]) == []
+
+
+async def test_bulk_already_subscribed_does_not_invalidate(
+    client, make_user, poll_delay
+):
+    user, headers = await make_user()
+    # Subscribe once.
+    first = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={"items": [{"youtube_channel_id": "UCdup", "name": "Dup Channel"}]},
+        headers=headers,
+    )
+    assert first.json()["results"][0]["status"] == "subscribed"
+    # Now seed recs, then re-subscribe to the SAME channel (already_subscribed).
+    await _seed_recs(user["id"])
+    again = await client.post(
+        "/api/channels/subscribe-bulk",
+        json={"items": [{"youtube_channel_id": "UCdup", "name": "Dup Channel"}]},
+        headers=headers,
+    )
+    assert again.json()["results"][0]["status"] == "already_subscribed"
+    # No real follow change -> recommendations untouched.
+    assert await _live_names(user["id"]) == ["Live One", "Live Two"]

--- a/tests/test_recommendation_reaper.py
+++ b/tests/test_recommendation_reaper.py
@@ -1,0 +1,59 @@
+"""Unit tests for the stale-recommendation reaper (sync, in-memory)."""
+
+from datetime import timedelta
+
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from app.models import Base
+from app.models.recommendation import Recommendation
+from app.services.recommendation_reaper import sweep_stale_recommendations
+from app.utils.time import utcnow_naive
+
+
+def _sync_db():
+    engine = create_engine("sqlite://")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_sweep_deletes_old_live_keeps_recent_and_dismissed():
+    db = _sync_db()
+    now = utcnow_naive()
+    old = now - timedelta(days=10)
+    db.add_all(
+        [
+            Recommendation(user_id="u1", channel_name="stale", created_at=old),
+            Recommendation(user_id="u1", channel_name="fresh", created_at=now),
+            Recommendation(
+                user_id="u1",
+                channel_name="stale-dismissed",
+                dismissed=True,
+                created_at=old,
+            ),
+        ]
+    )
+    db.commit()
+
+    deleted = sweep_stale_recommendations(db, stale_days=7)
+    assert deleted == 1
+    remaining = sorted(
+        r.channel_name for r in db.execute(select(Recommendation)).scalars()
+    )
+    # The stale live rec is gone; the fresh one and the dismissed one stay.
+    assert remaining == ["fresh", "stale-dismissed"]
+
+
+def test_sweep_disabled_when_non_positive():
+    db = _sync_db()
+    db.add(
+        Recommendation(
+            user_id="u1",
+            channel_name="old",
+            created_at=utcnow_naive() - timedelta(days=999),
+        )
+    )
+    db.commit()
+    assert sweep_stale_recommendations(db, stale_days=0) == 0
+    assert sweep_stale_recommendations(db, stale_days=-1) == 0
+    assert db.execute(select(Recommendation)).scalars().first() is not None


### PR DESCRIPTION
## Summary

Recommendations were generated on demand and never refreshed, so they didn't reflect follow/unfollow changes until a manual Refresh. This adds two cheap mechanisms — **without** recomputing the slow (embeddings + LLM + yt-dlp) pipeline on every action:

1. **Invalidate on subscription change.** `invalidate_recommendations(user_id, db)` deletes a user's live (non-dismissed) recommendations; it's called from **subscribe**, **unsubscribe**, and **subscribe-bulk** (bulk only when something actually subscribed — not an all-`already_subscribed` no-op), in the same transaction as the subscription change. The next Discover open lazily regenerates from current follows, so a newly-followed channel stops being suggested and an unfollowed one stops shaping results. Dismissed rows (the do-not-recommend list) are preserved.
2. **Weekly staleness sweep.** A daily Celery beat task deletes non-dismissed recs older than `NULLFEED_RECOMMENDATION_STALE_DAYS` (default **7**; `<=0` disables) so they regenerate on next open. It's a single indexed DELETE — inactive users cost nothing, since regeneration stays lazy in the async API path.

This directly answers "recalculate on follow/unfollow, and daily/weekly": follow/unfollow invalidates immediately; the sweep bounds staleness (set it to `1` for daily). And yes — the pipeline already excludes channels you follow at generation time; invalidation makes that reflect changes promptly.

## Hardening (second commit)
Adversarially reviewed. Wrapped the best-effort invalidation and the poll-enqueue in try/except so a broker/DB hiccup after a subscription commits can't fail the request or skip invalidation; added single-subscribe + cross-user-isolation test coverage.

## Test plan
`invalidate` helper, all three endpoints, the already-subscribed no-op guard, cross-user isolation, and the reaper (old/recent/dismissed/disabled). 439 pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)