### PR TITLE
Subscribing no longer wipes the whole Discover list

### DIFF
--- a/app/api/channels.py
+++ b/app/api/channels.py
@@ -204,10 +204,6 @@ async def subscribe(
     # Create/reactivate user video refs for ALL existing videos in this channel
     await _ensure_refs_for_channel(user.id, channel.id, db)
 
-    # Follows changed the taste profile — drop stale recs so the next Discover
-    # open regenerates (and this newly-followed channel stops being suggested).
-    await invalidate_recommendations(user.id, db)
-
     await db.commit()
     await db.refresh(channel)
 
@@ -244,18 +240,6 @@ async def subscribe_bulk(
                     detail="Subscription failed",
                 )
             )
-    # If anything actually subscribed, invalidate once so the next Discover open
-    # regenerates from the new follow set (per-item commits already landed).
-    # Best-effort — this must never discard the batch's committed results.
-    if any(r.status == "subscribed" for r in results):
-        try:
-            await invalidate_recommendations(user.id, db)
-            await db.commit()
-        except Exception:
-            logger.exception(
-                "Could not invalidate recommendations after bulk subscribe"
-            )
-            await db.rollback()
     return BulkSubscribeResponse(results=results)
 
 

--- a/tests/test_recommendation_freshness.py
+++ b/tests/test_recommendation_freshness.py
@@ -1,4 +1,4 @@
-"""Recommendation freshness: invalidate-on-subscription-change + staleness sweep."""
+"""Recommendation freshness: invalidate-on-unsubscribe + subscribe preserves."""
 
 import pytest
 from sqlalchemy import select
@@ -114,9 +114,12 @@ async def test_unsubscribe_invalidates_recommendations(client, make_user):
     assert await _live_names(other["id"]) == ["Live One", "Live Two"]
 
 
-async def test_subscribe_invalidates_recommendations(
+async def test_subscribe_preserves_recommendations(
     client, make_user, poll_delay, monkeypatch
 ):
+    # Subscribing to a recommendation (the Explore "browse and pick" flow) must
+    # NOT clear the whole list — the client dismisses just the picked card. Only
+    # unsubscribing (a taste change) and the staleness sweep invalidate.
     monkeypatch.setattr(
         "app.api.channels.fetch_channel_metadata",
         lambda cid: {"channel_id": "UCsub", "name": "Sub Channel", "handle": "@sub"},
@@ -134,13 +137,10 @@ async def test_subscribe_invalidates_recommendations(
         headers=headers,
     )
     assert resp.status_code == 200, resp.text
-    assert await _live_names(user["id"]) == []
-    assert await _all_names(user["id"]) == ["Dismissed"]
+    assert await _live_names(user["id"]) == ["Live One", "Live Two"]
 
 
-async def test_bulk_subscribe_invalidates_recommendations(
-    client, make_user, poll_delay
-):
+async def test_bulk_subscribe_preserves_recommendations(client, make_user, poll_delay):
     user, headers = await make_user()
     await _seed_recs(user["id"])
 
@@ -151,27 +151,4 @@ async def test_bulk_subscribe_invalidates_recommendations(
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["results"][0]["status"] == "subscribed"
-    assert await _live_names(user["id"]) == []
-
-
-async def test_bulk_already_subscribed_does_not_invalidate(
-    client, make_user, poll_delay
-):
-    user, headers = await make_user()
-    # Subscribe once.
-    first = await client.post(
-        "/api/channels/subscribe-bulk",
-        json={"items": [{"youtube_channel_id": "UCdup", "name": "Dup Channel"}]},
-        headers=headers,
-    )
-    assert first.json()["results"][0]["status"] == "subscribed"
-    # Now seed recs, then re-subscribe to the SAME channel (already_subscribed).
-    await _seed_recs(user["id"])
-    again = await client.post(
-        "/api/channels/subscribe-bulk",
-        json={"items": [{"youtube_channel_id": "UCdup", "name": "Dup Channel"}]},
-        headers=headers,
-    )
-    assert again.json()["results"][0]["status"] == "already_subscribed"
-    # No real follow change -> recommendations untouched.
     assert await _live_names(user["id"]) == ["Live One", "Live Two"]


### PR DESCRIPTION
## Tester report
Subscribing to a recommendation from Explore showed **"Subscribed to X, but the suggestion could not be cleared"** and left the card with a stale Subscribe button.

## Root cause
#132's invalidate-on-subscribe deleted **all** of the user's non-dismissed recommendations — including the card they just tapped. The client then dismisses that recommendation to clear it, which **404'd** (the row was already gone), so the provider rolled the card back and the screen showed the error. It also wiped the rest of the Explore list server-side on every pick, which is wrong for a browse-and-subscribe flow.

## Fix
Remove `invalidate_recommendations` from `subscribe` and `subscribe-bulk`. The Explore flow already removes the picked card via its own `dismiss` call; whole-list invalidation belongs only to **unsubscribe** (a genuine taste change) and the **daily staleness sweep** — both unchanged. Tests updated to assert subscribe preserves the list.

A companion Flutter PR hardens the client so a "recommendation already gone" (404) during clear is treated as success rather than an error (covers the staleness-sweep race).

## Test plan
438 pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)