### PR TITLE
Clarify the marketing site install CTA

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -53,7 +53,7 @@
       <h1 class="rise d1">The algorithm stops <em>at your router.</em></h1>
       <p class="lede rise d2">NullFeed is a self-hosted YouTube media center. Follow the channels you actually care about, and your own server quietly caches every new upload for instant, ad-free playback on iPhone, Apple&nbsp;TV, and the web. Nothing recommended. Nothing tracked. Nothing you didn't ask for.</p>
       <div class="ctas rise d3">
-        <a class="btn btn-violet" href="https://github.com/windoze95/nullfeed-backend" target="_blank" rel="noopener">Self-host it on GitHub</a>
+        <a class="btn btn-violet" href="https://github.com/windoze95/nullfeed-backend#quick-start" target="_blank" rel="noopener">View the install guide</a>
         <a class="btn btn-ghost" href="#how">See how it works</a>
       </div>
       <p class="hero-note rise d4">One Docker container · Unraid-native · iPhone &amp; Apple&nbsp;TV apps in TestFlight</p>


### PR DESCRIPTION
## What changed

- rename the hero CTA from “Self-host it on GitHub” to “View the install guide”
- link directly to the README's Quick Start section

## Why

GitHub hosts the source and setup instructions, not the user's NullFeed server. The new wording accurately describes the destination and action.

## Validation

- `git diff --check`
- verified the old CTA text is absent and the Quick Start anchor is present